### PR TITLE
docs: clarify Windows build prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,12 @@ Prerequisites:
 
 ### Windows
 
+Install WinFsp first. AppFS uses WinFsp as the Windows mount backend for `--backend winfsp`.
+
+- Download and install the latest WinFsp release from [winfsp.dev/rel](https://winfsp.dev/rel/)
+- After installation, open a new terminal before running `agentfs appfs up`
+- A reboot is usually not required, but if Windows reports the driver is busy or mounts still fail after install, reboot once and retry
+
 Start the reference HTTP bridge:
 
 ```powershell

--- a/README.md
+++ b/README.md
@@ -154,6 +154,79 @@ Then use the same `/_appfs/register_app.act`, per-app `.act`, and ordinary file 
 
 ## Build From Source
 
+### Environment Dependencies
+
+On a fresh Windows machine, install the Rust toolchain and Visual Studio Build Tools before running `cargo build`.
+
+If you see:
+
+```text
+error: linker `link.exe` not found
+```
+
+the MSVC build environment is not available in the current shell yet.
+
+1. Install Rust
+
+```powershell
+winget install --id Rustlang.Rustup -e
+rustup default stable-x86_64-pc-windows-msvc
+```
+
+2. Install Visual Studio Build Tools
+
+```powershell
+# Download the Visual Studio Build Tools installer
+Invoke-WebRequest -Uri https://aka.ms/vs/17/release/vs_buildtools.exe -OutFile vs_buildtools.exe
+
+# Install the C++ Build Tools workload (without the full IDE)
+Start-Process -Wait -FilePath .\vs_buildtools.exe -ArgumentList "--quiet --wait --norestart --nocache --add Microsoft.VisualStudio.Workload.VCTools --includeRecommended"
+```
+
+3. Install the official LLVM Windows release
+
+Download the latest Windows installer (`LLVM-*-win64.exe`) from the official LLVM release page:
+
+- [LLVM official releases](https://github.com/llvm/llvm-project/releases)
+
+During installation, enable the option to add LLVM to `PATH` if the installer offers it. The default install location is usually:
+
+```text
+C:\Program Files\LLVM\bin
+```
+
+4. Make sure the MSVC and LLVM compiler directories are on `PATH`
+
+Open a new terminal, then run:
+
+```powershell
+$MsvcBin = Get-ChildItem "${env:ProgramFiles(x86)}\Microsoft Visual Studio\2022\BuildTools\VC\Tools\MSVC" -Directory |
+    Sort-Object Name -Descending |
+    Select-Object -First 1 |
+    ForEach-Object { Join-Path $_.FullName "bin\Hostx64\x64" }
+
+$LlvmBin = "C:\Program Files\LLVM\bin"
+
+$env:Path = "$MsvcBin;$LlvmBin;$env:Path"
+
+where.exe cl
+where.exe link
+where.exe clang-cl
+```
+
+On a typical machine these resolve to paths like:
+
+```text
+C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Tools\MSVC\<version>\bin\Hostx64\x64
+C:\Program Files\LLVM\bin
+```
+
+If `where.exe cl` or `where.exe link` still cannot find anything, check that the MSVC directory above exists first. If it does not, re-run the Build Tools installer.
+
+If `where.exe clang-cl` still cannot find anything, LLVM is either not installed yet or was not added to `PATH`. In that case, check whether `C:\Program Files\LLVM\bin\clang-cl.exe` exists and add `C:\Program Files\LLVM\bin` to `PATH`.
+
+For `cargo build`, the important part is simply that `cl.exe`, `link.exe`, and `clang-cl.exe` are reachable on `PATH`.
+
 ### CLI and Rust SDK
 
 ```bash

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -60,6 +60,12 @@ managed runtime 的共享状态文件位于：
 
 ### Windows
 
+请先安装 WinFsp。AppFS 在 Windows 上通过 `--backend winfsp` 使用 WinFsp 作为挂载后端。
+
+- 从 [winfsp.dev/rel](https://winfsp.dev/rel/) 下载并安装最新版本的 WinFsp
+- 安装完成后，请重新打开一个终端，再运行 `agentfs appfs up`
+- 通常不需要重启；如果安装后仍然提示驱动忙碌，或者挂载还是失败，再重启一次后重试
+
 启动参考 HTTP bridge：
 
 ```powershell

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -154,6 +154,79 @@ cargo run -- appfs up .agentfs/managed-http.db /tmp/appfs-managed-http --backend
 
 ## 手动编译
 
+### 环境依赖
+
+在一台全新的 Windows 机器上，运行 `cargo build` 之前需要先安装 Rust toolchain 和 Visual Studio Build Tools。
+
+如果你看到：
+
+```text
+error: linker `link.exe` not found
+```
+
+通常说明当前 shell 里还没有加载 MSVC 的编译环境。
+
+1. 安装 Rust
+
+```powershell
+winget install --id Rustlang.Rustup -e
+rustup default stable-x86_64-pc-windows-msvc
+```
+
+2. 安装 Visual Studio Build Tools
+
+```powershell
+# 下载 Visual Studio Build Tools 安装器
+Invoke-WebRequest -Uri https://aka.ms/vs/17/release/vs_buildtools.exe -OutFile vs_buildtools.exe
+
+# 安装 C++ Build Tools workload（不带完整 IDE）
+Start-Process -Wait -FilePath .\vs_buildtools.exe -ArgumentList "--quiet --wait --norestart --nocache --add Microsoft.VisualStudio.Workload.VCTools --includeRecommended"
+```
+
+3. 单独安装官方 LLVM Windows 发行版
+
+请从 LLVM 官方发布页下载最新的 Windows 安装包 `LLVM-*-win64.exe`：
+
+- [LLVM 官方发布页](https://github.com/llvm/llvm-project/releases)
+
+安装时如果看到“Add LLVM to PATH”之类的选项，建议勾上。默认安装目录通常是：
+
+```text
+C:\Program Files\LLVM\bin
+```
+
+4. 确保 MSVC 和 LLVM 编译器目录已经在 `PATH` 中
+
+重新打开一个终端后，再执行：
+
+```powershell
+$MsvcBin = Get-ChildItem "${env:ProgramFiles(x86)}\Microsoft Visual Studio\2022\BuildTools\VC\Tools\MSVC" -Directory |
+    Sort-Object Name -Descending |
+    Select-Object -First 1 |
+    ForEach-Object { Join-Path $_.FullName "bin\Hostx64\x64" }
+
+$LlvmBin = "C:\Program Files\LLVM\bin"
+
+$env:Path = "$MsvcBin;$LlvmBin;$env:Path"
+
+where.exe cl
+where.exe link
+where.exe clang-cl
+```
+
+在常见安装路径下，这两个目录通常会长这样：
+
+```text
+C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Tools\MSVC\<version>\bin\Hostx64\x64
+C:\Program Files\LLVM\bin
+```
+
+如果 `where.exe cl` 或 `where.exe link` 仍然找不到结果，先检查上面的 MSVC 目录是否存在。不存在的话，说明 Build Tools 没有安装完整，需要重新安装。
+
+如果 `where.exe clang-cl` 仍然找不到结果，说明 LLVM 还没有安装好，或者没有加入 `PATH`。这时请先检查 `C:\Program Files\LLVM\bin\clang-cl.exe` 是否存在，再把 `C:\Program Files\LLVM\bin` 加入 `PATH`。
+
+对 `cargo build` 来说，最关键的条件其实就是 `cl.exe`、`link.exe` 和 `clang-cl.exe` 都能通过 `PATH` 被找到。
+
 ### CLI 与 Rust SDK
 
 ```bash


### PR DESCRIPTION
## Summary
- add a Windows-specific environment dependencies section under Build From Source
- document Rust, Visual Studio Build Tools, and standalone official LLVM installation
- show how to verify and temporarily add MSVC and LLVM compiler directories to PATH

## Context
This updates the README based on a fresh-machine build experience on Windows, where `cargo build` can fail if `link.exe` or `clang-cl.exe` are not available in the current environment.

## Testing
- not run (documentation-only changes)