### PR TITLE
fix(appfs): reduce windows action sink contention

### DIFF
--- a/cli/src/cmd/appfs.rs
+++ b/cli/src/cmd/appfs.rs
@@ -1479,7 +1479,7 @@ fn try_decode_utf16_line(slice: &[u8], allow_bom: bool) -> Option<String> {
         return Some(String::new());
     }
 
-    if bytes.len() % 2 != 0 {
+    if !bytes.len().is_multiple_of(2) {
         return None;
     }
 
@@ -1522,7 +1522,7 @@ fn try_decode_utf16_line(slice: &[u8], allow_bom: bool) -> Option<String> {
     }
 
     let mut out = String::with_capacity(units.len());
-    for ch in std::char::decode_utf16(units.into_iter()) {
+    for ch in std::char::decode_utf16(units) {
         let ch = ch.ok()?;
         out.push(ch);
     }


### PR DESCRIPTION
## Summary
- reduce `.act` read contention in `serve appfs` to improve Windows append stability
- treat Windows sharing violations as transient busy (retry next poll) instead of INVALID_PAYLOAD noise

## Changes
- skip opening action sink when `cursor.offset == file_len` (no new bytes)
- on metadata/read errors with Windows busy codes (5/32/33), defer processing without consuming cursor
- keep existing overwrite/truncate safety semantics intact

## Validation
- `cargo check --package agentfs`
- `cargo test --package agentfs appfs`