### PR TITLE
[codex] Publish AppFS runtime manifest for agent attach

### DIFF
--- a/cli/src/cmd/appfs.rs
+++ b/cli/src/cmd/appfs.rs
@@ -22,6 +22,7 @@ pub(crate) mod registry;
 mod registry_manager;
 mod runtime_config;
 mod runtime_entry;
+mod runtime_manifest;
 mod runtime_supervisor;
 mod shared;
 mod snapshot_cache;
@@ -173,7 +174,7 @@ pub async fn handle_appfs_adapter_command(args: AppfsServeArgs) -> Result<()> {
         )
     };
     let resolved_runtime_args = resolve_runtime_cli_args(runtime_args);
-    let mut supervisor = AppfsRuntimeSupervisor::new(root, resolved_runtime_args)?;
+    let mut supervisor = AppfsRuntimeSupervisor::new(root, resolved_runtime_args, managed)?;
     supervisor.prepare_action_sinks()?;
     supervisor.sync_registry_to_disk(existing_registry.as_ref())?;
     supervisor.log_started();
@@ -572,6 +573,7 @@ mod supervisor_tests {
         let mut supervisor = AppfsRuntimeSupervisor::new(
             temp.path().to_path_buf(),
             resolve_runtime_cli_args(runtime_args),
+            false,
         )
         .expect("supervisor");
         supervisor.prepare_action_sinks().expect("prepare sinks");
@@ -620,9 +622,11 @@ mod supervisor_tests {
         let mut supervisor = AppfsRuntimeSupervisor::new(
             temp.path().to_path_buf(),
             resolve_runtime_cli_args(runtime_args),
+            false,
         )
         .expect("supervisor");
         supervisor.prepare_action_sinks().expect("prepare sinks");
+        assert!(!super::runtime_manifest::runtime_manifest_path(temp.path()).exists());
         supervisor
             .sync_registry_to_disk(None)
             .expect("persist registry");
@@ -633,6 +637,22 @@ mod supervisor_tests {
         assert_eq!(stored.apps.len(), 1);
         assert_eq!(stored.apps[0].app_id, "aiim");
         assert_eq!(stored.apps[0].session_id, "sess-aiim");
+        let manifest_path = super::runtime_manifest::runtime_manifest_path(temp.path());
+        assert!(manifest_path.exists());
+        let manifest: serde_json::Value =
+            serde_json::from_slice(&fs::read(&manifest_path).expect("read runtime manifest"))
+                .expect("parse runtime manifest");
+        assert_eq!(
+            manifest["runtime_session_id"]
+                .as_str()
+                .unwrap_or_default()
+                .starts_with("rt-"),
+            true
+        );
+        assert_eq!(
+            manifest["multi_agent_mode"].as_str(),
+            Some(super::runtime_manifest::APPFS_MULTI_AGENT_MODE_SHARED)
+        );
     }
 
     #[test]
@@ -649,6 +669,7 @@ mod supervisor_tests {
         let mut supervisor = AppfsRuntimeSupervisor::new(
             temp.path().to_path_buf(),
             resolve_runtime_cli_args(runtime_args),
+            false,
         )
         .expect("supervisor");
         supervisor.prepare_action_sinks().expect("prepare sinks");
@@ -704,7 +725,8 @@ mod supervisor_tests {
     fn supervisor_can_register_app_dynamically_from_empty_runtime() {
         let temp = TempDir::new().expect("tempdir");
         let mut supervisor =
-            AppfsRuntimeSupervisor::new(temp.path().to_path_buf(), Vec::new()).expect("supervisor");
+            AppfsRuntimeSupervisor::new(temp.path().to_path_buf(), Vec::new(), false)
+                .expect("supervisor");
         supervisor.prepare_action_sinks().expect("prepare sinks");
 
         append_text(
@@ -744,6 +766,7 @@ mod supervisor_tests {
         let mut supervisor = AppfsRuntimeSupervisor::new(
             temp.path().to_path_buf(),
             resolve_runtime_cli_args(runtime_args),
+            false,
         )
         .expect("supervisor");
         supervisor.prepare_action_sinks().expect("prepare sinks");

--- a/cli/src/cmd/appfs/runtime_manifest.rs
+++ b/cli/src/cmd/appfs/runtime_manifest.rs
@@ -1,0 +1,188 @@
+use anyhow::{Context, Result};
+use chrono::Utc;
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::path::{Path, PathBuf};
+use uuid::Uuid;
+
+pub(crate) const APPFS_RUNTIME_MANIFEST_REL_PATH: &str = ".well-known/appfs/runtime.json";
+pub(crate) const APPFS_RUNTIME_SCHEMA_VERSION: u32 = 1;
+pub(crate) const APPFS_RUNTIME_KIND: &str = "appfs";
+pub(crate) const APPFS_MULTI_AGENT_MODE_SHARED: &str = "shared_mount_distinct_attach";
+const CONTROL_REGISTER_ACTION_PATH: &str = "/_appfs/register_app.act";
+const CONTROL_UNREGISTER_ACTION_PATH: &str = "/_appfs/unregister_app.act";
+const CONTROL_LIST_ACTION_PATH: &str = "/_appfs/list_apps.act";
+const CONTROL_REGISTRY_PATH: &str = "/_appfs/apps.registry.json";
+const CONTROL_EVENTS_PATH: &str = "/_appfs/_stream/events.evt.jsonl";
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct AppfsRuntimeManifestControlPlaneDoc {
+    pub(crate) register_action: String,
+    pub(crate) unregister_action: String,
+    pub(crate) list_action: String,
+    pub(crate) registry: String,
+    pub(crate) events: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct AppfsRuntimeManifestCapabilitiesDoc {
+    pub(crate) app_registration: bool,
+    pub(crate) event_stream: bool,
+    pub(crate) multi_app: bool,
+    pub(crate) scope_switch: bool,
+    pub(crate) multi_agent_attach: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct AppfsRuntimeManifestDoc {
+    pub(crate) schema_version: u32,
+    pub(crate) runtime_kind: String,
+    pub(crate) mount_root: PathBuf,
+    pub(crate) runtime_session_id: String,
+    pub(crate) managed: bool,
+    pub(crate) multi_agent_mode: String,
+    pub(crate) control_plane: AppfsRuntimeManifestControlPlaneDoc,
+    pub(crate) capabilities: AppfsRuntimeManifestCapabilitiesDoc,
+    pub(crate) generated_at: String,
+}
+
+pub(crate) fn generate_runtime_session_id() -> String {
+    let uuid = Uuid::new_v4().simple().to_string();
+    format!("rt-{}", &uuid[..8])
+}
+
+pub(crate) fn runtime_manifest_path(root: &Path) -> PathBuf {
+    root.join(APPFS_RUNTIME_MANIFEST_REL_PATH.replace('/', std::path::MAIN_SEPARATOR_STR))
+}
+
+pub(crate) fn build_runtime_manifest(
+    root: &Path,
+    runtime_session_id: &str,
+    managed: bool,
+) -> AppfsRuntimeManifestDoc {
+    AppfsRuntimeManifestDoc {
+        schema_version: APPFS_RUNTIME_SCHEMA_VERSION,
+        runtime_kind: APPFS_RUNTIME_KIND.to_string(),
+        mount_root: root.canonicalize().unwrap_or_else(|_| root.to_path_buf()),
+        runtime_session_id: runtime_session_id.to_string(),
+        managed,
+        multi_agent_mode: APPFS_MULTI_AGENT_MODE_SHARED.to_string(),
+        control_plane: AppfsRuntimeManifestControlPlaneDoc {
+            register_action: CONTROL_REGISTER_ACTION_PATH.to_string(),
+            unregister_action: CONTROL_UNREGISTER_ACTION_PATH.to_string(),
+            list_action: CONTROL_LIST_ACTION_PATH.to_string(),
+            registry: CONTROL_REGISTRY_PATH.to_string(),
+            events: CONTROL_EVENTS_PATH.to_string(),
+        },
+        capabilities: AppfsRuntimeManifestCapabilitiesDoc {
+            app_registration: true,
+            event_stream: true,
+            multi_app: true,
+            scope_switch: true,
+            multi_agent_attach: true,
+        },
+        generated_at: Utc::now().to_rfc3339(),
+    }
+}
+
+pub(crate) fn write_runtime_manifest(
+    root: &Path,
+    runtime_session_id: &str,
+    managed: bool,
+) -> Result<()> {
+    let path = runtime_manifest_path(root);
+    let parent = path
+        .parent()
+        .ok_or_else(|| anyhow::anyhow!("invalid AppFS runtime manifest path {}", path.display()))?;
+    fs::create_dir_all(parent).with_context(|| {
+        format!(
+            "failed to create AppFS runtime manifest directory {}",
+            parent.display()
+        )
+    })?;
+    let doc = build_runtime_manifest(root, runtime_session_id, managed);
+    let bytes =
+        serde_json::to_vec_pretty(&doc).context("failed to serialize AppFS runtime manifest")?;
+    let tmp_path = path.with_extension("json.tmp");
+    fs::write(&tmp_path, bytes).with_context(|| {
+        format!(
+            "failed to write temporary AppFS runtime manifest {}",
+            tmp_path.display()
+        )
+    })?;
+    fs::rename(&tmp_path, &path).with_context(|| {
+        format!(
+            "failed to publish AppFS runtime manifest {}",
+            path.display()
+        )
+    })?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        build_runtime_manifest, generate_runtime_session_id, runtime_manifest_path,
+        write_runtime_manifest, APPFS_MULTI_AGENT_MODE_SHARED, APPFS_RUNTIME_KIND,
+        APPFS_RUNTIME_MANIFEST_REL_PATH, APPFS_RUNTIME_SCHEMA_VERSION,
+    };
+    use tempfile::tempdir;
+
+    #[test]
+    fn writes_runtime_manifest_at_well_known_path() {
+        let temp = tempdir().expect("tempdir");
+        let session_id = "rt-shared-01";
+
+        write_runtime_manifest(temp.path(), session_id, true).expect("write runtime manifest");
+
+        let manifest_path = runtime_manifest_path(temp.path());
+        assert!(manifest_path.exists());
+        let doc: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(&manifest_path).expect("read runtime manifest"))
+                .expect("parse runtime manifest");
+        assert_eq!(doc["schema_version"], APPFS_RUNTIME_SCHEMA_VERSION);
+        assert_eq!(doc["runtime_kind"], APPFS_RUNTIME_KIND);
+        assert_eq!(doc["runtime_session_id"], session_id);
+        assert_eq!(doc["multi_agent_mode"], APPFS_MULTI_AGENT_MODE_SHARED);
+        assert_eq!(
+            manifest_path
+                .strip_prefix(temp.path())
+                .expect("manifest relative path")
+                .to_string_lossy()
+                .replace('\\', "/"),
+            APPFS_RUNTIME_MANIFEST_REL_PATH
+        );
+    }
+
+    #[test]
+    fn runtime_session_id_is_prefixed_for_runtime_scope() {
+        let session_id = generate_runtime_session_id();
+        assert!(session_id.starts_with("rt-"));
+        assert!(session_id.len() > 3);
+    }
+
+    #[test]
+    fn build_runtime_manifest_marks_multi_agent_attach_capability() {
+        let temp = tempdir().expect("tempdir");
+        let doc = build_runtime_manifest(temp.path(), "rt-shared-02", false);
+        assert!(doc.capabilities.multi_agent_attach);
+        assert!(doc.capabilities.event_stream);
+        assert!(!doc.mount_root.as_os_str().is_empty());
+    }
+
+    #[test]
+    fn write_runtime_manifest_rewrites_existing_manifest() {
+        let temp = tempdir().expect("tempdir");
+
+        write_runtime_manifest(temp.path(), "rt-shared-03", true).expect("write first manifest");
+        write_runtime_manifest(temp.path(), "rt-shared-04", false)
+            .expect("rewrite runtime manifest");
+
+        let manifest_path = runtime_manifest_path(temp.path());
+        let doc: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(&manifest_path).expect("read runtime manifest"))
+                .expect("parse runtime manifest");
+        assert_eq!(doc["runtime_session_id"], "rt-shared-04");
+        assert_eq!(doc["managed"], false);
+    }
+}

--- a/cli/src/cmd/appfs/runtime_supervisor.rs
+++ b/cli/src/cmd/appfs/runtime_supervisor.rs
@@ -4,6 +4,7 @@ use super::registry_manager::{self, RegistryRuntimeSnapshot};
 use super::runtime_entry::{
     build_runtime_entry, read_active_scope, transport_summary, AppRuntimeEntry,
 };
+use super::runtime_manifest;
 use super::supervisor_control;
 use super::ResolvedAppfsRuntimeCliArgs;
 use anyhow::Result;
@@ -12,6 +13,8 @@ use std::path::PathBuf;
 
 pub(super) struct AppfsRuntimeSupervisor {
     root: PathBuf,
+    managed: bool,
+    runtime_session_id: String,
     control_plane: supervisor_control::SupervisorControlPlane,
     pub(super) runtimes: BTreeMap<String, AppRuntimeEntry>,
 }
@@ -20,6 +23,7 @@ impl AppfsRuntimeSupervisor {
     pub(super) fn new(
         root: PathBuf,
         runtime_args: Vec<ResolvedAppfsRuntimeCliArgs>,
+        managed: bool,
     ) -> Result<Self> {
         let mut runtimes = BTreeMap::new();
         for runtime in runtime_args {
@@ -32,6 +36,8 @@ impl AppfsRuntimeSupervisor {
             }
         }
         Ok(Self {
+            managed,
+            runtime_session_id: runtime_manifest::generate_runtime_session_id(),
             control_plane: supervisor_control::SupervisorControlPlane::new(
                 root.clone(),
                 std::env::var("APPFS_ACTIONLINE_STRICT")
@@ -64,6 +70,12 @@ impl AppfsRuntimeSupervisor {
     }
 
     pub(super) fn log_started(&self) {
+        eprintln!(
+            "AppFS runtime session started (mount_root={} runtime_session_id={} managed={})",
+            self.root.display(),
+            self.runtime_session_id,
+            self.managed
+        );
         for entry in self.runtimes.values() {
             let adapter = &entry.adapter;
             eprintln!(
@@ -87,7 +99,8 @@ impl AppfsRuntimeSupervisor {
                 app_dir: entry.adapter.app_dir.clone(),
             })
             .collect::<Vec<_>>();
-        registry_manager::persist_runtime_registry(&self.root, &snapshots, existing)
+        registry_manager::persist_runtime_registry(&self.root, &snapshots, existing)?;
+        runtime_manifest::write_runtime_manifest(&self.root, &self.runtime_session_id, self.managed)
     }
 
     fn handle_control_invocation(

--- a/docs/plans/2026-04-07-appfs-principal-visibility-and-agent-identity.md
+++ b/docs/plans/2026-04-07-appfs-principal-visibility-and-agent-identity.md
@@ -1,0 +1,264 @@
+# AppFS Principal Visibility And Agent Identity Design
+
+**Date:** 2026-04-07  
+**Status:** Future plan, not current mainline scope  
+**Depends on:** AppFS attach contract v1.1, stable IC-0 / IC-1 / IC-2 baselines
+
+## 1. Goal
+
+Define a future model for:
+
+1. shared vs private app views inside one AppFS mount;
+2. stable app identity separate from transient agent process identity;
+3. connector-side session/account isolation for apps such as chat software.
+
+This design is intentionally **not** the current primary goal. The current mainline remains:
+
+1. stabilize the attach contract;
+2. keep the AppFS mounted app loop working;
+3. preserve `appfs-agent` as a general-purpose agent.
+
+## 2. Recommendation
+
+The distinction between shared and private app data should be modeled primarily at the **AppFS layer**, not at the `appfs-agent` layer.
+
+`appfs-agent` should declare who is attaching. AppFS should decide which app view that identity is allowed to see. Connectors should map that view to real upstream app sessions, accounts, or profiles.
+
+In short:
+
+1. `appfs-agent` provides identity hints;
+2. AppFS owns visibility, path routing, and view isolation;
+3. connectors own upstream login/session/account binding.
+
+## 3. Why This Belongs In AppFS
+
+If shared/private behavior only exists in `appfs-agent`, the semantics become client-specific. A different client, script, or direct filesystem consumer could bypass those assumptions and observe a different app surface.
+
+That would create three problems:
+
+1. the filesystem would stop being the source of truth for what is visible;
+2. app identity isolation would depend on which client happened to mount or browse the tree;
+3. connector behavior would become harder to reason about because upstream session binding would be hidden in one consumer.
+
+The cleaner model is:
+
+1. AppFS exposes an explicit view;
+2. all clients see that same view for the same principal;
+3. connector session binding follows the AppFS-selected principal/profile.
+
+## 4. Identity Layers
+
+These identities should remain separate:
+
+### 4.1 Runtime identity
+
+`runtime_session_id`
+
+Meaning:
+
+1. identifies one shared AppFS runtime / mount lifecycle;
+2. common to all attached agents on the same mount.
+
+### 4.2 Agent instance identity
+
+`attach_id`
+
+Meaning:
+
+1. identifies one attached `appfs-agent` process instance;
+2. may be ephemeral;
+3. should not be used as the durable app account identity.
+
+### 4.3 Principal identity
+
+Recommended future field:
+
+`principal_id`
+
+Meaning:
+
+1. identifies the stable app-facing identity or persona;
+2. may correspond to a user, role, bot identity, or named workspace profile;
+3. should be the key used for private app views.
+
+Examples:
+
+1. `planner`
+2. `reviewer`
+3. `ops-bot`
+
+### 4.4 Visibility policy
+
+Recommended future field:
+
+`visibility`
+
+Initial policy values:
+
+1. `shared`
+2. `private`
+3. `team`
+
+Meaning:
+
+1. `shared` means all attached principals may observe the same AppFS app view;
+2. `private` means the app view is scoped to one `principal_id`;
+3. `team` means the view is shared among an allowed subset of principals.
+
+## 5. Target Responsibility Split
+
+### 5.1 `appfs-agent`
+
+Future responsibility:
+
+1. declare attach identity;
+2. optionally declare `principal_id`;
+3. optionally declare desired role and visibility hint;
+4. stay usable without AppFS.
+
+Non-responsibility:
+
+1. it should not define the authoritative isolation rules for app views;
+2. it should not be the only place where private/shared policy exists.
+
+### 5.2 AppFS
+
+Future responsibility:
+
+1. store or resolve principal-aware app view policy;
+2. map principals to visible mount paths;
+3. enforce whether an app is shared or private;
+4. ensure different clients see the same view for the same principal.
+
+### 5.3 Connector
+
+Future responsibility:
+
+1. bind `principal_id` to upstream app account/session/profile;
+2. keep multiple upstream identities isolated where needed;
+3. expose connector-owned paths and data for the selected principal.
+
+This is especially important for apps like chat software, where two agents may share the same AppFS mount but must not share the same chat identity.
+
+## 6. Preferred Data Model
+
+When this work starts, the attach surface should grow from:
+
+1. `runtime_session_id`
+2. `attach_id`
+3. `attach_role`
+
+to a future model such as:
+
+1. `runtime_session_id`
+2. `attach_id`
+3. `attach_role`
+4. `principal_id`
+5. `visibility`
+6. optional `profile_id`
+
+Notes:
+
+1. `principal_id` is the semantic identity;
+2. `profile_id` is optional when one principal may hold multiple app-side profiles;
+3. `attach_id` remains process-scoped and should not replace either of them.
+
+## 7. Preferred Namespace Shape
+
+Avoid making private/shared behavior depend only on invisible runtime state. Prefer explicit and debuggable paths.
+
+Recommended long-term shape:
+
+1. `/workspace/...`
+2. `/apps/shared/<app_id>/...`
+3. `/apps/private/<principal_id>/<app_id>/...`
+4. `/apps/team/<team_id>/<app_id>/...`
+
+Optional future convenience aliases may exist, but they should be derived views rather than the only source of truth.
+
+Example:
+
+1. `agent-a` and `agent-b` share one mount and one `runtime_session_id`;
+2. `agent-a` attaches as `principal_id=planner`;
+3. `agent-b` attaches as `principal_id=reviewer`;
+4. both can see `/apps/shared/notion/...`;
+5. `planner` sees `/apps/private/planner/chat/...`;
+6. `reviewer` sees `/apps/private/reviewer/chat/...`;
+7. connector binds those two chat views to different upstream sessions.
+
+## 8. Policy Rules
+
+Recommended future rules:
+
+1. shared/private/team is decided by AppFS app policy, not by agent-local convention;
+2. private apps must never implicitly fall back to another principal's view;
+3. connectors must not reuse upstream session state across principals unless the app policy is explicitly shared;
+4. AppFS should make the effective principal and visibility observable in status/control output.
+
+## 9. Why This Is Deferred
+
+This design should wait until the current baseline is stable because it introduces a new semantic layer on top of attach.
+
+Doing it now would mix together:
+
+1. attach correctness;
+2. multi-agent correctness;
+3. app visibility policy;
+4. connector account/session isolation.
+
+That would make regressions harder to localize.
+
+The recommended order is:
+
+1. finish and stabilize attach contract v1.1;
+2. automate IC-2 multi-agent attach baseline;
+3. keep registered app loop green;
+4. only then start principal/visibility design work.
+
+## 10. Suggested Future Milestones
+
+### P1. Principal-aware attach metadata
+
+Add optional attach metadata:
+
+1. `principal_id`
+2. `visibility`
+3. optional `profile_id`
+
+No path isolation yet. Status/control output only.
+
+### P2. App policy model in AppFS
+
+Add AppFS-side app policy for:
+
+1. `shared`
+2. `private`
+3. `team`
+
+No connector-side enforcement yet beyond metadata plumbing.
+
+### P3. Principal-aware namespace routing
+
+Expose explicit shared/private/team mount paths and derive view resolution from AppFS policy.
+
+### P4. Connector session/profile isolation
+
+Require relevant connectors to bind upstream session/account/profile by `principal_id` or `profile_id`.
+
+## 11. Open Questions
+
+These do not block current work:
+
+1. should `principal_id` be supplied by launcher env, control action, or both?
+2. should private app views live in one shared mount namespace or separate virtual roots?
+3. how should team-scoped views express membership and authorization?
+4. should AppFS persist principal-to-app policy centrally or let app registration supply it?
+
+## 12. Final Position
+
+For future shared/private app data support:
+
+1. the main policy belongs in AppFS;
+2. `appfs-agent` should only declare attach and principal intent;
+3. connectors should isolate upstream app sessions accordingly;
+4. this is future work, not the current primary delivery target.


### PR DESCRIPTION
## Summary
- publish a stable AppFS runtime manifest at `/.well-known/appfs/runtime.json`
- persist runtime session and control-plane metadata from the AppFS runtime supervisor
- add a future planning note for principal and visibility modeling

## Why
- provide a stable attach surface for `appfs-agent` that is not tied to the internal `_appfs` directory name
- make the shared AppFS runtime identity explicit so multiple agents can attach to the same mount cleanly
- document the next-step identity model without making it part of the current runtime contract

## Impact
- `AppfsRuntimeSupervisor` now owns a generated `runtime_session_id`
- registry sync now also publishes the runtime manifest with multi-agent capabilities
- tests cover runtime manifest creation during bootstrap persistence

## Validation
- `cargo test --package agentfs supervisor_persists_registry_for_bootstrap_apps -- --nocapture` passed in the validated standalone checkout before isolating this commit
- rerunning the same command in the clean PR worktree hit a local clang/Windows SDK header issue (`errno.h` / `windows.h` not found), so this PR notes that environment-specific blocker explicitly
