### PR TITLE
[codex] Backfill IC-3 launcher baseline from appfs-platform

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -84,6 +84,9 @@ aegis = { version = "0.9.6", features = ["pure-rust"] }
 # Note: Requires WinFsp to be installed from https://winfsp.dev/rel/
 # The winfsp crate includes pre-built bindings, no LLVM/bindgen needed
 [target.'cfg(target_os = "windows")'.dependencies]
+# Force the pure-Rust aegis backend on Windows as well so self-hosted runners
+# do not need an additional clang-cl toolchain just to build turso's crypto deps.
+aegis = { version = "0.9.8", features = ["pure-rust"] }
 winfsp = { version = "0.12", default-features = false, features = ["delayload"] }
 
 # Build dependencies for Windows (needed for winfsp_link_delayload in build.rs)

--- a/cli/src/cmd/appfs.rs
+++ b/cli/src/cmd/appfs.rs
@@ -1,10 +1,12 @@
 use agentfs_sdk::AppConnector;
-use anyhow::Result;
+use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
 use std::collections::HashMap;
-use std::path::PathBuf;
+use std::path::{Component, Path, PathBuf};
+use std::process::{Child, Command as ProcessCommand, Stdio};
 use std::time::{Duration, Instant};
+use uuid::Uuid;
 
 mod action_dispatcher;
 mod bridge_resilience;
@@ -55,6 +57,12 @@ const SNAPSHOT_PUBLISH_DELAY_ENV: &str = "APPFS_SNAPSHOT_PUBLISH_DELAY_MS";
 const DEFAULT_SNAPSHOT_COALESCE_WINDOW_MS: u64 = 120;
 const SNAPSHOT_EXPAND_JOURNAL_FILENAME: &str = "snapshot-expand.state.res.json";
 const APP_STRUCTURE_SYNC_STATE_FILENAME: &str = "app-structure-sync.state.res.json";
+const APPFS_ATTACH_SCHEMA_ENV: &str = "APPFS_ATTACH_SCHEMA";
+const APPFS_RUNTIME_MANIFEST_ENV: &str = "APPFS_RUNTIME_MANIFEST";
+const APPFS_MOUNT_ROOT_ENV: &str = "APPFS_MOUNT_ROOT";
+const APPFS_RUNTIME_SESSION_ID_ENV: &str = "APPFS_RUNTIME_SESSION_ID";
+const APPFS_ATTACH_ID_ENV: &str = "APPFS_ATTACH_ID";
+const APPFS_AGENT_ROLE_ENV: &str = "APPFS_AGENT_ROLE";
 
 const MAX_SEGMENT_BYTES: usize = 255;
 
@@ -93,6 +101,24 @@ pub struct AppfsUpArgs {
     pub poll_ms: u64,
 }
 
+#[derive(Debug, Clone)]
+pub struct AppfsLaunchArgs {
+    pub id_or_path: String,
+    pub mountpoint: PathBuf,
+    pub backend: crate::cmd::mount::MountBackend,
+    pub allow_root: bool,
+    pub allow_other: bool,
+    pub uid: Option<u32>,
+    pub gid: Option<u32>,
+    pub poll_ms: u64,
+    pub agent_bin: PathBuf,
+    pub workspace: PathBuf,
+    pub attach_id: Option<String>,
+    pub attach_role: Option<String>,
+    pub startup_timeout_ms: u64,
+    pub agent_args: Vec<String>,
+}
+
 fn build_managed_mount_args(args: &AppfsUpArgs) -> crate::cmd::MountArgs {
     crate::cmd::MountArgs {
         id_or_path: args.id_or_path.clone(),
@@ -117,6 +143,200 @@ fn build_managed_mount_args(args: &AppfsUpArgs) -> crate::cmd::MountArgs {
         adapter_bridge_max_backoff_ms: 1_000,
         adapter_bridge_circuit_breaker_failures: 5,
         adapter_bridge_circuit_breaker_cooldown_ms: 3_000,
+    }
+}
+
+fn build_appfs_up_launcher_command(args: &AppfsLaunchArgs) -> Result<ProcessCommand> {
+    let current_exe = std::env::current_exe()
+        .context("failed to resolve current agentfs executable for launcher startup")?;
+    let mut command = ProcessCommand::new(current_exe);
+    command
+        .arg("appfs")
+        .arg("up")
+        .arg(&args.id_or_path)
+        .arg(&args.mountpoint)
+        .arg("--backend")
+        .arg(args.backend.to_string())
+        .arg("--poll-ms")
+        .arg(args.poll_ms.to_string())
+        .arg("--auto-unmount");
+
+    if args.allow_root {
+        command.arg("--allow-root");
+    }
+    if args.allow_other {
+        command.arg("--system");
+    }
+    if let Some(uid) = args.uid {
+        command.arg("--uid").arg(uid.to_string());
+    }
+    if let Some(gid) = args.gid {
+        command.arg("--gid").arg(gid.to_string());
+    }
+
+    Ok(command)
+}
+
+fn validate_workspace_path(workspace: &Path) -> Result<()> {
+    if workspace.is_absolute() {
+        anyhow::bail!(
+            "launcher workspace path must be relative to the AppFS mount root: {}",
+            workspace.display()
+        );
+    }
+
+    for component in workspace.components() {
+        match component {
+            Component::CurDir | Component::Normal(_) => {}
+            Component::ParentDir => {
+                anyhow::bail!(
+                    "launcher workspace path cannot escape the AppFS mount root: {}",
+                    workspace.display()
+                );
+            }
+            Component::Prefix(_) | Component::RootDir => {
+                anyhow::bail!(
+                    "launcher workspace path must stay inside the AppFS mount root: {}",
+                    workspace.display()
+                );
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn resolve_launch_workspace_path(mount_root: &Path, workspace: &Path) -> Result<PathBuf> {
+    validate_workspace_path(workspace)?;
+    Ok(mount_root.join(workspace))
+}
+
+fn generate_launcher_attach_id() -> String {
+    let uuid = Uuid::new_v4().simple().to_string();
+    format!("agent-{}", &uuid[..8])
+}
+
+fn build_launch_agent_environment(
+    manifest_path: &Path,
+    manifest: &runtime_manifest::AppfsRuntimeManifestDoc,
+    attach_id: &str,
+    attach_role: Option<&str>,
+) -> Vec<(String, String)> {
+    let mut envs = vec![
+        (APPFS_ATTACH_SCHEMA_ENV.to_string(), "1".to_string()),
+        (
+            APPFS_RUNTIME_MANIFEST_ENV.to_string(),
+            manifest_path.display().to_string(),
+        ),
+        (
+            APPFS_MOUNT_ROOT_ENV.to_string(),
+            manifest.mount_root.display().to_string(),
+        ),
+        (
+            APPFS_RUNTIME_SESSION_ID_ENV.to_string(),
+            manifest.runtime_session_id.clone(),
+        ),
+        (APPFS_ATTACH_ID_ENV.to_string(), attach_id.to_string()),
+    ];
+
+    if let Some(role) = attach_role.filter(|role| !role.trim().is_empty()) {
+        envs.push((APPFS_AGENT_ROLE_ENV.to_string(), role.to_string()));
+    }
+
+    envs
+}
+
+async fn wait_for_runtime_manifest_ready(
+    mount_root: &Path,
+    timeout: Duration,
+    appfs_child: &mut Child,
+) -> Result<(PathBuf, runtime_manifest::AppfsRuntimeManifestDoc)> {
+    let manifest_path = runtime_manifest::runtime_manifest_path(mount_root);
+    let started = Instant::now();
+    let mut last_manifest_error: Option<String> = None;
+
+    loop {
+        if let Some(status) = appfs_child.try_wait()? {
+            anyhow::bail!(
+                "AppFS launcher child exited before runtime manifest became ready (status: {})",
+                status
+            );
+        }
+
+        if manifest_path.exists() {
+            match std::fs::read(&manifest_path) {
+                Ok(bytes) => match serde_json::from_slice(&bytes) {
+                    Ok(manifest) => return Ok((manifest_path, manifest)),
+                    Err(err) => {
+                        last_manifest_error = Some(format!(
+                            "failed to parse AppFS runtime manifest {}: {err}",
+                            manifest_path.display()
+                        ));
+                    }
+                },
+                Err(err) => {
+                    last_manifest_error = Some(format!(
+                        "failed to read AppFS runtime manifest {}: {err}",
+                        manifest_path.display()
+                    ));
+                }
+            }
+        }
+
+        if started.elapsed() >= timeout {
+            if let Some(last_error) = last_manifest_error {
+                anyhow::bail!(
+                    "timed out waiting for AppFS runtime manifest readiness at {} ({last_error})",
+                    manifest_path.display()
+                );
+            }
+            anyhow::bail!(
+                "timed out waiting for AppFS runtime manifest readiness at {}",
+                manifest_path.display()
+            );
+        }
+
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+}
+
+fn wait_for_child_exit(child: &mut Child, timeout: Duration) -> bool {
+    let started = Instant::now();
+    loop {
+        match child.try_wait() {
+            Ok(Some(_)) => return true,
+            Ok(None) => {}
+            Err(_) => return false,
+        }
+
+        if started.elapsed() >= timeout {
+            return false;
+        }
+
+        std::thread::sleep(Duration::from_millis(100));
+    }
+}
+
+fn terminate_launcher_child(child: &mut Child) {
+    match child.try_wait() {
+        Ok(Some(_)) => {}
+        Ok(None) => {
+            let _ = child.kill();
+            if wait_for_child_exit(child, Duration::from_secs(5)) {
+                return;
+            }
+
+            #[cfg(target_os = "windows")]
+            {
+                let _ = ProcessCommand::new("taskkill")
+                    .args(["/PID", &child.id().to_string(), "/T", "/F"])
+                    .stdout(Stdio::null())
+                    .stderr(Stdio::null())
+                    .status();
+                let _ = wait_for_child_exit(child, Duration::from_secs(5));
+            }
+        }
+        Err(_) => {}
     }
 }
 
@@ -259,6 +479,65 @@ pub async fn handle_appfs_up_command(args: AppfsUpArgs) -> Result<()> {
             "AppFS mount thread panicked during shutdown"
         )),
     }
+}
+
+pub async fn handle_appfs_launch_command(args: AppfsLaunchArgs) -> Result<()> {
+    let mut appfs_up_command = build_appfs_up_launcher_command(&args)?;
+    let mut appfs_up_child = appfs_up_command
+        .spawn()
+        .context("failed to spawn AppFS launcher child process")?;
+
+    let launch_result = async {
+        let timeout = Duration::from_millis(args.startup_timeout_ms.max(1));
+        let (manifest_path, manifest) =
+            wait_for_runtime_manifest_ready(&args.mountpoint, timeout, &mut appfs_up_child).await?;
+
+        let workspace_dir = resolve_launch_workspace_path(&manifest.mount_root, &args.workspace)?;
+        std::fs::create_dir_all(&workspace_dir).with_context(|| {
+            format!(
+                "failed to prepare AppFS launcher workspace {}",
+                workspace_dir.display()
+            )
+        })?;
+
+        let attach_id = args
+            .attach_id
+            .clone()
+            .unwrap_or_else(generate_launcher_attach_id);
+        let launch_env = build_launch_agent_environment(
+            &manifest_path,
+            &manifest,
+            &attach_id,
+            args.attach_role.as_deref(),
+        );
+
+        let mut child_command = ProcessCommand::new(&args.agent_bin);
+        child_command.current_dir(&workspace_dir);
+        child_command.args(&args.agent_args);
+        for (key, value) in launch_env {
+            child_command.env(key, value);
+        }
+
+        let mut agent_child = child_command.spawn().with_context(|| {
+            format!(
+                "failed to spawn appfs-agent child {}",
+                args.agent_bin.display()
+            )
+        })?;
+        let status = agent_child
+            .wait()
+            .context("failed while waiting for appfs-agent child process")?;
+
+        if !status.success() {
+            anyhow::bail!("appfs-agent child exited with non-zero status: {status}");
+        }
+
+        Ok::<(), anyhow::Error>(())
+    }
+    .await;
+
+    terminate_launcher_child(&mut appfs_up_child);
+    launch_result
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -506,6 +785,96 @@ mod supervisor_tests {
         assert!(mount_args.appfs_app_ids.is_empty());
         assert!(mount_args.adapter_http_endpoint.is_none());
         assert!(mount_args.adapter_grpc_endpoint.is_none());
+    }
+
+    #[test]
+    fn appfs_launch_builds_appfs_up_launcher_command() {
+        let args = super::AppfsLaunchArgs {
+            id_or_path: ".agentfs/demo.db".to_string(),
+            mountpoint: std::path::PathBuf::from("C:\\mnt\\demo"),
+            backend: crate::cmd::mount::MountBackend::Winfsp,
+            allow_root: false,
+            allow_other: true,
+            uid: Some(1000),
+            gid: Some(1000),
+            poll_ms: 150,
+            agent_bin: std::path::PathBuf::from("C:\\tools\\claw.exe"),
+            workspace: std::path::PathBuf::from("workspace"),
+            attach_id: Some("agent-a".to_string()),
+            attach_role: Some("planner".to_string()),
+            startup_timeout_ms: 15_000,
+            agent_args: vec!["status".to_string()],
+        };
+
+        let command = super::build_appfs_up_launcher_command(&args)
+            .expect("launcher command should be built");
+        let rendered = format!("{command:?}");
+        assert!(rendered.contains("appfs"));
+        assert!(rendered.contains("up"));
+        assert!(rendered.contains("--auto-unmount"));
+        assert!(rendered.contains("--backend"));
+        assert!(rendered.contains("winfsp"));
+        assert!(rendered.contains("--system"));
+        assert!(rendered.contains("--uid"));
+        assert!(rendered.contains("--gid"));
+        assert!(rendered.contains("--poll-ms"));
+    }
+
+    #[test]
+    fn appfs_launch_workspace_path_stays_under_mount_root() {
+        let mount_root = std::path::Path::new("C:\\mnt\\appfs");
+        let workspace = std::path::Path::new("workspace\\nested");
+        let resolved = super::resolve_launch_workspace_path(mount_root, workspace)
+            .expect("workspace path should resolve");
+        assert_eq!(
+            resolved,
+            std::path::PathBuf::from("C:\\mnt\\appfs").join("workspace\\nested")
+        );
+    }
+
+    #[test]
+    fn appfs_launch_workspace_path_rejects_parent_escape() {
+        let mount_root = std::path::Path::new("C:\\mnt\\appfs");
+        let workspace = std::path::Path::new("..\\outside");
+        let err = super::resolve_launch_workspace_path(mount_root, workspace)
+            .expect_err("workspace path escape must fail");
+        assert!(err.to_string().contains("cannot escape"));
+    }
+
+    #[test]
+    fn appfs_launch_builds_child_attach_environment_from_manifest() {
+        let mount_root = std::env::temp_dir().join("appfs-launch-manifest");
+        let manifest_path = super::runtime_manifest::runtime_manifest_path(&mount_root);
+        let manifest =
+            super::runtime_manifest::build_runtime_manifest(&mount_root, "rt-shared-01", true);
+        let envs = super::build_launch_agent_environment(
+            &manifest_path,
+            &manifest,
+            "agent-planner",
+            Some("planner"),
+        );
+        let env_map: std::collections::HashMap<String, String> = envs.into_iter().collect();
+
+        assert_eq!(
+            env_map.get(super::APPFS_ATTACH_SCHEMA_ENV),
+            Some(&"1".to_string())
+        );
+        assert_eq!(
+            env_map.get(super::APPFS_RUNTIME_SESSION_ID_ENV),
+            Some(&"rt-shared-01".to_string())
+        );
+        assert_eq!(
+            env_map.get(super::APPFS_ATTACH_ID_ENV),
+            Some(&"agent-planner".to_string())
+        );
+        assert_eq!(
+            env_map.get(super::APPFS_AGENT_ROLE_ENV),
+            Some(&"planner".to_string())
+        );
+        assert_eq!(
+            env_map.get(super::APPFS_RUNTIME_MANIFEST_ENV),
+            Some(&manifest_path.display().to_string())
+        );
     }
 
     fn append_text(path: &std::path::Path, text: &str) {

--- a/cli/src/cmd/appfs.rs
+++ b/cli/src/cmd/appfs.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
 use std::collections::HashMap;
 use std::path::{Component, Path, PathBuf};
-use std::process::{Child, Command as ProcessCommand, Stdio};
+use std::process::{Child, Command as ProcessCommand};
 use std::time::{Duration, Instant};
 use uuid::Uuid;
 
@@ -322,18 +322,16 @@ fn terminate_launcher_child(child: &mut Child) {
         Ok(Some(_)) => {}
         Ok(None) => {
             let _ = child.kill();
-            if wait_for_child_exit(child, Duration::from_secs(5)) {
-                return;
-            }
-
-            #[cfg(target_os = "windows")]
-            {
-                let _ = ProcessCommand::new("taskkill")
-                    .args(["/PID", &child.id().to_string(), "/T", "/F"])
-                    .stdout(Stdio::null())
-                    .stderr(Stdio::null())
-                    .status();
-                let _ = wait_for_child_exit(child, Duration::from_secs(5));
+            if !wait_for_child_exit(child, Duration::from_secs(5)) {
+                #[cfg(target_os = "windows")]
+                {
+                    let _ = ProcessCommand::new("taskkill")
+                        .args(["/PID", &child.id().to_string(), "/T", "/F"])
+                        .stdout(std::process::Stdio::null())
+                        .stderr(std::process::Stdio::null())
+                        .status();
+                    let _ = wait_for_child_exit(child, Duration::from_secs(5));
+                }
             }
         }
         Err(_) => {}
@@ -835,7 +833,7 @@ mod supervisor_tests {
     #[test]
     fn appfs_launch_workspace_path_rejects_parent_escape() {
         let mount_root = std::path::Path::new("C:\\mnt\\appfs");
-        let workspace = std::path::Path::new("..\\outside");
+        let workspace = std::path::Path::new("../outside");
         let err = super::resolve_launch_workspace_path(mount_root, workspace)
             .expect_err("workspace path escape must fail");
         assert!(err.to_string().contains("cannot escape"));
@@ -1011,13 +1009,10 @@ mod supervisor_tests {
         let manifest: serde_json::Value =
             serde_json::from_slice(&fs::read(&manifest_path).expect("read runtime manifest"))
                 .expect("parse runtime manifest");
-        assert_eq!(
-            manifest["runtime_session_id"]
-                .as_str()
-                .unwrap_or_default()
-                .starts_with("rt-"),
-            true
-        );
+        assert!(manifest["runtime_session_id"]
+            .as_str()
+            .unwrap_or_default()
+            .starts_with("rt-"));
         assert_eq!(
             manifest["multi_agent_mode"].as_str(),
             Some(super::runtime_manifest::APPFS_MULTI_AGENT_MODE_SHARED)

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -459,6 +459,45 @@ fn main() {
                     std::process::exit(1);
                 }
             }
+            AppfsCommand::Launch {
+                id_or_path,
+                mountpoint,
+                agent_bin,
+                backend,
+                allow_root,
+                system,
+                uid,
+                gid,
+                poll_ms,
+                workspace,
+                attach_id,
+                attach_role,
+                startup_timeout_ms,
+                agent_args,
+            } => {
+                let rt = get_runtime();
+                if let Err(e) = rt.block_on(cmd::appfs::handle_appfs_launch_command(
+                    cmd::appfs::AppfsLaunchArgs {
+                        id_or_path,
+                        mountpoint,
+                        backend,
+                        allow_root,
+                        allow_other: system,
+                        uid,
+                        gid,
+                        poll_ms,
+                        agent_bin,
+                        workspace,
+                        attach_id,
+                        attach_role,
+                        startup_timeout_ms,
+                        agent_args,
+                    },
+                )) {
+                    eprintln!("Error: {}", e);
+                    std::process::exit(1);
+                }
+            }
         },
         Command::Ps => {
             if let Err(e) = cmd::ps::list_ps(&mut std::io::stdout()) {

--- a/cli/src/opts.rs
+++ b/cli/src/opts.rs
@@ -621,6 +621,64 @@ pub enum AppfsCommand {
         #[arg(long, default_value_t = 200)]
         poll_ms: u64,
     },
+    /// Launch one appfs-agent process inside an AppFS-backed workspace
+    Launch {
+        /// Agent ID or database path
+        #[arg(value_name = "ID_OR_PATH", add = ArgValueCompleter::new(id_or_path_completer))]
+        id_or_path: String,
+
+        /// Mount point directory
+        #[arg(value_name = "MOUNTPOINT", add = ArgValueCompleter::new(PathCompleter::dir()))]
+        mountpoint: PathBuf,
+
+        /// Path to the appfs-agent executable to launch
+        #[arg(long, env = "APPFS_AGENT_BIN", add = ArgValueCompleter::new(PathCompleter::file()))]
+        agent_bin: PathBuf,
+
+        /// Backend to use for mounting
+        #[arg(long, default_value_t = MountBackend::default())]
+        backend: MountBackend,
+
+        /// Allow root user to access filesystem
+        #[arg(long)]
+        allow_root: bool,
+
+        /// Allow other system users to access this mount
+        #[arg(long = "system")]
+        system: bool,
+
+        /// User ID to report for all files (defaults to current user)
+        #[arg(long)]
+        uid: Option<u32>,
+
+        /// Group ID to report for all files (defaults to current group)
+        #[arg(long)]
+        gid: Option<u32>,
+
+        /// Poll interval in milliseconds for action sink scanning
+        #[arg(long, default_value_t = 200)]
+        poll_ms: u64,
+
+        /// Relative workspace path inside the mounted AppFS view
+        #[arg(long, default_value = "workspace")]
+        workspace: PathBuf,
+
+        /// Explicit attach id for the launched child agent
+        #[arg(long)]
+        attach_id: Option<String>,
+
+        /// Descriptive attach role for the launched child agent
+        #[arg(long)]
+        attach_role: Option<String>,
+
+        /// Maximum time to wait for AppFS runtime manifest readiness
+        #[arg(long, default_value_t = 10000)]
+        startup_timeout_ms: u64,
+
+        /// Arguments passed through to the launched appfs-agent child process
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        agent_args: Vec<String>,
+    },
 }
 
 #[derive(Subcommand, Debug)]
@@ -744,6 +802,78 @@ mod tests {
                 assert_eq!(uid, None);
                 assert_eq!(gid, None);
                 assert_eq!(poll_ms, 150);
+            }
+            other => panic!("unexpected command shape: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parses_appfs_launch_command() {
+        let args = Args::parse_from([
+            "agentfs",
+            "appfs",
+            "launch",
+            ".agentfs/demo.db",
+            "C:\\mnt\\appfs",
+            "--agent-bin",
+            "C:\\tools\\claw.exe",
+            "--backend",
+            "winfsp",
+            "--workspace",
+            "workspace",
+            "--attach-id",
+            "agent-planner",
+            "--attach-role",
+            "planner",
+            "--startup-timeout-ms",
+            "15000",
+            "--",
+            "status",
+            "--output-format",
+            "json",
+        ]);
+
+        match args.command {
+            Command::Appfs {
+                command:
+                    AppfsCommand::Launch {
+                        id_or_path,
+                        mountpoint,
+                        agent_bin,
+                        backend,
+                        allow_root,
+                        system,
+                        uid,
+                        gid,
+                        poll_ms,
+                        workspace,
+                        attach_id,
+                        attach_role,
+                        startup_timeout_ms,
+                        agent_args,
+                    },
+            } => {
+                assert_eq!(id_or_path, ".agentfs/demo.db");
+                assert_eq!(mountpoint, PathBuf::from("C:\\mnt\\appfs"));
+                assert_eq!(agent_bin, PathBuf::from("C:\\tools\\claw.exe"));
+                assert!(matches!(backend, MountBackend::Winfsp));
+                assert!(!allow_root);
+                assert!(!system);
+                assert_eq!(uid, None);
+                assert_eq!(gid, None);
+                assert_eq!(poll_ms, 200);
+                assert_eq!(workspace, PathBuf::from("workspace"));
+                assert_eq!(attach_id.as_deref(), Some("agent-planner"));
+                assert_eq!(attach_role.as_deref(), Some("planner"));
+                assert_eq!(startup_timeout_ms, 15000);
+                assert_eq!(
+                    agent_args,
+                    vec![
+                        "status".to_string(),
+                        "--output-format".to_string(),
+                        "json".to_string()
+                    ]
+                );
             }
             other => panic!("unexpected command shape: {other:?}"),
         }

--- a/cli/test-windows-appfs-managed.ps1
+++ b/cli/test-windows-appfs-managed.ps1
@@ -412,7 +412,7 @@ function Main {
     $bridgeUri = [Uri]$HttpEndpoint
     $bridgeHost = $bridgeUri.Host
     $bridgePort = $bridgeUri.Port
-    $bridgeDir = Join-Path $script:RepoRoot "examples\appfs\http-bridge\python"
+    $bridgeDir = Join-Path $script:RepoRoot "examples\appfs\bridges\http-python"
     $bridgeCommand = "set `"APPFS_BRIDGE_HOST=$bridgeHost`" && set `"APPFS_BRIDGE_PORT=$bridgePort`" && python -u bridge_server.py"
     $script:BridgeHandle = New-LogHandle -Name "bridge" -FilePath "cmd.exe" -ArgumentList @("/c", $bridgeCommand) -WorkingDirectory $bridgeDir
     Wait-Until -Description "HTTP bridge startup" -TimeoutSec 15 -Condition {


### PR DESCRIPTION
﻿## Summary

Backfill the IC-3 launcher baseline from `appfs-platform` into standalone `appfs`.

This brings the standalone CLI back in sync for the component-owned parts of the launcher work that already landed in the platform repo.

## What Changed

- add `agentfs appfs launch ...` to orchestrate `appfs up` plus a child `appfs-agent` process
- plumb launcher options through CLI parsing and command dispatch
- add launcher-focused unit coverage for command construction, workspace path validation, attach env wiring, and CLI parsing
- force the pure-Rust `aegis` backend on Windows so builds do not require an extra `clang-cl` crypto toolchain
- update the Windows managed regression script to follow the reorganized HTTP bridge example path

## Why

The IC-3 launcher work was prototyped and merged in `appfs-platform` as integration-first work.
Per the repo workflow ADR, the `appfs` component-owned code should be backfilled into the standalone repository so future monorepo syncs keep a clean source-of-truth model.

## Validation

- `cargo test appfs_launch --manifest-path cli/Cargo.toml`
  - passed after exporting Windows SDK include paths for `winfsp-sys` bindgen on this machine
- PowerShell syntax check for `cli/test-windows-appfs-managed.ps1`
