### PR TITLE
Add AppFS compose startup and Huoyan attached-case bootstrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,13 @@ AppFS is the primary product story in this repository, but it is currently shipp
 
 In other words: AppFS is the app-facing protocol and UX; AgentFS is the engine that powers it.
 
-The recommended runtime entrypoint is:
+The recommended integration entrypoint for real app projects is:
+
+```bash
+agentfs appfs compose up -f appfs-compose.yaml
+```
+
+The lower-level managed runtime primitive remains:
 
 ```bash
 agentfs appfs up <id-or-path> <mountpoint>
@@ -51,7 +57,13 @@ Low-level debug commands still exist:
 
 ## Quick Start
 
-The normal AppFS flow is:
+The higher-level AppFS flow is now:
+
+1. declare runtime, connectors, and apps in `appfs-compose.yaml`
+2. run `agentfs appfs compose up`
+3. use the mounted tree directly
+
+The lower-level managed flow is still:
 
 1. start a bridge or in-process connector
 2. initialize an empty AgentFS database that AppFS will use as its storage and mount substrate
@@ -59,7 +71,54 @@ The normal AppFS flow is:
 4. register an app through `/_appfs/register_app.act`
 5. read files, switch scope, and trigger actions through the mounted tree
 
-Today this flow intentionally spans both layers: initialize storage with AgentFS, then launch the app-facing protocol/runtime with the AppFS subcommand.
+Today the recommended integration path is compose-first. `agentfs appfs up` remains the lower-level runtime primitive when you want to debug mount/runtime behavior directly.
+
+A Huoyan attached-case compose example lives at [examples/appfs/appfs-compose.huoyan-attached-case.example.yaml](./examples/appfs/appfs-compose.huoyan-attached-case.example.yaml).
+
+Minimal compose shape for the reference HTTP bridge:
+
+```yaml
+version: 1
+
+runtime:
+  db: ./.agentfs/compose-aiim.db
+  mountpoint: C:/mnt/appfs-compose-aiim
+  backend: winfsp
+  init: if_missing
+  reset: false
+
+connectors:
+  aiim-http:
+    mode: command
+    transport: http
+    endpoint: http://127.0.0.1:8080
+    healthcheck:
+      kind: connector
+      interval_ms: 500
+      timeout_ms: 2000
+      max_attempts: 40
+    command:
+      cwd: ./examples/appfs/bridges/http-python
+      program: uv
+      args: ["run", "python", "bridge_server.py"]
+
+apps:
+  aiim:
+    connector: aiim-http
+```
+
+With that file in place:
+
+```bash
+agentfs appfs compose up -f appfs-compose.yaml
+```
+
+Compose is the recommended path when you want one command to:
+
+- prepare or reopen the AgentFS runtime database
+- supervise an external or command-launched connector
+- bootstrap the managed AppFS registry
+- mount the tree and start the runtime in one foreground process
 
 Prerequisites:
 
@@ -77,6 +136,16 @@ Install WinFsp first. AppFS uses WinFsp as the Windows mount backend for `--back
 - Download and install the latest WinFsp release from [winfsp.dev/rel](https://winfsp.dev/rel/)
 - After installation, open a new terminal before running `agentfs appfs up`
 - A reboot is usually not required, but if Windows reports the driver is busy or mounts still fail after install, reboot once and retry
+- For WinFsp, the mountpoint path itself should be absent before mount. Keep the parent directory, such as `C:\mnt`, but do not pre-create `C:\mnt\appfs-compose-aiim`. `appfs compose up` now preserves this WinFsp expectation and will clean up an empty stale placeholder directory if an older run left one behind.
+
+Compose-first startup on Windows:
+
+```powershell
+cd C:\Users\esp3j\rep\agentfs\cli
+cargo run -- appfs compose up -f ..\examples\appfs\appfs-compose.huoyan-attached-case.example.yaml
+```
+
+If the target software is already inside a case or other attached scope, prefer passing that bootstrap mode through connector env in the compose file, as shown in the Huoyan example. That avoids issuing an extra `enter_scope` just to land on the working tree.
 
 Start the reference HTTP bridge:
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -32,7 +32,13 @@ AppFS 主要面向真实的 LLM + shell 工作流：
 
 也就是说：AppFS 是面向用户的协议与交互层，AgentFS 是在底下提供能力的引擎。
 
-推荐启动入口：
+面向真实项目集成时，推荐的高层启动入口是：
+
+```bash
+agentfs appfs compose up -f appfs-compose.yaml
+```
+
+底层 managed runtime 原语仍然是：
 
 ```bash
 agentfs appfs up <id-or-path> <mountpoint>
@@ -51,7 +57,13 @@ managed runtime 的共享状态文件位于：
 
 ## Quick Start
 
-标准 AppFS 流程如下：
+现在更推荐的高层 AppFS 流程是：
+
+1. 在 `appfs-compose.yaml` 中声明 runtime、connectors、apps
+2. 运行 `agentfs appfs compose up`
+3. 直接使用挂载树
+
+底层 managed 流程仍然保留：
 
 1. 启动 bridge 或进程内 connector
 2. 初始化一个空的 AgentFS 数据库，作为 AppFS 的存储与挂载底座
@@ -59,7 +71,54 @@ managed runtime 的共享状态文件位于：
 4. 通过 `/_appfs/register_app.act` 注册 app
 5. 在挂载树中直接读文件、切换 scope、触发动作
 
-也就是说，当前推荐路径会显式跨过两层：先用 AgentFS 初始化底座，再用 AppFS 子命令启动面向应用侧的协议与 runtime。
+也就是说，当前更推荐 compose-first 的集成路径；`agentfs appfs up` 继续保留给需要直接调试 mount/runtime 行为的场景。
+
+一个 Huoyan attached-case 的 compose 示例位于 [examples/appfs/appfs-compose.huoyan-attached-case.example.yaml](./examples/appfs/appfs-compose.huoyan-attached-case.example.yaml)。
+
+下面是参考 HTTP bridge 的最小 compose 结构：
+
+```yaml
+version: 1
+
+runtime:
+  db: ./.agentfs/compose-aiim.db
+  mountpoint: C:/mnt/appfs-compose-aiim
+  backend: winfsp
+  init: if_missing
+  reset: false
+
+connectors:
+  aiim-http:
+    mode: command
+    transport: http
+    endpoint: http://127.0.0.1:8080
+    healthcheck:
+      kind: connector
+      interval_ms: 500
+      timeout_ms: 2000
+      max_attempts: 40
+    command:
+      cwd: ./examples/appfs/bridges/http-python
+      program: uv
+      args: ["run", "python", "bridge_server.py"]
+
+apps:
+  aiim:
+    connector: aiim-http
+```
+
+有了这个文件之后，直接运行：
+
+```bash
+agentfs appfs compose up -f appfs-compose.yaml
+```
+
+compose 是当前推荐的主路径，因为它会在一个前台进程里完成：
+
+- 准备或复用 AgentFS runtime 数据库
+- 拉起并监管 external / command 模式的 connector
+- 预填充 managed AppFS registry
+- 挂载树并启动 runtime
 
 环境前置：
 
@@ -77,6 +136,16 @@ managed runtime 的共享状态文件位于：
 - 从 [winfsp.dev/rel](https://winfsp.dev/rel/) 下载并安装最新版本的 WinFsp
 - 安装完成后，请重新打开一个终端，再运行 `agentfs appfs up`
 - 通常不需要重启；如果安装后仍然提示驱动忙碌，或者挂载还是失败，再重启一次后重试
+- 对 WinFsp 来说，挂载点路径本身应该不存在。保留父目录，例如 `C:\mnt`，但不要提前创建 `C:\mnt\appfs-compose-aiim`。现在 `appfs compose up` 已兼容这个约束；如果旧版本运行残留了一个空目录占位符，也会在启动时自动清理掉。
+
+Windows 下的 compose 启动方式：
+
+```powershell
+cd C:\Users\esp3j\rep\agentfs\cli
+cargo run -- appfs compose up -f ..\examples\appfs\appfs-compose.huoyan-attached-case.example.yaml
+```
+
+如果目标软件本身已经处在案件或其他附着 scope 内，推荐像 Huoyan 示例那样，通过 compose 里的 connector 环境变量传入 attached-case bootstrap 信息，而不是再额外触发一次 `enter_scope`。
 
 启动参考 HTTP bridge：
 

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -100,6 +100,7 @@ dependencies = [
  "reverie-ptrace",
  "serde",
  "serde_json",
+ "serde_yaml",
  "smallvec",
  "tempfile",
  "tokio",
@@ -2943,6 +2944,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap 2.13.0",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "sha1_smol"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3744,6 +3758,12 @@ dependencies = [
  "crypto-common",
  "subtle",
 ]
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -33,6 +33,7 @@ parking_lot = "0.12.5"
 clap_complete = { version = "=4.5.61", features = ["unstable-dynamic"] }
 dirs = "6"
 serde_json = "1.0.147"
+serde_yaml = "0.9"
 tracing = "0.1.44"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 chrono = { version = "0.4.42", features = ["serde"] }

--- a/cli/src/cmd/appfs.rs
+++ b/cli/src/cmd/appfs.rs
@@ -1,4 +1,4 @@
-use agentfs_sdk::AppConnector;
+use agentfs_sdk::{AgentFSOptions, AppConnector};
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
@@ -14,6 +14,7 @@ use uuid::Uuid;
 
 mod action_dispatcher;
 mod bridge_resilience;
+pub(crate) mod compose;
 mod core;
 mod errors;
 mod events;
@@ -401,6 +402,218 @@ fn fallback_poll_interval(poll_ms: u64) -> Option<Duration> {
     }
 }
 
+async fn prepare_compose_runtime(runtime: &compose::schema::AppfsComposeRuntime) -> Result<String> {
+    if let Some(parent) = runtime.db.parent() {
+        std::fs::create_dir_all(parent).with_context(|| {
+            format!(
+                "failed to create compose runtime db parent directory {}",
+                parent.display()
+            )
+        })?;
+    }
+
+    if runtime.backend == crate::cmd::mount::MountBackend::Winfsp {
+        let mount_parent = runtime
+            .mountpoint
+            .parent()
+            .filter(|parent| !parent.as_os_str().is_empty())
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "compose runtime winfsp mountpoint must include a parent directory: {}",
+                    runtime.mountpoint.display()
+                )
+            })?;
+        std::fs::create_dir_all(mount_parent).with_context(|| {
+            format!(
+                "failed to create compose runtime winfsp mountpoint parent directory {}",
+                mount_parent.display()
+            )
+        })?;
+        if runtime.mountpoint.exists() {
+            if !runtime.mountpoint.is_dir() {
+                anyhow::bail!(
+                    "compose runtime mountpoint exists but is not a directory: {}",
+                    runtime.mountpoint.display()
+                );
+            }
+            let is_empty = std::fs::read_dir(&runtime.mountpoint)
+                .with_context(|| {
+                    format!(
+                        "failed to inspect compose runtime winfsp mountpoint directory {}",
+                        runtime.mountpoint.display()
+                    )
+                })?
+                .next()
+                .is_none();
+            if !is_empty {
+                anyhow::bail!(
+                    "compose runtime winfsp mountpoint must be empty or absent: {}",
+                    runtime.mountpoint.display()
+                );
+            }
+            std::fs::remove_dir(&runtime.mountpoint).with_context(|| {
+                format!(
+                    "failed to remove empty compose runtime winfsp mountpoint placeholder {}",
+                    runtime.mountpoint.display()
+                )
+            })?;
+        }
+    } else if runtime.mountpoint.exists() {
+        if !runtime.mountpoint.is_dir() {
+            anyhow::bail!(
+                "compose runtime mountpoint exists but is not a directory: {}",
+                runtime.mountpoint.display()
+            );
+        }
+    } else {
+        std::fs::create_dir_all(&runtime.mountpoint).with_context(|| {
+            format!(
+                "failed to create compose runtime mountpoint directory {}",
+                runtime.mountpoint.display()
+            )
+        })?;
+    }
+
+    let db_path = runtime
+        .db
+        .to_str()
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "compose runtime db path must be valid UTF-8: {}",
+                runtime.db.display()
+            )
+        })?
+        .to_string();
+    let sidecar_info_path = PathBuf::from(format!("{db_path}-info"));
+
+    if runtime.reset {
+        if runtime.db.exists() {
+            std::fs::remove_file(&runtime.db).with_context(|| {
+                format!(
+                    "failed to remove compose runtime db {}",
+                    runtime.db.display()
+                )
+            })?;
+        }
+        if sidecar_info_path.exists() {
+            std::fs::remove_file(&sidecar_info_path).with_context(|| {
+                format!(
+                    "failed to remove compose runtime sync sidecar {}",
+                    sidecar_info_path.display()
+                )
+            })?;
+        }
+    }
+
+    match runtime.init {
+        compose::schema::AppfsComposeInitMode::Never => {
+            if !runtime.db.exists() {
+                anyhow::bail!(
+                    "compose runtime db does not exist and runtime.init=never: {}",
+                    runtime.db.display()
+                );
+            }
+        }
+        compose::schema::AppfsComposeInitMode::IfMissing => {
+            if !runtime.db.exists() {
+                let _agent = crate::cmd::init::open_agentfs(AgentFSOptions::with_path(&db_path))
+                    .await
+                    .with_context(|| {
+                        format!(
+                            "failed to initialize compose runtime db {}",
+                            runtime.db.display()
+                        )
+                    })?;
+            }
+        }
+        compose::schema::AppfsComposeInitMode::Always => {
+            let _agent = crate::cmd::init::open_agentfs(AgentFSOptions::with_path(&db_path))
+                .await
+                .with_context(|| {
+                    format!(
+                        "failed to initialize compose runtime db {}",
+                        runtime.db.display()
+                    )
+                })?;
+        }
+    }
+
+    Ok(db_path)
+}
+
+async fn run_managed_appfs_with_bootstrap<F>(args: AppfsUpArgs, bootstrap: F) -> Result<()>
+where
+    F: FnOnce(&Path) -> Result<()>,
+{
+    let action_wake = ActionWakeHandle::new();
+    let mut mount_args = build_managed_mount_args(&args);
+    mount_args.action_wake = Some(action_wake.clone());
+    let mountpoint = mount_args.mountpoint.clone();
+    let (ready_tx, ready_rx) = std::sync::mpsc::sync_channel(1);
+    let mount_thread = std::thread::spawn(move || {
+        let startup_tx = ready_tx.clone();
+        let result = crate::cmd::mount::mount_with_ready(mount_args, Some(startup_tx));
+        if let Err(err) = &result {
+            let _ = ready_tx.send(Err(anyhow::anyhow!(err.to_string())));
+        }
+        result
+    });
+
+    match ready_rx.recv_timeout(Duration::from_secs(10)) {
+        Ok(Ok(())) => {}
+        Ok(Err(err)) => {
+            let _ = mount_thread.join();
+            return Err(err);
+        }
+        Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
+            return Err(anyhow::anyhow!(
+                "AppFS mount did not report readiness within 10 seconds: {}",
+                mountpoint.display()
+            ));
+        }
+        Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
+            return Err(anyhow::anyhow!(
+                "AppFS mount exited before reporting readiness: {}",
+                mountpoint.display()
+            ));
+        }
+    }
+
+    bootstrap(&mountpoint)?;
+
+    let runtime_result = handle_appfs_adapter_command(AppfsServeArgs {
+        root: mountpoint,
+        managed: true,
+        app_id: None,
+        app_ids: Vec::new(),
+        session_id: None,
+        poll_ms: args.poll_ms,
+        action_wake: Some(action_wake),
+        adapter_http_endpoint: None,
+        adapter_http_timeout_ms: 5_000,
+        adapter_grpc_endpoint: None,
+        adapter_grpc_timeout_ms: 5_000,
+        adapter_bridge_max_retries: 2,
+        adapter_bridge_initial_backoff_ms: 100,
+        adapter_bridge_max_backoff_ms: 1_000,
+        adapter_bridge_circuit_breaker_failures: 5,
+        adapter_bridge_circuit_breaker_cooldown_ms: 3_000,
+    })
+    .await;
+
+    if let Err(err) = runtime_result {
+        return Err(err);
+    }
+
+    match mount_thread.join() {
+        Ok(Ok(())) => runtime_result,
+        Ok(Err(err)) => Err(err),
+        Err(_) => Err(anyhow::anyhow!(
+            "AppFS mount thread panicked during shutdown"
+        )),
+    }
+}
+
 pub async fn handle_appfs_adapter_command(args: AppfsServeArgs) -> Result<()> {
     let AppfsServeArgs {
         root,
@@ -544,71 +757,38 @@ pub async fn handle_appfs_adapter_command(args: AppfsServeArgs) -> Result<()> {
 }
 
 pub async fn handle_appfs_up_command(args: AppfsUpArgs) -> Result<()> {
-    let action_wake = ActionWakeHandle::new();
-    let mut mount_args = build_managed_mount_args(&args);
-    mount_args.action_wake = Some(action_wake.clone());
-    let mountpoint = mount_args.mountpoint.clone();
-    let (ready_tx, ready_rx) = std::sync::mpsc::sync_channel(1);
-    let mount_thread = std::thread::spawn(move || {
-        let startup_tx = ready_tx.clone();
-        let result = crate::cmd::mount::mount_with_ready(mount_args, Some(startup_tx));
-        if let Err(err) = &result {
-            let _ = ready_tx.send(Err(anyhow::anyhow!(err.to_string())));
-        }
-        result
-    });
+    run_managed_appfs_with_bootstrap(args, |_| Ok(())).await
+}
 
-    match ready_rx.recv_timeout(Duration::from_secs(10)) {
-        Ok(Ok(())) => {}
-        Ok(Err(err)) => {
-            let _ = mount_thread.join();
-            return Err(err);
-        }
-        Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
-            return Err(anyhow::anyhow!(
-                "AppFS mount did not report readiness within 10 seconds: {}",
-                mountpoint.display()
-            ));
-        }
-        Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
-            return Err(anyhow::anyhow!(
-                "AppFS mount exited before reporting readiness: {}",
-                mountpoint.display()
-            ));
-        }
-    }
+pub async fn handle_appfs_compose_up_command(compose_path: Option<PathBuf>) -> Result<()> {
+    let cwd = std::env::current_dir().context("failed to resolve current working directory")?;
+    let compose_doc = compose::loader::load_compose_doc(compose_path.as_deref(), &cwd)?;
+    let db_path = prepare_compose_runtime(&compose_doc.runtime).await?;
 
-    let runtime_result = handle_appfs_adapter_command(AppfsServeArgs {
-        root: mountpoint,
-        managed: true,
-        app_id: None,
-        app_ids: Vec::new(),
-        session_id: None,
-        poll_ms: args.poll_ms,
-        action_wake: Some(action_wake),
-        adapter_http_endpoint: None,
-        adapter_http_timeout_ms: 5_000,
-        adapter_grpc_endpoint: None,
-        adapter_grpc_timeout_ms: 5_000,
-        adapter_bridge_max_retries: 2,
-        adapter_bridge_initial_backoff_ms: 100,
-        adapter_bridge_max_backoff_ms: 1_000,
-        adapter_bridge_circuit_breaker_failures: 5,
-        adapter_bridge_circuit_breaker_cooldown_ms: 3_000,
-    })
+    let (mut connector_supervisor, resolved_apps) =
+        compose::connector_supervisor::ComposeConnectorSupervisor::resolve_apps(&compose_doc)?;
+
+    let result = run_managed_appfs_with_bootstrap(
+        AppfsUpArgs {
+            id_or_path: db_path,
+            mountpoint: compose_doc.runtime.mountpoint.clone(),
+            backend: compose_doc.runtime.backend,
+            auto_unmount: compose_doc.runtime.auto_unmount,
+            allow_root: compose_doc.runtime.allow_root,
+            allow_other: compose_doc.runtime.allow_other,
+            uid: compose_doc.runtime.uid,
+            gid: compose_doc.runtime.gid,
+            poll_ms: compose_doc.runtime.poll_ms,
+        },
+        |root| {
+            compose::reconcile::bootstrap_registry_from_resolved_apps(root, &resolved_apps)?;
+            Ok(())
+        },
+    )
     .await;
 
-    if let Err(err) = runtime_result {
-        return Err(err);
-    }
-
-    match mount_thread.join() {
-        Ok(Ok(())) => runtime_result,
-        Ok(Err(err)) => Err(err),
-        Err(_) => Err(anyhow::anyhow!(
-            "AppFS mount thread panicked during shutdown"
-        )),
-    }
+    connector_supervisor.shutdown();
+    result
 }
 
 pub async fn handle_appfs_launch_command(args: AppfsLaunchArgs) -> Result<()> {
@@ -866,7 +1046,7 @@ struct AppfsAdapter {
 #[cfg(test)]
 mod supervisor_tests {
     use super::{
-        build_runtime_cli_args, registry, resolve_runtime_cli_args, runtime_config,
+        build_runtime_cli_args, compose, registry, resolve_runtime_cli_args, runtime_config,
         ActionWakeHandle, AppfsBridgeCliArgs, AppfsRuntimeSupervisor,
     };
     use serde_json::{json, Value as JsonValue};
@@ -1031,6 +1211,143 @@ mod supervisor_tests {
             env_map.get(super::APPFS_RUNTIME_MANIFEST_ENV),
             Some(&manifest_path.display().to_string())
         );
+    }
+
+    #[test]
+    fn prepare_compose_runtime_non_winfsp_creates_db_and_mountpoint_when_missing() {
+        let temp = TempDir::new().expect("tempdir");
+        let runtime = compose::schema::AppfsComposeRuntime {
+            db: temp.path().join(".agentfs/compose.db"),
+            mountpoint: temp.path().join("mnt/appfs"),
+            backend: crate::cmd::mount::MountBackend::Nfs,
+            init: compose::schema::AppfsComposeInitMode::IfMissing,
+            reset: false,
+            auto_unmount: true,
+            allow_root: false,
+            allow_other: false,
+            uid: None,
+            gid: None,
+            poll_ms: 0,
+        };
+
+        let db_path = crate::get_runtime()
+            .block_on(super::prepare_compose_runtime(&runtime))
+            .expect("compose runtime should prepare");
+
+        assert_eq!(db_path, runtime.db.to_string_lossy().to_string());
+        assert!(runtime.db.exists());
+        assert!(runtime.mountpoint.exists());
+        assert!(runtime.mountpoint.is_dir());
+    }
+
+    #[test]
+    fn prepare_compose_runtime_winfsp_creates_parent_without_mountpoint() {
+        let temp = TempDir::new().expect("tempdir");
+        let mountpoint = temp.path().join("mnt/appfs");
+        let mount_parent = mountpoint.parent().expect("mount parent").to_path_buf();
+        let runtime = compose::schema::AppfsComposeRuntime {
+            db: temp.path().join(".agentfs/compose.db"),
+            mountpoint: mountpoint.clone(),
+            backend: crate::cmd::mount::MountBackend::Winfsp,
+            init: compose::schema::AppfsComposeInitMode::IfMissing,
+            reset: false,
+            auto_unmount: true,
+            allow_root: false,
+            allow_other: false,
+            uid: None,
+            gid: None,
+            poll_ms: 0,
+        };
+
+        let db_path = crate::get_runtime()
+            .block_on(super::prepare_compose_runtime(&runtime))
+            .expect("compose runtime should prepare");
+
+        assert_eq!(db_path, runtime.db.to_string_lossy().to_string());
+        assert!(runtime.db.exists());
+        assert!(mount_parent.exists());
+        assert!(mount_parent.is_dir());
+        assert!(!mountpoint.exists());
+    }
+
+    #[test]
+    fn prepare_compose_runtime_winfsp_removes_empty_mountpoint_placeholder() {
+        let temp = TempDir::new().expect("tempdir");
+        let mountpoint = temp.path().join("mnt/appfs");
+        fs::create_dir_all(&mountpoint).expect("create mountpoint placeholder");
+        let runtime = compose::schema::AppfsComposeRuntime {
+            db: temp.path().join(".agentfs/compose.db"),
+            mountpoint: mountpoint.clone(),
+            backend: crate::cmd::mount::MountBackend::Winfsp,
+            init: compose::schema::AppfsComposeInitMode::IfMissing,
+            reset: false,
+            auto_unmount: true,
+            allow_root: false,
+            allow_other: false,
+            uid: None,
+            gid: None,
+            poll_ms: 0,
+        };
+
+        crate::get_runtime()
+            .block_on(super::prepare_compose_runtime(&runtime))
+            .expect("compose runtime should prepare");
+
+        assert!(!mountpoint.exists());
+    }
+
+    #[test]
+    fn prepare_compose_runtime_reset_removes_existing_db_sidecar() {
+        let temp = TempDir::new().expect("tempdir");
+        let db_path = temp.path().join(".agentfs/compose.db");
+        let sidecar_path = std::path::PathBuf::from(format!("{}-info", db_path.display()));
+        fs::create_dir_all(db_path.parent().expect("db parent")).expect("create parent");
+        fs::write(&db_path, b"stale").expect("write db");
+        fs::write(&sidecar_path, b"stale-sidecar").expect("write sidecar");
+
+        let runtime = compose::schema::AppfsComposeRuntime {
+            db: db_path.clone(),
+            mountpoint: temp.path().join("mnt/appfs"),
+            backend: crate::cmd::mount::MountBackend::default(),
+            init: compose::schema::AppfsComposeInitMode::IfMissing,
+            reset: true,
+            auto_unmount: true,
+            allow_root: false,
+            allow_other: false,
+            uid: None,
+            gid: None,
+            poll_ms: 0,
+        };
+
+        crate::get_runtime()
+            .block_on(super::prepare_compose_runtime(&runtime))
+            .expect("compose runtime should prepare");
+
+        assert!(db_path.exists());
+        assert!(!sidecar_path.exists());
+    }
+
+    #[test]
+    fn prepare_compose_runtime_never_requires_existing_db() {
+        let temp = TempDir::new().expect("tempdir");
+        let runtime = compose::schema::AppfsComposeRuntime {
+            db: temp.path().join(".agentfs/missing.db"),
+            mountpoint: temp.path().join("mnt/appfs"),
+            backend: crate::cmd::mount::MountBackend::default(),
+            init: compose::schema::AppfsComposeInitMode::Never,
+            reset: false,
+            auto_unmount: true,
+            allow_root: false,
+            allow_other: false,
+            uid: None,
+            gid: None,
+            poll_ms: 0,
+        };
+
+        let err = crate::get_runtime()
+            .block_on(super::prepare_compose_runtime(&runtime))
+            .expect_err("missing db should fail");
+        assert!(err.to_string().contains("runtime.init=never"));
     }
 
     fn append_text(path: &std::path::Path, text: &str) {

--- a/cli/src/cmd/appfs/compose.rs
+++ b/cli/src/cmd/appfs/compose.rs
@@ -1,0 +1,6 @@
+#![allow(dead_code)]
+
+pub(crate) mod connector_supervisor;
+pub(crate) mod loader;
+pub(crate) mod reconcile;
+pub(crate) mod schema;

--- a/cli/src/cmd/appfs/compose/connector_supervisor.rs
+++ b/cli/src/cmd/appfs/compose/connector_supervisor.rs
@@ -1,0 +1,715 @@
+use super::schema::{
+    AppfsComposeAppTransport, AppfsComposeConnector, AppfsComposeConnectorHealthcheck,
+    AppfsComposeConnectorMode, AppfsComposeDoc, AppfsComposeTransportKind,
+};
+use crate::cmd::appfs::core::build_app_connector;
+use crate::cmd::appfs::{build_appfs_bridge_config, AppfsBridgeCliArgs};
+use agentfs_sdk::{AuthStatus, ConnectorContext};
+use anyhow::{Context, Result};
+use std::collections::BTreeMap;
+use std::process::{Child, Command as ProcessCommand};
+use std::thread;
+use std::time::{Duration, Instant};
+use uuid::Uuid;
+
+const DEFAULT_HEALTHCHECK_INTERVAL_MS: u64 = 1_000;
+const DEFAULT_HEALTHCHECK_TIMEOUT_MS: u64 = 3_000;
+const DEFAULT_HEALTHCHECK_MAX_ATTEMPTS: u32 = 20;
+
+#[derive(Debug)]
+pub(crate) struct ComposeConnectorSupervisor {
+    owned_children: Vec<ComposeOwnedChild>,
+}
+
+#[derive(Debug)]
+struct ComposeOwnedChild {
+    connector_name: String,
+    child: Child,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ResolvedComposeApp {
+    pub(crate) app_id: String,
+    pub(crate) connector_name: String,
+    pub(crate) transport_kind: AppfsComposeTransportKind,
+    pub(crate) endpoint: String,
+    pub(crate) session_id: Option<String>,
+    pub(crate) transport: AppfsComposeAppTransport,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct ResolvedHealthcheck {
+    interval_ms: u64,
+    timeout_ms: u64,
+    max_attempts: u32,
+}
+
+impl ComposeConnectorSupervisor {
+    pub(crate) fn resolve_apps(
+        compose: &AppfsComposeDoc,
+    ) -> Result<(Self, BTreeMap<String, ResolvedComposeApp>)> {
+        let mut supervisor = Self {
+            owned_children: Vec::new(),
+        };
+        let mut resolved_apps = BTreeMap::new();
+
+        for (app_id, app) in &compose.apps {
+            let connector = compose.connectors.get(&app.connector).ok_or_else(|| {
+                anyhow::anyhow!(
+                    "compose app {} references unknown connector {}",
+                    app_id,
+                    app.connector
+                )
+            })?;
+            let resolved = match supervisor.resolve_app_connector(app_id, app, connector) {
+                Ok(resolved) => resolved,
+                Err(err) => {
+                    supervisor.shutdown();
+                    return Err(err);
+                }
+            };
+            resolved_apps.insert(app_id.clone(), resolved);
+        }
+
+        Ok((supervisor, resolved_apps))
+    }
+
+    pub(crate) fn shutdown(&mut self) {
+        for owned in self.owned_children.iter_mut().rev() {
+            terminate_child_process(&mut owned.child);
+        }
+        self.owned_children.clear();
+    }
+
+    #[cfg(test)]
+    fn owned_pids(&self) -> Vec<u32> {
+        self.owned_children
+            .iter()
+            .map(|owned| owned.child.id())
+            .collect()
+    }
+
+    fn resolve_app_connector(
+        &mut self,
+        app_id: &str,
+        app: &super::schema::AppfsComposeApp,
+        connector: &AppfsComposeConnector,
+    ) -> Result<ResolvedComposeApp> {
+        let healthcheck = resolve_healthcheck(connector.healthcheck.as_ref());
+        match connector.mode {
+            AppfsComposeConnectorMode::External => {
+                wait_for_connector_ready(app_id, connector, healthcheck)?;
+            }
+            AppfsComposeConnectorMode::Command => {
+                let mut child = spawn_connector_child(&app.connector, connector)
+                    .with_context(|| format!("failed to launch connector for app {app_id}"))?;
+                if let Err(err) = wait_for_connector_ready(app_id, connector, healthcheck) {
+                    terminate_child_process(&mut child);
+                    return Err(err);
+                }
+                self.owned_children.push(ComposeOwnedChild {
+                    connector_name: app.connector.clone(),
+                    child,
+                });
+            }
+            AppfsComposeConnectorMode::ExternalOrCommand => {
+                if probe_connector_once(app_id, connector, healthcheck.timeout_ms).is_err() {
+                    let mut child =
+                        spawn_connector_child(&app.connector, connector).with_context(|| {
+                            format!("failed to launch fallback connector for app {app_id}")
+                        })?;
+                    if let Err(err) = wait_for_connector_ready(app_id, connector, healthcheck) {
+                        terminate_child_process(&mut child);
+                        return Err(err);
+                    }
+                    self.owned_children.push(ComposeOwnedChild {
+                        connector_name: app.connector.clone(),
+                        child,
+                    });
+                }
+            }
+        }
+
+        Ok(ResolvedComposeApp {
+            app_id: app_id.to_string(),
+            connector_name: app.connector.clone(),
+            transport_kind: connector.transport,
+            endpoint: connector.endpoint.clone(),
+            session_id: app.session_id.clone(),
+            transport: app.transport.clone(),
+        })
+    }
+}
+
+impl Drop for ComposeConnectorSupervisor {
+    fn drop(&mut self) {
+        self.shutdown();
+    }
+}
+
+fn resolve_healthcheck(
+    healthcheck: Option<&AppfsComposeConnectorHealthcheck>,
+) -> ResolvedHealthcheck {
+    ResolvedHealthcheck {
+        interval_ms: healthcheck
+            .map(|healthcheck| healthcheck.interval_ms)
+            .unwrap_or(DEFAULT_HEALTHCHECK_INTERVAL_MS),
+        timeout_ms: healthcheck
+            .map(|healthcheck| healthcheck.timeout_ms)
+            .unwrap_or(DEFAULT_HEALTHCHECK_TIMEOUT_MS),
+        max_attempts: healthcheck
+            .map(|healthcheck| healthcheck.max_attempts)
+            .unwrap_or(DEFAULT_HEALTHCHECK_MAX_ATTEMPTS),
+    }
+}
+
+fn wait_for_connector_ready(
+    app_id: &str,
+    connector: &AppfsComposeConnector,
+    healthcheck: ResolvedHealthcheck,
+) -> Result<()> {
+    let started = Instant::now();
+    let mut last_error = None;
+    for attempt in 1..=healthcheck.max_attempts.max(1) {
+        match probe_connector_once(app_id, connector, healthcheck.timeout_ms) {
+            Ok(()) => return Ok(()),
+            Err(err) => {
+                last_error = Some(err);
+                if attempt < healthcheck.max_attempts.max(1) {
+                    thread::sleep(Duration::from_millis(healthcheck.interval_ms.max(1)));
+                }
+            }
+        }
+    }
+    let last_error = last_error.unwrap_or_else(|| {
+        anyhow::anyhow!(
+            "connector {} for app {} did not become ready",
+            connector.endpoint,
+            app_id
+        )
+    });
+    Err(anyhow::anyhow!(
+        "connector {} for app {} did not become ready within {} ms: {last_error:#}",
+        connector.endpoint,
+        app_id,
+        started.elapsed().as_millis()
+    ))
+}
+
+fn probe_connector_once(
+    app_id: &str,
+    connector: &AppfsComposeConnector,
+    timeout_ms: u64,
+) -> Result<()> {
+    let bridge_config = build_health_bridge_config(connector, timeout_ms);
+    let mut connector_client = build_app_connector(app_id, &bridge_config).with_context(|| {
+        format!(
+            "failed to initialize connector for app {} at {}",
+            app_id, connector.endpoint
+        )
+    })?;
+    let ctx = ConnectorContext {
+        app_id: app_id.to_string(),
+        session_id: format!("compose-health-{}", app_id),
+        request_id: format!("compose-health-{}", Uuid::new_v4().simple()),
+        client_token: None,
+        trace_id: None,
+    };
+    let health = connector_client
+        .health(&ctx)
+        .map_err(|err| anyhow::anyhow!("connector health failed: {}: {}", err.code, err.message))?;
+    if !health.healthy {
+        anyhow::bail!(
+            "connector reported unhealthy auth_status={:?} message={}",
+            health.auth_status,
+            health.message.unwrap_or_else(|| "<none>".to_string())
+        );
+    }
+    if matches!(
+        health.auth_status,
+        AuthStatus::Expired | AuthStatus::Invalid
+    ) {
+        anyhow::bail!("connector auth is not ready: {:?}", health.auth_status);
+    }
+    Ok(())
+}
+
+fn build_health_bridge_config(
+    connector: &AppfsComposeConnector,
+    timeout_ms: u64,
+) -> crate::cmd::appfs::AppfsBridgeConfig {
+    build_appfs_bridge_config(AppfsBridgeCliArgs {
+        adapter_http_endpoint: match connector.transport {
+            AppfsComposeTransportKind::Http => Some(connector.endpoint.clone()),
+            AppfsComposeTransportKind::Grpc => None,
+        },
+        adapter_http_timeout_ms: timeout_ms.max(1),
+        adapter_grpc_endpoint: match connector.transport {
+            AppfsComposeTransportKind::Http => None,
+            AppfsComposeTransportKind::Grpc => Some(connector.endpoint.clone()),
+        },
+        adapter_grpc_timeout_ms: timeout_ms.max(1),
+        adapter_bridge_max_retries: 0,
+        adapter_bridge_initial_backoff_ms: 1,
+        adapter_bridge_max_backoff_ms: 1,
+        adapter_bridge_circuit_breaker_failures: 0,
+        adapter_bridge_circuit_breaker_cooldown_ms: 1,
+    })
+}
+
+fn spawn_connector_child(connector_name: &str, connector: &AppfsComposeConnector) -> Result<Child> {
+    let command = connector.command.as_ref().ok_or_else(|| {
+        anyhow::anyhow!(
+            "compose connector {} requires command but none was configured",
+            connector_name
+        )
+    })?;
+    let mut process = ProcessCommand::new(&command.program);
+    process.current_dir(&command.cwd);
+    process.args(&command.args);
+    for (key, value) in &command.env {
+        process.env(key, value);
+    }
+    process.spawn().with_context(|| {
+        format!(
+            "failed to spawn compose connector {} via {}",
+            connector_name,
+            command.program.display()
+        )
+    })
+}
+
+fn terminate_child_process(child: &mut Child) {
+    match child.try_wait() {
+        Ok(Some(_)) => {}
+        Ok(None) => {
+            let _ = child.kill();
+            if !wait_for_child_exit(child, Duration::from_secs(5)) {
+                #[cfg(target_os = "windows")]
+                {
+                    let _ = ProcessCommand::new("taskkill")
+                        .args(["/PID", &child.id().to_string(), "/T", "/F"])
+                        .status();
+                    let _ = wait_for_child_exit(child, Duration::from_secs(5));
+                }
+            }
+        }
+        Err(_) => {}
+    }
+}
+
+fn wait_for_child_exit(child: &mut Child, timeout: Duration) -> bool {
+    let started = Instant::now();
+    loop {
+        match child.try_wait() {
+            Ok(Some(_)) => return true,
+            Ok(None) => {}
+            Err(_) => return false,
+        }
+        if started.elapsed() >= timeout {
+            return false;
+        }
+        thread::sleep(Duration::from_millis(100));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ComposeConnectorSupervisor, ResolvedComposeApp};
+    use crate::cmd::appfs::compose::schema::parse_compose_doc;
+    use serde_json::json;
+    use std::io::{Read, Write};
+    use std::net::{TcpListener, TcpStream};
+    use std::path::Path;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::Arc;
+    use std::thread;
+    use std::time::{Duration, Instant};
+    use tempfile::TempDir;
+
+    #[test]
+    fn resolves_external_http_connector() {
+        let server = MockHttpConnectorServer::spawn("aiim");
+        let temp = TempDir::new().expect("tempdir");
+        let doc = parse_compose_doc(
+            &format!(
+                r#"
+version: 1
+runtime:
+  db: .agentfs/demo.db
+  mountpoint: ./mnt/appfs
+  backend: fuse
+connectors:
+  aiim-http:
+    mode: external
+    transport: http
+    endpoint: {}
+    healthcheck:
+      interval_ms: 20
+      timeout_ms: 100
+      max_attempts: 5
+apps:
+  aiim:
+    connector: aiim-http
+"#,
+                server.endpoint()
+            ),
+            temp.path().join("appfs-compose.yaml"),
+        )
+        .expect("compose should parse");
+
+        let (_supervisor, resolved) =
+            ComposeConnectorSupervisor::resolve_apps(&doc).expect("compose should resolve");
+
+        let resolved_aiim = resolved.get("aiim").expect("resolved app");
+        assert_eq!(
+            resolved_aiim,
+            &ResolvedComposeApp {
+                app_id: "aiim".to_string(),
+                connector_name: "aiim-http".to_string(),
+                transport_kind: crate::cmd::appfs::compose::schema::AppfsComposeTransportKind::Http,
+                endpoint: server.endpoint(),
+                session_id: None,
+                transport: Default::default(),
+            }
+        );
+    }
+
+    #[test]
+    fn launches_command_connector_and_shuts_it_down() {
+        let temp = TempDir::new().expect("tempdir");
+        let signal_path = temp.path().join("connector-started.txt");
+        let port = reserve_test_port();
+        let endpoint = format!("http://127.0.0.1:{port}");
+        let server_started = Arc::new(AtomicBool::new(false));
+        let server_signal = signal_path.clone();
+        let server_started_flag = server_started.clone();
+        let server_thread = thread::spawn(move || {
+            wait_for_path(&server_signal, Duration::from_secs(5)).expect("wait for child signal");
+            let _server = MockHttpConnectorServer::bind_at("aiim", port);
+            server_started_flag.store(true, Ordering::SeqCst);
+            thread::sleep(Duration::from_secs(2));
+        });
+
+        let doc = parse_compose_doc(
+            &format!(
+                r#"
+version: 1
+runtime:
+  db: .agentfs/demo.db
+  mountpoint: ./mnt/appfs
+  backend: fuse
+connectors:
+  aiim-http:
+    mode: command
+    transport: http
+    endpoint: {endpoint}
+    healthcheck:
+      interval_ms: 20
+      timeout_ms: 100
+      max_attempts: 50
+    command:
+      program: {program}
+      args: {args}
+apps:
+  aiim:
+    connector: aiim-http
+"#,
+                program = shell_program_literal(),
+                args = shell_args_yaml(&signal_path),
+            ),
+            temp.path().join("appfs-compose.yaml"),
+        )
+        .expect("compose should parse");
+
+        let (mut supervisor, resolved) =
+            ComposeConnectorSupervisor::resolve_apps(&doc).expect("compose should resolve");
+        assert!(signal_path.exists());
+        assert!(server_started.load(Ordering::SeqCst));
+        assert_eq!(resolved.get("aiim").expect("resolved").endpoint, endpoint);
+        let owned_pids = supervisor.owned_pids();
+        assert_eq!(owned_pids.len(), 1);
+
+        supervisor.shutdown();
+        wait_for_process_exit(owned_pids[0], Duration::from_secs(5))
+            .expect("compose-owned child should exit");
+        server_thread.join().expect("server thread");
+    }
+
+    #[test]
+    fn external_or_command_falls_back_to_command() {
+        let temp = TempDir::new().expect("tempdir");
+        let signal_path = temp.path().join("connector-started.txt");
+        let port = reserve_test_port();
+        let endpoint = format!("http://127.0.0.1:{port}");
+        let server_signal = signal_path.clone();
+        let server_thread = thread::spawn(move || {
+            wait_for_path(&server_signal, Duration::from_secs(5)).expect("wait for child signal");
+            let _server = MockHttpConnectorServer::bind_at("aiim", port);
+            thread::sleep(Duration::from_secs(2));
+        });
+
+        let doc = parse_compose_doc(
+            &format!(
+                r#"
+version: 1
+runtime:
+  db: .agentfs/demo.db
+  mountpoint: ./mnt/appfs
+  backend: fuse
+connectors:
+  aiim-http:
+    mode: external_or_command
+    transport: http
+    endpoint: {endpoint}
+    healthcheck:
+      interval_ms: 20
+      timeout_ms: 100
+      max_attempts: 50
+    command:
+      program: {program}
+      args: {args}
+apps:
+  aiim:
+    connector: aiim-http
+"#,
+                program = shell_program_literal(),
+                args = shell_args_yaml(&signal_path),
+            ),
+            temp.path().join("appfs-compose.yaml"),
+        )
+        .expect("compose should parse");
+
+        let (mut supervisor, _resolved) =
+            ComposeConnectorSupervisor::resolve_apps(&doc).expect("compose should resolve");
+        assert!(signal_path.exists());
+        assert_eq!(supervisor.owned_pids().len(), 1);
+        supervisor.shutdown();
+        server_thread.join().expect("server thread");
+    }
+
+    fn wait_for_path(path: &Path, timeout: Duration) -> anyhow::Result<()> {
+        let started = Instant::now();
+        while started.elapsed() < timeout {
+            if path.exists() {
+                return Ok(());
+            }
+            thread::sleep(Duration::from_millis(20));
+        }
+        anyhow::bail!("timed out waiting for {}", path.display())
+    }
+
+    fn reserve_test_port() -> u16 {
+        TcpListener::bind("127.0.0.1:0")
+            .expect("bind port")
+            .local_addr()
+            .expect("local addr")
+            .port()
+    }
+
+    fn wait_for_process_exit(pid: u32, timeout: Duration) -> anyhow::Result<()> {
+        let started = Instant::now();
+        while started.elapsed() < timeout {
+            if !process_exists(pid)? {
+                return Ok(());
+            }
+            thread::sleep(Duration::from_millis(50));
+        }
+        anyhow::bail!("process {} did not exit in time", pid)
+    }
+
+    fn process_exists(pid: u32) -> anyhow::Result<bool> {
+        #[cfg(target_os = "windows")]
+        {
+            let status = std::process::Command::new("powershell")
+                .args([
+                    "-NoProfile",
+                    "-Command",
+                    &format!(
+                        "if (Get-Process -Id {} -ErrorAction SilentlyContinue) {{ exit 0 }} else {{ exit 1 }}",
+                        pid
+                    ),
+                ])
+                .status()?;
+            Ok(status.success())
+        }
+        #[cfg(not(target_os = "windows"))]
+        {
+            let status = std::process::Command::new("sh")
+                .args(["-c", &format!("kill -0 {} >/dev/null 2>&1", pid)])
+                .status()?;
+            Ok(status.success())
+        }
+    }
+
+    fn shell_program_literal() -> &'static str {
+        #[cfg(target_os = "windows")]
+        {
+            "powershell"
+        }
+        #[cfg(not(target_os = "windows"))]
+        {
+            "sh"
+        }
+    }
+
+    fn shell_args_yaml(signal_path: &Path) -> String {
+        #[cfg(target_os = "windows")]
+        {
+            serde_json::to_string(&vec![
+                "-NoProfile".to_string(),
+                "-Command".to_string(),
+                format!(
+                    "Set-Content -LiteralPath '{}' -Value started; Start-Sleep -Seconds 30",
+                    signal_path.display()
+                ),
+            ])
+            .expect("serialize shell args")
+        }
+        #[cfg(not(target_os = "windows"))]
+        {
+            serde_json::to_string(&vec![
+                "-c".to_string(),
+                format!("printf started > '{}' ; sleep 30", signal_path.display()),
+            ])
+            .expect("serialize shell args")
+        }
+    }
+
+    struct MockHttpConnectorServer {
+        endpoint: String,
+        stop: Arc<AtomicBool>,
+        thread: Option<thread::JoinHandle<()>>,
+    }
+
+    impl MockHttpConnectorServer {
+        fn spawn(app_id: &str) -> Self {
+            let port = reserve_test_port();
+            Self::bind_at(app_id, port)
+        }
+
+        fn bind_at(app_id: &str, port: u16) -> Self {
+            let listener = TcpListener::bind(("127.0.0.1", port)).expect("bind connector server");
+            listener
+                .set_nonblocking(true)
+                .expect("set nonblocking listener");
+            let endpoint = format!("http://127.0.0.1:{port}");
+            let app_id = app_id.to_string();
+            let stop = Arc::new(AtomicBool::new(false));
+            let stop_flag = stop.clone();
+            let thread = thread::spawn(move || {
+                while !stop_flag.load(Ordering::SeqCst) {
+                    match listener.accept() {
+                        Ok((mut stream, _)) => {
+                            handle_http_connection(&mut stream, &app_id);
+                        }
+                        Err(err) if err.kind() == std::io::ErrorKind::WouldBlock => {
+                            thread::sleep(Duration::from_millis(10));
+                        }
+                        Err(_) => break,
+                    }
+                }
+            });
+            Self {
+                endpoint,
+                stop,
+                thread: Some(thread),
+            }
+        }
+
+        fn endpoint(&self) -> String {
+            self.endpoint.clone()
+        }
+    }
+
+    impl Drop for MockHttpConnectorServer {
+        fn drop(&mut self) {
+            self.stop.store(true, Ordering::SeqCst);
+            let _ = TcpStream::connect(self.endpoint.trim_start_matches("http://"));
+            if let Some(thread) = self.thread.take() {
+                let _ = thread.join();
+            }
+        }
+    }
+
+    fn handle_http_connection(stream: &mut TcpStream, app_id: &str) {
+        let Some((route, _payload)) = parse_http_request(stream) else {
+            return;
+        };
+        let (status, body) = match route.as_str() {
+            "/connector/info" => (
+                200,
+                json!({
+                    "connector_id": format!("mock-{app_id}"),
+                    "version": "test",
+                    "app_id": app_id,
+                    "transport": "http_bridge",
+                    "supports_snapshot": true,
+                    "supports_live": true,
+                    "supports_action": true,
+                    "optional_features": []
+                }),
+            ),
+            "/connector/health" => (
+                200,
+                json!({
+                    "healthy": true,
+                    "auth_status": "valid",
+                    "message": "ok",
+                    "checked_at": "2026-04-22T00:00:00Z"
+                }),
+            ),
+            _ => (
+                404,
+                json!({
+                    "code": "NOT_SUPPORTED",
+                    "message": format!("unknown route: {route}"),
+                    "retryable": false
+                }),
+            ),
+        };
+        write_http_json(stream, status, &body);
+    }
+
+    fn parse_http_request(stream: &mut TcpStream) -> Option<(String, serde_json::Value)> {
+        let mut buf = [0u8; 4096];
+        let read = stream.read(&mut buf).ok()?;
+        if read == 0 {
+            return None;
+        }
+        let request = String::from_utf8_lossy(&buf[..read]);
+        let header_end = request.find("\r\n\r\n")?;
+        let headers = &request[..header_end];
+        let mut lines = headers.lines();
+        let request_line = lines.next()?;
+        let route = request_line.split_whitespace().nth(1)?.to_string();
+        let content_length = lines
+            .find_map(|line| {
+                line.strip_prefix("Content-Length:")
+                    .map(str::trim)
+                    .and_then(|value| value.parse::<usize>().ok())
+            })
+            .unwrap_or(0);
+        let body_bytes = &buf[header_end + 4..read];
+        let payload = if content_length == 0 {
+            json!({})
+        } else {
+            serde_json::from_slice(body_bytes).ok()?
+        };
+        Some((route, payload))
+    }
+
+    fn write_http_json(stream: &mut TcpStream, status: u16, body: &serde_json::Value) {
+        let body_bytes = serde_json::to_vec(body).expect("encode body");
+        let response = format!(
+            "HTTP/1.1 {} OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+            status,
+            body_bytes.len()
+        );
+        stream
+            .write_all(response.as_bytes())
+            .expect("write headers");
+        stream.write_all(&body_bytes).expect("write body");
+        stream.flush().expect("flush response");
+    }
+}

--- a/cli/src/cmd/appfs/compose/loader.rs
+++ b/cli/src/cmd/appfs/compose/loader.rs
@@ -1,0 +1,141 @@
+use super::schema::{parse_compose_doc, AppfsComposeDoc};
+use anyhow::{Context, Result};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+pub(crate) const DEFAULT_COMPOSE_FILENAMES: [&str; 2] = ["appfs-compose.yaml", "appfs-compose.yml"];
+
+pub(crate) fn discover_compose_file(cwd: &Path) -> Result<PathBuf> {
+    let mut matches = DEFAULT_COMPOSE_FILENAMES
+        .iter()
+        .map(|filename| cwd.join(filename))
+        .filter(|path| path.is_file())
+        .collect::<Vec<_>>();
+
+    match matches.len() {
+        0 => anyhow::bail!(
+            "no AppFS compose file found in {}; tried {}",
+            cwd.display(),
+            DEFAULT_COMPOSE_FILENAMES.join(", ")
+        ),
+        1 => Ok(matches.remove(0)),
+        _ => anyhow::bail!(
+            "multiple AppFS compose files found in {}: {}",
+            cwd.display(),
+            matches
+                .iter()
+                .map(|path| path.display().to_string())
+                .collect::<Vec<_>>()
+                .join(", ")
+        ),
+    }
+}
+
+pub(crate) fn load_compose_doc(compose_path: Option<&Path>, cwd: &Path) -> Result<AppfsComposeDoc> {
+    let resolved_path = match compose_path {
+        Some(path) => resolve_source_path(path, cwd),
+        None => discover_compose_file(cwd)?,
+    };
+    load_compose_doc_from_path(&resolved_path)
+}
+
+pub(crate) fn load_compose_doc_from_path(path: &Path) -> Result<AppfsComposeDoc> {
+    let source_path = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        std::env::current_dir()
+            .context("failed to resolve current working directory for compose path")?
+            .join(path)
+    };
+    let yaml = fs::read_to_string(&source_path).with_context(|| {
+        format!(
+            "failed to read AppFS compose file {}",
+            source_path.display()
+        )
+    })?;
+    parse_compose_doc(&yaml, source_path)
+}
+
+fn resolve_source_path(path: &Path, cwd: &Path) -> PathBuf {
+    if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        cwd.join(path)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{discover_compose_file, load_compose_doc, DEFAULT_COMPOSE_FILENAMES};
+    use std::fs;
+    use tempfile::TempDir;
+
+    #[test]
+    fn discovers_default_compose_filename() {
+        let temp = TempDir::new().expect("tempdir");
+        let compose_path = temp.path().join(DEFAULT_COMPOSE_FILENAMES[0]);
+        fs::write(
+            &compose_path,
+            r#"
+version: 1
+runtime:
+  db: .agentfs/demo.db
+  mountpoint: ./mnt/appfs
+  backend: fuse
+"#,
+        )
+        .expect("write compose");
+
+        let discovered = discover_compose_file(temp.path()).expect("should discover compose");
+        assert_eq!(discovered, compose_path);
+    }
+
+    #[test]
+    fn rejects_ambiguous_default_compose_filenames() {
+        let temp = TempDir::new().expect("tempdir");
+        for filename in DEFAULT_COMPOSE_FILENAMES {
+            fs::write(
+                temp.path().join(filename),
+                r#"
+version: 1
+runtime:
+  db: .agentfs/demo.db
+  mountpoint: ./mnt/appfs
+  backend: fuse
+"#,
+            )
+            .expect("write compose");
+        }
+
+        let err = discover_compose_file(temp.path()).expect_err("should fail");
+        assert!(err.to_string().contains("multiple AppFS compose files"));
+    }
+
+    #[test]
+    fn load_compose_doc_resolves_explicit_relative_path_against_cwd() {
+        let temp = TempDir::new().expect("tempdir");
+        let compose_dir = temp.path().join("config");
+        fs::create_dir_all(&compose_dir).expect("create compose dir");
+        fs::write(
+            compose_dir.join("appfs-compose.yaml"),
+            r#"
+version: 1
+runtime:
+  db: ../.agentfs/demo.db
+  mountpoint: ../mnt/appfs
+  backend: fuse
+"#,
+        )
+        .expect("write compose");
+
+        let doc = load_compose_doc(
+            Some(std::path::Path::new("config/appfs-compose.yaml")),
+            temp.path(),
+        )
+        .expect("compose should load");
+
+        assert_eq!(doc.source_path, compose_dir.join("appfs-compose.yaml"));
+        assert_eq!(doc.runtime.db, temp.path().join(".agentfs/demo.db"));
+        assert_eq!(doc.runtime.mountpoint, temp.path().join("mnt/appfs"));
+    }
+}

--- a/cli/src/cmd/appfs/compose/reconcile.rs
+++ b/cli/src/cmd/appfs/compose/reconcile.rs
@@ -1,0 +1,226 @@
+use super::connector_supervisor::ResolvedComposeApp;
+use crate::cmd::appfs::normalize_appfs_session_id;
+use crate::cmd::appfs::registry;
+use anyhow::Result;
+use std::collections::{BTreeMap, HashMap};
+use std::path::Path;
+
+pub(crate) fn build_registry_doc_from_resolved_apps(
+    resolved_apps: &BTreeMap<String, ResolvedComposeApp>,
+    existing: Option<&registry::AppfsAppsRegistryDoc>,
+) -> registry::AppfsAppsRegistryDoc {
+    let existing_registered_at = existing
+        .map(|doc| {
+            doc.apps
+                .iter()
+                .map(|app| (app.app_id.clone(), app.registered_at.clone()))
+                .collect::<HashMap<_, _>>()
+        })
+        .unwrap_or_default();
+    let now = chrono::Utc::now().to_rfc3339();
+
+    registry::AppfsAppsRegistryDoc {
+        version: registry::APPFS_REGISTRY_VERSION,
+        apps: resolved_apps
+            .values()
+            .map(|app| {
+                let session_id = normalize_appfs_session_id(app.session_id.clone());
+                registry::AppfsRegisteredAppDoc {
+                    app_id: app.app_id.clone(),
+                    transport: registry_transport_from_resolved_app(app),
+                    session_id,
+                    registered_at: existing_registered_at
+                        .get(&app.app_id)
+                        .cloned()
+                        .unwrap_or_else(|| now.clone()),
+                    active_scope: None,
+                }
+            })
+            .collect(),
+    }
+}
+
+pub(crate) fn bootstrap_registry_from_resolved_apps(
+    root: &Path,
+    resolved_apps: &BTreeMap<String, ResolvedComposeApp>,
+) -> Result<registry::AppfsAppsRegistryDoc> {
+    let existing = registry::read_app_registry(root)?;
+    let doc = build_registry_doc_from_resolved_apps(resolved_apps, existing.as_ref());
+    if existing.as_ref() != Some(&doc) {
+        registry::write_app_registry(root, &doc)?;
+    }
+    Ok(doc)
+}
+
+fn registry_transport_from_resolved_app(
+    app: &ResolvedComposeApp,
+) -> registry::AppfsRegistryTransportDoc {
+    let kind = match app.transport_kind {
+        super::schema::AppfsComposeTransportKind::Http => {
+            registry::AppfsRegistryTransportKind::Http
+        }
+        super::schema::AppfsComposeTransportKind::Grpc => {
+            registry::AppfsRegistryTransportKind::Grpc
+        }
+    };
+    registry::AppfsRegistryTransportDoc {
+        kind,
+        endpoint: Some(app.endpoint.clone()),
+        http_timeout_ms: app.transport.http_timeout_ms,
+        grpc_timeout_ms: app.transport.grpc_timeout_ms,
+        bridge_max_retries: app.transport.bridge_max_retries,
+        bridge_initial_backoff_ms: app.transport.bridge_initial_backoff_ms,
+        bridge_max_backoff_ms: app.transport.bridge_max_backoff_ms,
+        bridge_circuit_breaker_failures: app.transport.bridge_circuit_breaker_failures,
+        bridge_circuit_breaker_cooldown_ms: app.transport.bridge_circuit_breaker_cooldown_ms,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{bootstrap_registry_from_resolved_apps, build_registry_doc_from_resolved_apps};
+    use crate::cmd::appfs::compose::connector_supervisor::ResolvedComposeApp;
+    use crate::cmd::appfs::compose::schema::{AppfsComposeAppTransport, AppfsComposeTransportKind};
+    use crate::cmd::appfs::{registry, resolve_runtime_cli_args};
+    use std::collections::BTreeMap;
+    use tempfile::TempDir;
+
+    fn resolved_app(
+        app_id: &str,
+        connector_name: &str,
+        transport_kind: AppfsComposeTransportKind,
+        endpoint: &str,
+        session_id: Option<&str>,
+    ) -> ResolvedComposeApp {
+        ResolvedComposeApp {
+            app_id: app_id.to_string(),
+            connector_name: connector_name.to_string(),
+            transport_kind,
+            endpoint: endpoint.to_string(),
+            session_id: session_id.map(str::to_string),
+            transport: AppfsComposeAppTransport::default(),
+        }
+    }
+
+    #[test]
+    fn build_registry_doc_from_resolved_apps_keeps_only_declared_apps() {
+        let mut resolved_apps = BTreeMap::new();
+        resolved_apps.insert(
+            "aiim".to_string(),
+            resolved_app(
+                "aiim",
+                "aiim-http",
+                AppfsComposeTransportKind::Http,
+                "http://127.0.0.1:8080",
+                Some("sess-aiim"),
+            ),
+        );
+
+        let existing = registry::AppfsAppsRegistryDoc {
+            version: registry::APPFS_REGISTRY_VERSION,
+            apps: vec![
+                registry::AppfsRegisteredAppDoc {
+                    app_id: "aiim".to_string(),
+                    transport: registry::AppfsRegistryTransportDoc {
+                        kind: registry::AppfsRegistryTransportKind::Http,
+                        endpoint: Some("http://127.0.0.1:8080".to_string()),
+                        http_timeout_ms: 5000,
+                        grpc_timeout_ms: 5000,
+                        bridge_max_retries: 2,
+                        bridge_initial_backoff_ms: 100,
+                        bridge_max_backoff_ms: 1000,
+                        bridge_circuit_breaker_failures: 5,
+                        bridge_circuit_breaker_cooldown_ms: 3000,
+                    },
+                    session_id: "sess-old".to_string(),
+                    registered_at: "2026-04-01T00:00:00Z".to_string(),
+                    active_scope: Some("chat-001".to_string()),
+                },
+                registry::AppfsRegisteredAppDoc {
+                    app_id: "stale".to_string(),
+                    transport: registry::AppfsRegistryTransportDoc {
+                        kind: registry::AppfsRegistryTransportKind::Grpc,
+                        endpoint: Some("http://127.0.0.1:50051".to_string()),
+                        http_timeout_ms: 5000,
+                        grpc_timeout_ms: 5000,
+                        bridge_max_retries: 2,
+                        bridge_initial_backoff_ms: 100,
+                        bridge_max_backoff_ms: 1000,
+                        bridge_circuit_breaker_failures: 5,
+                        bridge_circuit_breaker_cooldown_ms: 3000,
+                    },
+                    session_id: "sess-stale".to_string(),
+                    registered_at: "2026-04-02T00:00:00Z".to_string(),
+                    active_scope: Some("stale-scope".to_string()),
+                },
+            ],
+        };
+
+        let doc = build_registry_doc_from_resolved_apps(&resolved_apps, Some(&existing));
+
+        assert_eq!(doc.apps.len(), 1);
+        assert_eq!(doc.apps[0].app_id, "aiim");
+        assert_eq!(doc.apps[0].session_id, "sess-aiim");
+        assert_eq!(doc.apps[0].registered_at, "2026-04-01T00:00:00Z");
+        assert_eq!(doc.apps[0].active_scope, None);
+    }
+
+    #[test]
+    fn bootstrap_registry_from_resolved_apps_round_trips_into_runtime_args() {
+        let temp = TempDir::new().expect("tempdir");
+        let mut resolved_apps = BTreeMap::new();
+        resolved_apps.insert(
+            "aiim".to_string(),
+            resolved_app(
+                "aiim",
+                "aiim-http",
+                AppfsComposeTransportKind::Http,
+                "http://127.0.0.1:8080",
+                None,
+            ),
+        );
+        resolved_apps.insert(
+            "huoyan".to_string(),
+            resolved_app(
+                "huoyan",
+                "huoyan-grpc",
+                AppfsComposeTransportKind::Grpc,
+                "http://127.0.0.1:50051",
+                Some("sess-huoyan"),
+            ),
+        );
+
+        let stored =
+            bootstrap_registry_from_resolved_apps(temp.path(), &resolved_apps).expect("bootstrap");
+        assert_eq!(stored.apps.len(), 2);
+        assert_eq!(
+            stored
+                .apps
+                .iter()
+                .map(|app| app.app_id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["aiim", "huoyan"]
+        );
+
+        let runtime_args =
+            registry::runtime_args_from_registry(&stored).expect("runtime args from registry");
+        let resolved_runtime_args = resolve_runtime_cli_args(runtime_args);
+        assert_eq!(resolved_runtime_args.len(), 2);
+        assert_eq!(resolved_runtime_args[0].app_id, "aiim");
+        assert_eq!(
+            resolved_runtime_args[0]
+                .bridge
+                .adapter_http_endpoint
+                .as_deref(),
+            Some("http://127.0.0.1:8080")
+        );
+        assert_eq!(resolved_runtime_args[1].app_id, "huoyan");
+        assert_eq!(
+            resolved_runtime_args[1]
+                .bridge
+                .adapter_grpc_endpoint
+                .as_deref(),
+            Some("http://127.0.0.1:50051")
+        );
+    }
+}

--- a/cli/src/cmd/appfs/compose/schema.rs
+++ b/cli/src/cmd/appfs/compose/schema.rs
@@ -1,0 +1,928 @@
+use crate::cmd::mount::MountBackend;
+use anyhow::{Context, Result};
+use serde::Deserialize;
+use std::collections::BTreeMap;
+use std::ffi::OsString;
+use std::path::{Path, PathBuf};
+
+const COMPOSE_VERSION: u32 = 1;
+const DEFAULT_HTTP_TIMEOUT_MS: u64 = 5_000;
+const DEFAULT_GRPC_TIMEOUT_MS: u64 = 5_000;
+const DEFAULT_BRIDGE_MAX_RETRIES: u32 = 2;
+const DEFAULT_BRIDGE_INITIAL_BACKOFF_MS: u64 = 100;
+const DEFAULT_BRIDGE_MAX_BACKOFF_MS: u64 = 1_000;
+const DEFAULT_BRIDGE_CIRCUIT_BREAKER_FAILURES: u32 = 5;
+const DEFAULT_BRIDGE_CIRCUIT_BREAKER_COOLDOWN_MS: u64 = 3_000;
+const DEFAULT_HEALTHCHECK_INTERVAL_MS: u64 = 1_000;
+const DEFAULT_HEALTHCHECK_TIMEOUT_MS: u64 = 3_000;
+const DEFAULT_HEALTHCHECK_MAX_ATTEMPTS: u32 = 20;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct AppfsComposeDoc {
+    pub(crate) source_path: PathBuf,
+    pub(crate) base_dir: PathBuf,
+    pub(crate) version: u32,
+    pub(crate) name: Option<String>,
+    pub(crate) runtime: AppfsComposeRuntime,
+    pub(crate) connectors: BTreeMap<String, AppfsComposeConnector>,
+    pub(crate) apps: BTreeMap<String, AppfsComposeApp>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct AppfsComposeRuntime {
+    pub(crate) db: PathBuf,
+    pub(crate) mountpoint: PathBuf,
+    pub(crate) backend: MountBackend,
+    pub(crate) init: AppfsComposeInitMode,
+    pub(crate) reset: bool,
+    pub(crate) auto_unmount: bool,
+    pub(crate) allow_root: bool,
+    pub(crate) allow_other: bool,
+    pub(crate) uid: Option<u32>,
+    pub(crate) gid: Option<u32>,
+    pub(crate) poll_ms: u64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum AppfsComposeInitMode {
+    IfMissing,
+    Always,
+    Never,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct AppfsComposeConnector {
+    pub(crate) mode: AppfsComposeConnectorMode,
+    pub(crate) transport: AppfsComposeTransportKind,
+    pub(crate) endpoint: String,
+    pub(crate) healthcheck: Option<AppfsComposeConnectorHealthcheck>,
+    pub(crate) command: Option<AppfsComposeCommand>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum AppfsComposeConnectorMode {
+    External,
+    Command,
+    ExternalOrCommand,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum AppfsComposeTransportKind {
+    Http,
+    Grpc,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct AppfsComposeConnectorHealthcheck {
+    pub(crate) kind: AppfsComposeHealthcheckKind,
+    pub(crate) interval_ms: u64,
+    pub(crate) timeout_ms: u64,
+    pub(crate) max_attempts: u32,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum AppfsComposeHealthcheckKind {
+    Connector,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct AppfsComposeCommand {
+    pub(crate) cwd: PathBuf,
+    pub(crate) program: PathBuf,
+    pub(crate) args: Vec<String>,
+    pub(crate) env: BTreeMap<String, String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct AppfsComposeApp {
+    pub(crate) connector: String,
+    pub(crate) session_id: Option<String>,
+    pub(crate) transport: AppfsComposeAppTransport,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct AppfsComposeAppTransport {
+    pub(crate) http_timeout_ms: u64,
+    pub(crate) grpc_timeout_ms: u64,
+    pub(crate) bridge_max_retries: u32,
+    pub(crate) bridge_initial_backoff_ms: u64,
+    pub(crate) bridge_max_backoff_ms: u64,
+    pub(crate) bridge_circuit_breaker_failures: u32,
+    pub(crate) bridge_circuit_breaker_cooldown_ms: u64,
+}
+
+impl Default for AppfsComposeAppTransport {
+    fn default() -> Self {
+        Self {
+            http_timeout_ms: DEFAULT_HTTP_TIMEOUT_MS,
+            grpc_timeout_ms: DEFAULT_GRPC_TIMEOUT_MS,
+            bridge_max_retries: DEFAULT_BRIDGE_MAX_RETRIES,
+            bridge_initial_backoff_ms: DEFAULT_BRIDGE_INITIAL_BACKOFF_MS,
+            bridge_max_backoff_ms: DEFAULT_BRIDGE_MAX_BACKOFF_MS,
+            bridge_circuit_breaker_failures: DEFAULT_BRIDGE_CIRCUIT_BREAKER_FAILURES,
+            bridge_circuit_breaker_cooldown_ms: DEFAULT_BRIDGE_CIRCUIT_BREAKER_COOLDOWN_MS,
+        }
+    }
+}
+
+pub(crate) fn parse_compose_doc(yaml: &str, source_path: PathBuf) -> Result<AppfsComposeDoc> {
+    let raw: RawAppfsComposeDoc =
+        serde_yaml::from_str(yaml).context("failed to parse AppFS compose YAML")?;
+    normalize_compose_doc(raw, source_path)
+}
+
+fn normalize_compose_doc(raw: RawAppfsComposeDoc, source_path: PathBuf) -> Result<AppfsComposeDoc> {
+    if raw.version != COMPOSE_VERSION {
+        anyhow::bail!(
+            "unsupported AppFS compose version {} (expected {})",
+            raw.version,
+            COMPOSE_VERSION
+        );
+    }
+
+    let base_dir = source_path.parent().ok_or_else(|| {
+        anyhow::anyhow!(
+            "compose source path {} does not have a parent directory",
+            source_path.display()
+        )
+    })?;
+    let base_dir = base_dir.to_path_buf();
+
+    let runtime = normalize_runtime(raw.runtime, &base_dir)?;
+    let connectors = normalize_connectors(raw.connectors, &base_dir)?;
+    let apps = normalize_apps(raw.apps, &connectors)?;
+    let name = normalize_optional_string(raw.name, "compose name")?;
+
+    Ok(AppfsComposeDoc {
+        source_path,
+        base_dir,
+        version: COMPOSE_VERSION,
+        name,
+        runtime,
+        connectors,
+        apps,
+    })
+}
+
+fn normalize_runtime(raw: RawAppfsComposeRuntime, base_dir: &Path) -> Result<AppfsComposeRuntime> {
+    Ok(AppfsComposeRuntime {
+        db: normalize_required_path(raw.db, base_dir, "runtime.db")?,
+        mountpoint: normalize_required_path(raw.mountpoint, base_dir, "runtime.mountpoint")?,
+        backend: normalize_backend(raw.backend)?,
+        init: normalize_init_mode(raw.init)?,
+        reset: raw.reset,
+        auto_unmount: raw.auto_unmount,
+        allow_root: raw.allow_root,
+        allow_other: raw.system,
+        uid: raw.uid,
+        gid: raw.gid,
+        poll_ms: raw.poll_ms,
+    })
+}
+
+fn normalize_connectors(
+    raw_connectors: BTreeMap<String, RawAppfsComposeConnector>,
+    base_dir: &Path,
+) -> Result<BTreeMap<String, AppfsComposeConnector>> {
+    let mut connectors = BTreeMap::new();
+    for (raw_name, raw_connector) in raw_connectors {
+        let name = normalize_map_key(&raw_name, "connector")?;
+        if connectors.contains_key(&name) {
+            anyhow::bail!("duplicate compose connector {}", name);
+        }
+        let connector = normalize_connector(&name, raw_connector, base_dir)?;
+        connectors.insert(name, connector);
+    }
+    Ok(connectors)
+}
+
+fn normalize_connector(
+    connector_name: &str,
+    raw: RawAppfsComposeConnector,
+    base_dir: &Path,
+) -> Result<AppfsComposeConnector> {
+    let mode = normalize_connector_mode(raw.mode)?;
+    let transport = normalize_transport_kind(raw.transport)?;
+    let endpoint = normalize_required_string(
+        raw.endpoint,
+        &format!("connectors.{connector_name}.endpoint"),
+    )?;
+
+    let command = raw
+        .command
+        .map(|command| normalize_command(connector_name, command, base_dir))
+        .transpose()?;
+    match mode {
+        AppfsComposeConnectorMode::External => {
+            if command.is_some() {
+                anyhow::bail!(
+                    "compose connector {} in external mode cannot define command",
+                    connector_name
+                );
+            }
+        }
+        AppfsComposeConnectorMode::Command | AppfsComposeConnectorMode::ExternalOrCommand => {
+            if command.is_none() {
+                anyhow::bail!(
+                    "compose connector {} in {} mode requires command",
+                    connector_name,
+                    connector_mode_label(mode)
+                );
+            }
+        }
+    }
+    let healthcheck = raw
+        .healthcheck
+        .map(|healthcheck| normalize_healthcheck(connector_name, healthcheck))
+        .transpose()?;
+
+    match transport {
+        AppfsComposeTransportKind::Http | AppfsComposeTransportKind::Grpc => {}
+    }
+
+    Ok(AppfsComposeConnector {
+        mode,
+        transport,
+        endpoint,
+        healthcheck,
+        command,
+    })
+}
+
+fn normalize_command(
+    connector_name: &str,
+    raw: RawAppfsComposeCommand,
+    base_dir: &Path,
+) -> Result<AppfsComposeCommand> {
+    let cwd = match raw.cwd {
+        Some(path) => normalize_required_path(
+            path,
+            base_dir,
+            &format!("connectors.{connector_name}.command.cwd"),
+        )?,
+        None => base_dir.to_path_buf(),
+    };
+    let program = raw.program.ok_or_else(|| {
+        anyhow::anyhow!(
+            "compose connector {} command.program is required",
+            connector_name
+        )
+    })?;
+    if program.as_os_str().is_empty() {
+        anyhow::bail!(
+            "compose connector {} command.program cannot be empty",
+            connector_name
+        );
+    }
+    let env = normalize_env_map(connector_name, raw.env)?;
+
+    Ok(AppfsComposeCommand {
+        cwd,
+        program,
+        args: raw.args,
+        env,
+    })
+}
+
+fn normalize_env_map(
+    connector_name: &str,
+    raw_env: BTreeMap<String, String>,
+) -> Result<BTreeMap<String, String>> {
+    let mut env = BTreeMap::new();
+    for (raw_key, raw_value) in raw_env {
+        let key = normalize_map_key(
+            &raw_key,
+            &format!("connectors.{connector_name}.command.env"),
+        )?;
+        if raw_value.trim().is_empty() {
+            anyhow::bail!(
+                "compose connector {} command.env.{} cannot be empty",
+                connector_name,
+                key
+            );
+        }
+        env.insert(key, raw_value);
+    }
+    Ok(env)
+}
+
+fn normalize_healthcheck(
+    connector_name: &str,
+    raw: RawAppfsComposeHealthcheck,
+) -> Result<AppfsComposeConnectorHealthcheck> {
+    let kind = normalize_healthcheck_kind(raw.kind)?;
+    let interval_ms = raw.interval_ms.unwrap_or(DEFAULT_HEALTHCHECK_INTERVAL_MS);
+    let timeout_ms = raw.timeout_ms.unwrap_or(DEFAULT_HEALTHCHECK_TIMEOUT_MS);
+    let max_attempts = raw.max_attempts.unwrap_or(DEFAULT_HEALTHCHECK_MAX_ATTEMPTS);
+    if interval_ms == 0 {
+        anyhow::bail!(
+            "compose connector {} healthcheck.interval_ms must be > 0",
+            connector_name
+        );
+    }
+    if timeout_ms == 0 {
+        anyhow::bail!(
+            "compose connector {} healthcheck.timeout_ms must be > 0",
+            connector_name
+        );
+    }
+    if max_attempts == 0 {
+        anyhow::bail!(
+            "compose connector {} healthcheck.max_attempts must be > 0",
+            connector_name
+        );
+    }
+    Ok(AppfsComposeConnectorHealthcheck {
+        kind,
+        interval_ms,
+        timeout_ms,
+        max_attempts,
+    })
+}
+
+fn normalize_apps(
+    raw_apps: BTreeMap<String, RawAppfsComposeApp>,
+    connectors: &BTreeMap<String, AppfsComposeConnector>,
+) -> Result<BTreeMap<String, AppfsComposeApp>> {
+    let mut apps = BTreeMap::new();
+    let mut connector_usage = BTreeMap::<String, Vec<String>>::new();
+    for (raw_app_id, raw_app) in raw_apps {
+        let app_id = normalize_map_key(&raw_app_id, "app")?;
+        if apps.contains_key(&app_id) {
+            anyhow::bail!("duplicate compose app {}", app_id);
+        }
+        let connector = normalize_required_string(
+            Some(raw_app.connector),
+            &format!("apps.{app_id}.connector"),
+        )?;
+        if !connectors.contains_key(&connector) {
+            anyhow::bail!(
+                "compose app {} references unknown connector {}",
+                app_id,
+                connector
+            );
+        }
+        let session_id =
+            normalize_optional_string(raw_app.session_id, &format!("apps.{app_id}.session_id"))?;
+        connector_usage
+            .entry(connector.clone())
+            .or_default()
+            .push(app_id.clone());
+        apps.insert(
+            app_id,
+            AppfsComposeApp {
+                connector,
+                session_id,
+                transport: normalize_app_transport(raw_app.transport),
+            },
+        );
+    }
+    for (connector, app_ids) in connector_usage {
+        if app_ids.len() > 1 {
+            anyhow::bail!(
+                "compose connector {} is referenced by multiple apps ({}) but v1 requires one connector per app",
+                connector,
+                app_ids.join(", ")
+            );
+        }
+    }
+    Ok(apps)
+}
+
+fn normalize_app_transport(raw: RawAppfsComposeAppTransport) -> AppfsComposeAppTransport {
+    AppfsComposeAppTransport {
+        http_timeout_ms: raw.http_timeout_ms.unwrap_or(DEFAULT_HTTP_TIMEOUT_MS),
+        grpc_timeout_ms: raw.grpc_timeout_ms.unwrap_or(DEFAULT_GRPC_TIMEOUT_MS),
+        bridge_max_retries: raw.bridge_max_retries.unwrap_or(DEFAULT_BRIDGE_MAX_RETRIES),
+        bridge_initial_backoff_ms: raw
+            .bridge_initial_backoff_ms
+            .unwrap_or(DEFAULT_BRIDGE_INITIAL_BACKOFF_MS),
+        bridge_max_backoff_ms: raw
+            .bridge_max_backoff_ms
+            .unwrap_or(DEFAULT_BRIDGE_MAX_BACKOFF_MS),
+        bridge_circuit_breaker_failures: raw
+            .bridge_circuit_breaker_failures
+            .unwrap_or(DEFAULT_BRIDGE_CIRCUIT_BREAKER_FAILURES),
+        bridge_circuit_breaker_cooldown_ms: raw
+            .bridge_circuit_breaker_cooldown_ms
+            .unwrap_or(DEFAULT_BRIDGE_CIRCUIT_BREAKER_COOLDOWN_MS),
+    }
+}
+
+fn normalize_required_path(raw: PathBuf, base_dir: &Path, field_name: &str) -> Result<PathBuf> {
+    if raw.as_os_str().is_empty() {
+        anyhow::bail!("{field_name} cannot be empty");
+    }
+    let path = if raw.is_absolute() {
+        raw
+    } else {
+        base_dir.join(raw)
+    };
+    Ok(lexically_normalize_path(path))
+}
+
+fn normalize_required_string(raw: Option<String>, field_name: &str) -> Result<String> {
+    let value = raw.ok_or_else(|| anyhow::anyhow!("{field_name} is required"))?;
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        anyhow::bail!("{field_name} cannot be empty");
+    }
+    if trimmed != value {
+        anyhow::bail!("{field_name} cannot contain leading or trailing whitespace");
+    }
+    Ok(value)
+}
+
+fn normalize_optional_string(
+    raw: Option<String>,
+    field_name: impl AsRef<str>,
+) -> Result<Option<String>> {
+    match raw {
+        Some(value) => Ok(Some(normalize_required_string(
+            Some(value),
+            field_name.as_ref(),
+        )?)),
+        None => Ok(None),
+    }
+}
+
+fn normalize_map_key(raw: &str, entity_name: &str) -> Result<String> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        anyhow::bail!("compose {entity_name} key cannot be empty");
+    }
+    if trimmed != raw {
+        anyhow::bail!(
+            "compose {entity_name} key {:?} cannot contain leading or trailing whitespace",
+            raw
+        );
+    }
+    Ok(raw.to_string())
+}
+
+fn lexically_normalize_path(path: PathBuf) -> PathBuf {
+    let mut prefix: Option<OsString> = None;
+    let mut has_root = false;
+    let mut segments: Vec<OsString> = Vec::new();
+
+    for component in path.components() {
+        match component {
+            std::path::Component::Prefix(value) => {
+                prefix = Some(value.as_os_str().to_os_string());
+            }
+            std::path::Component::RootDir => {
+                has_root = true;
+                segments.clear();
+            }
+            std::path::Component::CurDir => {}
+            std::path::Component::ParentDir => {
+                if matches!(segments.last(), Some(last) if last != "..") {
+                    segments.pop();
+                } else if !has_root {
+                    segments.push(OsString::from(".."));
+                }
+            }
+            std::path::Component::Normal(value) => segments.push(value.to_os_string()),
+        }
+    }
+
+    let mut normalized = match prefix {
+        Some(prefix) => PathBuf::from(prefix),
+        None => PathBuf::new(),
+    };
+    if has_root {
+        normalized.push(Path::new(std::path::MAIN_SEPARATOR_STR));
+    }
+    for segment in segments {
+        normalized.push(segment);
+    }
+    normalized
+}
+
+fn normalize_backend(raw: RawMountBackend) -> Result<MountBackend> {
+    Ok(match raw {
+        RawMountBackend::Fuse => MountBackend::Fuse,
+        RawMountBackend::Nfs => MountBackend::Nfs,
+        RawMountBackend::Winfsp => MountBackend::Winfsp,
+    })
+}
+
+fn normalize_init_mode(raw: RawAppfsComposeInitMode) -> Result<AppfsComposeInitMode> {
+    Ok(match raw {
+        RawAppfsComposeInitMode::IfMissing => AppfsComposeInitMode::IfMissing,
+        RawAppfsComposeInitMode::Always => AppfsComposeInitMode::Always,
+        RawAppfsComposeInitMode::Never => AppfsComposeInitMode::Never,
+    })
+}
+
+fn normalize_connector_mode(
+    raw: RawAppfsComposeConnectorMode,
+) -> Result<AppfsComposeConnectorMode> {
+    Ok(match raw {
+        RawAppfsComposeConnectorMode::External => AppfsComposeConnectorMode::External,
+        RawAppfsComposeConnectorMode::Command => AppfsComposeConnectorMode::Command,
+        RawAppfsComposeConnectorMode::ExternalOrCommand => {
+            AppfsComposeConnectorMode::ExternalOrCommand
+        }
+    })
+}
+
+fn connector_mode_label(mode: AppfsComposeConnectorMode) -> &'static str {
+    match mode {
+        AppfsComposeConnectorMode::External => "external",
+        AppfsComposeConnectorMode::Command => "command",
+        AppfsComposeConnectorMode::ExternalOrCommand => "external_or_command",
+    }
+}
+
+fn normalize_transport_kind(
+    raw: RawAppfsComposeTransportKind,
+) -> Result<AppfsComposeTransportKind> {
+    Ok(match raw {
+        RawAppfsComposeTransportKind::Http => AppfsComposeTransportKind::Http,
+        RawAppfsComposeTransportKind::Grpc => AppfsComposeTransportKind::Grpc,
+    })
+}
+
+fn normalize_healthcheck_kind(
+    raw: Option<RawAppfsComposeHealthcheckKind>,
+) -> Result<AppfsComposeHealthcheckKind> {
+    Ok(
+        match raw.unwrap_or(RawAppfsComposeHealthcheckKind::Connector) {
+            RawAppfsComposeHealthcheckKind::Connector => AppfsComposeHealthcheckKind::Connector,
+        },
+    )
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RawAppfsComposeDoc {
+    version: u32,
+    #[serde(default)]
+    name: Option<String>,
+    runtime: RawAppfsComposeRuntime,
+    #[serde(default)]
+    connectors: BTreeMap<String, RawAppfsComposeConnector>,
+    #[serde(default)]
+    apps: BTreeMap<String, RawAppfsComposeApp>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RawAppfsComposeRuntime {
+    db: PathBuf,
+    mountpoint: PathBuf,
+    backend: RawMountBackend,
+    #[serde(default)]
+    init: RawAppfsComposeInitMode,
+    #[serde(default)]
+    reset: bool,
+    #[serde(default = "default_true")]
+    auto_unmount: bool,
+    #[serde(default)]
+    allow_root: bool,
+    #[serde(default)]
+    system: bool,
+    #[serde(default)]
+    uid: Option<u32>,
+    #[serde(default)]
+    gid: Option<u32>,
+    #[serde(default)]
+    poll_ms: u64,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum RawMountBackend {
+    Fuse,
+    Nfs,
+    Winfsp,
+}
+
+#[derive(Debug, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+enum RawAppfsComposeInitMode {
+    #[default]
+    IfMissing,
+    Always,
+    Never,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RawAppfsComposeConnector {
+    mode: RawAppfsComposeConnectorMode,
+    transport: RawAppfsComposeTransportKind,
+    endpoint: Option<String>,
+    #[serde(default)]
+    healthcheck: Option<RawAppfsComposeHealthcheck>,
+    #[serde(default)]
+    command: Option<RawAppfsComposeCommand>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum RawAppfsComposeConnectorMode {
+    External,
+    Command,
+    ExternalOrCommand,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum RawAppfsComposeTransportKind {
+    Http,
+    Grpc,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RawAppfsComposeHealthcheck {
+    #[serde(default)]
+    kind: Option<RawAppfsComposeHealthcheckKind>,
+    #[serde(default)]
+    interval_ms: Option<u64>,
+    #[serde(default)]
+    timeout_ms: Option<u64>,
+    #[serde(default)]
+    max_attempts: Option<u32>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum RawAppfsComposeHealthcheckKind {
+    Connector,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RawAppfsComposeCommand {
+    #[serde(default)]
+    cwd: Option<PathBuf>,
+    program: Option<PathBuf>,
+    #[serde(default)]
+    args: Vec<String>,
+    #[serde(default)]
+    env: BTreeMap<String, String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RawAppfsComposeApp {
+    connector: String,
+    #[serde(default)]
+    session_id: Option<String>,
+    #[serde(default)]
+    transport: RawAppfsComposeAppTransport,
+}
+
+#[derive(Debug, Deserialize, Default)]
+#[serde(deny_unknown_fields)]
+struct RawAppfsComposeAppTransport {
+    #[serde(default)]
+    http_timeout_ms: Option<u64>,
+    #[serde(default)]
+    grpc_timeout_ms: Option<u64>,
+    #[serde(default)]
+    bridge_max_retries: Option<u32>,
+    #[serde(default)]
+    bridge_initial_backoff_ms: Option<u64>,
+    #[serde(default)]
+    bridge_max_backoff_ms: Option<u64>,
+    #[serde(default)]
+    bridge_circuit_breaker_failures: Option<u32>,
+    #[serde(default)]
+    bridge_circuit_breaker_cooldown_ms: Option<u64>,
+}
+
+const fn default_true() -> bool {
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        parse_compose_doc, AppfsComposeConnectorMode, AppfsComposeInitMode,
+        AppfsComposeTransportKind,
+    };
+    use std::path::PathBuf;
+
+    #[test]
+    fn parses_and_normalizes_relative_compose_paths() {
+        let source_path = if cfg!(windows) {
+            PathBuf::from(r"C:\work\agentfs\appfs-compose.yaml")
+        } else {
+            PathBuf::from("/work/agentfs/appfs-compose.yaml")
+        };
+        let doc = parse_compose_doc(
+            r#"
+version: 1
+name: local-demo
+runtime:
+  db: .agentfs/demo.db
+  mountpoint: ./mnt/appfs
+  backend: winfsp
+connectors:
+  demo-http:
+    mode: external_or_command
+    transport: http
+    endpoint: http://127.0.0.1:8080
+    command:
+      cwd: ./examples/appfs/bridges/http-python
+      program: uv
+      args: ["run", "python", "bridge_server.py"]
+      env:
+        APPFS_HTTP_BRIDGE_BACKEND: aiim
+apps:
+  aiim:
+    connector: demo-http
+"#,
+            source_path,
+        )
+        .expect("compose should parse");
+
+        assert_eq!(doc.version, 1);
+        assert_eq!(doc.name.as_deref(), Some("local-demo"));
+        let connector = doc.connectors.get("demo-http").expect("connector");
+        if cfg!(windows) {
+            assert_eq!(
+                doc.runtime.db,
+                PathBuf::from(r"C:\work\agentfs\.agentfs\demo.db")
+            );
+            assert_eq!(
+                doc.runtime.mountpoint,
+                PathBuf::from(r"C:\work\agentfs\mnt\appfs")
+            );
+            assert_eq!(
+                connector.command.as_ref().expect("command").cwd,
+                PathBuf::from(r"C:\work\agentfs\examples\appfs\bridges\http-python")
+            );
+        } else {
+            assert_eq!(
+                doc.runtime.db,
+                PathBuf::from("/work/agentfs/.agentfs/demo.db")
+            );
+            assert_eq!(
+                doc.runtime.mountpoint,
+                PathBuf::from("/work/agentfs/mnt/appfs")
+            );
+            assert_eq!(
+                connector.command.as_ref().expect("command").cwd,
+                PathBuf::from("/work/agentfs/examples/appfs/bridges/http-python")
+            );
+        }
+        assert_eq!(doc.runtime.init, AppfsComposeInitMode::IfMissing);
+        assert!(doc.runtime.auto_unmount);
+        assert_eq!(connector.mode, AppfsComposeConnectorMode::ExternalOrCommand);
+        assert_eq!(connector.transport, AppfsComposeTransportKind::Http);
+        assert_eq!(connector.endpoint, "http://127.0.0.1:8080");
+        assert_eq!(
+            doc.apps.get("aiim").expect("app").transport.http_timeout_ms,
+            5000
+        );
+    }
+
+    #[test]
+    fn rejects_unknown_connector_reference() {
+        let err = parse_compose_doc(
+            r#"
+version: 1
+runtime:
+  db: .agentfs/demo.db
+  mountpoint: ./mnt/appfs
+  backend: fuse
+apps:
+  aiim:
+    connector: missing
+"#,
+            PathBuf::from("/tmp/appfs-compose.yaml"),
+        )
+        .expect_err("compose should fail");
+
+        assert!(err.to_string().contains("unknown connector"));
+    }
+
+    #[test]
+    fn rejects_missing_command_for_command_mode() {
+        let err = parse_compose_doc(
+            r#"
+version: 1
+runtime:
+  db: .agentfs/demo.db
+  mountpoint: ./mnt/appfs
+  backend: fuse
+connectors:
+  demo-http:
+    mode: command
+    transport: http
+    endpoint: http://127.0.0.1:8080
+"#,
+            PathBuf::from("/tmp/appfs-compose.yaml"),
+        )
+        .expect_err("compose should fail");
+
+        assert!(err.to_string().contains("requires command"));
+    }
+
+    #[test]
+    fn rejects_missing_endpoint_for_command_mode() {
+        let err = parse_compose_doc(
+            r#"
+version: 1
+runtime:
+  db: .agentfs/demo.db
+  mountpoint: ./mnt/appfs
+  backend: fuse
+connectors:
+  demo-http:
+    mode: command
+    transport: http
+    command:
+      program: uv
+"#,
+            PathBuf::from("/tmp/appfs-compose.yaml"),
+        )
+        .expect_err("compose should fail");
+
+        assert!(err.to_string().contains("endpoint is required"));
+    }
+
+    #[test]
+    fn rejects_unknown_fields() {
+        let err = parse_compose_doc(
+            r#"
+version: 1
+runtime:
+  db: .agentfs/demo.db
+  mountpoint: ./mnt/appfs
+  backend: fuse
+  typo: true
+"#,
+            PathBuf::from("/tmp/appfs-compose.yaml"),
+        )
+        .expect_err("compose should fail");
+
+        assert!(format!("{err:#}").contains("unknown field"));
+    }
+
+    #[test]
+    fn rejects_multiple_apps_sharing_one_connector() {
+        let err = parse_compose_doc(
+            r#"
+version: 1
+runtime:
+  db: .agentfs/demo.db
+  mountpoint: ./mnt/appfs
+  backend: fuse
+connectors:
+  shared-http:
+    mode: external
+    transport: http
+    endpoint: http://127.0.0.1:8080
+apps:
+  aiim:
+    connector: shared-http
+  huoyan:
+    connector: shared-http
+"#,
+            PathBuf::from("/tmp/appfs-compose.yaml"),
+        )
+        .expect_err("compose should fail");
+
+        assert!(err.to_string().contains("requires one connector per app"));
+    }
+
+    #[test]
+    fn preserves_absolute_runtime_mountpoint() {
+        let yaml = if cfg!(windows) {
+            r#"
+version: 1
+runtime:
+  db: .agentfs/demo.db
+  mountpoint: C:\mnt\appfs
+  backend: winfsp
+"#
+        } else {
+            r#"
+version: 1
+runtime:
+  db: .agentfs/demo.db
+  mountpoint: /tmp/appfs
+  backend: fuse
+"#
+        };
+        let source_path = if cfg!(windows) {
+            PathBuf::from(r"C:\work\agentfs\appfs-compose.yaml")
+        } else {
+            PathBuf::from("/work/agentfs/appfs-compose.yaml")
+        };
+
+        let doc = parse_compose_doc(yaml, source_path).expect("compose should parse");
+
+        if cfg!(windows) {
+            assert_eq!(doc.runtime.mountpoint, PathBuf::from(r"C:\mnt\appfs"));
+        } else {
+            assert_eq!(doc.runtime.mountpoint, PathBuf::from("/tmp/appfs"));
+        }
+    }
+}

--- a/cli/src/cmd/appfs/compose/schema.rs
+++ b/cli/src/cmd/appfs/compose/schema.rs
@@ -363,7 +363,7 @@ fn normalize_apps(
             );
         }
         let session_id =
-            normalize_optional_string(raw_app.session_id, &format!("apps.{app_id}.session_id"))?;
+            normalize_optional_string(raw_app.session_id, format!("apps.{app_id}.session_id"))?;
         connector_usage
             .entry(connector.clone())
             .or_default()

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,7 +1,10 @@
 use agentfs::{
     cmd::{self, completions::handle_completions},
     get_runtime,
-    opts::{AppfsCommand, Args, Command, FsCommand, PruneCommand, ServeCommand, SyncCommand},
+    opts::{
+        AppfsCommand, AppfsComposeCommand, Args, Command, FsCommand, PruneCommand, ServeCommand,
+        SyncCommand,
+    },
 };
 use clap::{CommandFactory, Parser};
 use clap_complete::CompleteEnv;
@@ -500,6 +503,15 @@ fn main() {
                     std::process::exit(1);
                 }
             }
+            AppfsCommand::Compose { command } => match command {
+                AppfsComposeCommand::Up { file } => {
+                    let rt = get_runtime();
+                    if let Err(e) = rt.block_on(cmd::appfs::handle_appfs_compose_up_command(file)) {
+                        eprintln!("Error: {}", e);
+                        std::process::exit(1);
+                    }
+                }
+            },
         },
         Command::Ps => {
             if let Err(e) = cmd::ps::list_ps(&mut std::io::stdout()) {

--- a/cli/src/opts.rs
+++ b/cli/src/opts.rs
@@ -7,7 +7,7 @@ use clap_complete::{
 use std::path::{Path, PathBuf};
 
 /// Mount backend type
-#[derive(Debug, Clone, Copy, clap::ValueEnum)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
 pub enum MountBackend {
     /// FUSE filesystem (Linux only)
     Fuse,
@@ -682,6 +682,27 @@ pub enum AppfsCommand {
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
         agent_args: Vec<String>,
     },
+    /// Start AppFS from a declarative compose file
+    Compose {
+        #[command(subcommand)]
+        command: AppfsComposeCommand,
+    },
+}
+
+#[derive(Subcommand, Debug)]
+pub enum AppfsComposeCommand {
+    /// Start AppFS from `appfs-compose.yaml`
+    Up {
+        /// Optional compose file path.
+        /// Defaults to appfs-compose.yaml / appfs-compose.yml in the current directory.
+        #[arg(
+            short = 'f',
+            long = "file",
+            value_name = "FILE",
+            add = ArgValueCompleter::new(PathCompleter::file())
+        )]
+        file: Option<PathBuf>,
+    },
 }
 
 #[derive(Subcommand, Debug)]
@@ -762,7 +783,7 @@ fn id_or_path_completer(current: &std::ffi::OsStr) -> Vec<CompletionCandidate> {
 
 #[cfg(test)]
 mod tests {
-    use super::{AppfsCommand, Args, Command, MountBackend};
+    use super::{AppfsCommand, AppfsComposeCommand, Args, Command, MountBackend};
     use clap::Parser;
     use std::path::PathBuf;
 
@@ -807,6 +828,30 @@ mod tests {
                 assert_eq!(poll_ms, 150);
             }
             other => panic!("unexpected command shape: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parses_appfs_compose_up_command() {
+        let args = Args::parse_from([
+            "agentfs",
+            "appfs",
+            "compose",
+            "up",
+            "-f",
+            "appfs-compose.yaml",
+        ]);
+
+        match args.command {
+            Command::Appfs {
+                command:
+                    AppfsCommand::Compose {
+                        command: AppfsComposeCommand::Up { file },
+                    },
+            } => {
+                assert_eq!(file, Some(PathBuf::from("appfs-compose.yaml")));
+            }
+            _ => panic!("expected appfs compose up command"),
         }
     }
 

--- a/docs/plans/2026-04-22-appfs-compose-up-design.md
+++ b/docs/plans/2026-04-22-appfs-compose-up-design.md
@@ -1,0 +1,459 @@
+# AppFS Compose Up Design
+
+**Date:** 2026-04-22  
+**Status:** Frozen (CP1, 2026-04-22)  
+**Scope:** Declarative startup/orchestration layer above managed AppFS runtime for connector lifecycle, initial app registration, and multi-app bootstrap
+
+## 1. Goal
+
+Add one high-level, declarative startup path so AppFS can be integrated into real software without requiring:
+
+1. manual connector startup in a separate terminal;
+2. manual `/_appfs/register_app.act` writes after every boot;
+3. duplicated transport flags across shell history, env vars, and ad hoc JSON;
+4. one-off glue code in each host application such as `chat-server`.
+
+After this change, the intended happy path is:
+
+```text
+agentfs appfs compose up -f appfs-compose.yaml
+```
+
+The compose file declares:
+
+1. how to prepare the AgentFS/AppFS runtime;
+2. how each connector should be reached or launched;
+3. which apps should be registered at startup.
+
+## 2. Why `appfs up` Should Not Absorb This
+
+`agentfs appfs up` already solves one problem well: mount and runtime orchestration for managed AppFS.
+
+It should remain the low-level managed runtime entrypoint, not grow into a giant flag surface for:
+
+1. connector process supervision;
+2. external endpoint fallback rules;
+3. multi-app desired state;
+4. app auto-registration;
+5. project-local startup config for host applications.
+
+Trying to solve those with more CLI flags will recreate the same split-brain problem we just removed from `mount + serve appfs`.
+
+Conclusion:
+
+1. `appfs up` stays as the runtime primitive;
+2. `appfs compose up` becomes the high-level integration UX.
+
+## 3. Main Decisions
+
+### 3.1 Add a compose-specific orchestration command
+
+The new command is:
+
+```text
+agentfs appfs compose up -f appfs-compose.yaml
+```
+
+Recommended file names:
+
+1. `appfs-compose.yaml`
+2. `appfs-compose.yml`
+
+`-f` is optional when one of those files exists in the current working directory.
+
+V1 scope only includes:
+
+1. `up`
+
+Explicitly out of scope for the first slice:
+
+1. `down`
+2. `status`
+3. `logs`
+4. background daemon mode
+
+### 3.2 Compose is desired configuration, not runtime state
+
+The compose file is **not** a replacement for:
+
+`/_appfs/apps.registry.json`
+
+Instead:
+
+1. compose file = declarative startup intent owned by the operator/project;
+2. runtime registry = managed AppFS runtime state stored inside the mounted filesystem.
+
+Compose may seed or replace the initial managed registry before startup, but the runtime registry remains the engine's persisted state model.
+
+### 3.3 Compose owns initial app set at startup
+
+The current managed runtime loads apps from the persisted registry during startup.
+
+That means a compose command cannot simply "start runtime, then maybe register apps later", because undeclared stale registry entries would also boot.
+
+So the frozen compose startup rule is:
+
+1. load and validate compose file;
+2. resolve connector endpoints or launch connector commands;
+3. synthesize the desired managed registry from compose apps;
+4. persist that registry before AppFS runtime starts;
+5. start managed AppFS runtime using that registry as the initial app set.
+
+This makes startup deterministic and removes the need for a post-boot manual registration step in the happy path.
+
+### 3.4 Compose manages connectors, not app semantics
+
+Compose can manage connector startup and transport config, but it should not standardize app-specific business semantics such as:
+
+1. Huoyan attached-case bootstrap rules;
+2. AIIM demo-specific scope names;
+3. app-specific auth or cookie acquisition flows.
+
+Those remain connector-owned concerns, expressed through:
+
+1. connector command args;
+2. connector environment variables;
+3. connector endpoints and health checks.
+
+Example: Huoyan attached-case bootstrap should stay as connector env such as `APPFS_HUOYAN_BOOTSTRAP_MODE=attached_case`, not become a generic compose-level field.
+
+### 3.5 Compose should support both external and managed connectors
+
+Real integrations need three modes:
+
+1. use an already running connector at a fixed HTTP/gRPC endpoint;
+2. launch a connector command locally and supervise it;
+3. try an external endpoint first, and if it is unavailable, fall back to launching the connector locally.
+
+So connector mode is frozen as:
+
+1. `external`
+2. `command`
+3. `external_or_command`
+
+### 3.6 `register_app.act` remains valid after startup
+
+Compose removes the **manual startup requirement** for app registration, but it does not remove the AppFS control plane.
+
+After `compose up` starts:
+
+1. `/_appfs/register_app.act`
+2. `/_appfs/unregister_app.act`
+3. `/_appfs/list_apps.act`
+
+remain valid for dynamic runtime changes.
+
+Compose just becomes the standard way to define the initial app set.
+
+## 4. Target UX
+
+### 4.1 Minimal example
+
+```yaml
+version: 1
+
+runtime:
+  db: .agentfs/huoyan-local.db
+  mountpoint: C:\mnt\appfs-huoyan
+  backend: winfsp
+  init: if_missing
+  reset: false
+
+connectors:
+  huoyan-http:
+    mode: external_or_command
+    transport: http
+    endpoint: http://127.0.0.1:8080
+    healthcheck:
+      kind: connector
+      interval_ms: 1000
+      timeout_ms: 3000
+      max_attempts: 20
+    command:
+      cwd: ./examples/appfs/bridges/http-python
+      program: uv
+      args: ["run", "python", "bridge_server.py"]
+      env:
+        APPFS_HTTP_BRIDGE_BACKEND: huoyan
+        APPFS_HUOYAN_HOST: http://127.0.0.1:7777
+        APPFS_HUOYAN_CASE_ID: "1"
+        APPFS_HUOYAN_BOOTSTRAP_MODE: attached_case
+
+apps:
+  huoyan:
+    connector: huoyan-http
+    transport:
+      http_timeout_ms: 5000
+      grpc_timeout_ms: 5000
+      bridge_max_retries: 2
+      bridge_initial_backoff_ms: 100
+      bridge_max_backoff_ms: 1000
+      bridge_circuit_breaker_failures: 5
+      bridge_circuit_breaker_cooldown_ms: 3000
+```
+
+Then the operator runs:
+
+```text
+agentfs appfs compose up -f appfs-compose.yaml
+```
+
+Result:
+
+1. connector endpoint is resolved or launched;
+2. AgentFS DB is created if needed;
+3. managed AppFS runtime starts;
+4. `huoyan` is already present in the initial registry;
+5. the mounted tree is ready without a manual register step.
+
+### 4.2 Chat-server integration shape
+
+For `chat-server`, the intended pattern is:
+
+1. keep one checked-in `appfs-compose.yaml` near the project;
+2. let compose own connector env, connector launch command, DB path, and mountpoint;
+3. let `chat-server` invoke one command instead of reproducing AppFS boot logic itself.
+
+That reduces integration code and makes the runtime topology reviewable in one file.
+
+## 5. Compose Schema
+
+### 5.1 Top-level layout
+
+```yaml
+version: 1
+name: optional-project-name
+runtime: ...
+connectors: ...
+apps: ...
+```
+
+### 5.2 `runtime`
+
+`runtime` declares how managed AppFS should start.
+
+Fields:
+
+1. `db`: AgentFS database path
+2. `mountpoint`: mount path
+3. `backend`: `fuse | nfs | winfsp`
+4. `init`: `if_missing | always | never`
+5. `reset`: boolean, default `false`
+6. `auto_unmount`: boolean, default `true`
+7. `allow_root`: boolean, optional
+8. `system`: boolean, optional
+9. `uid`: optional Linux/macOS override
+10. `gid`: optional Linux/macOS override
+11. `poll_ms`: optional runtime fallback poll interval
+
+Frozen behavior:
+
+1. relative paths are resolved relative to the compose file directory;
+2. `reset: true` means remove or recreate the AgentFS DB before startup;
+3. `init: if_missing` is the default.
+
+### 5.3 `connectors`
+
+`connectors` is a map keyed by connector name.
+
+Each entry contains:
+
+1. `mode`: `external | command | external_or_command`
+2. `transport`: `http | grpc`
+3. `endpoint`: required for V1 bridge transports, including `command`, because compose does not yet auto-discover connector endpoints
+4. `healthcheck`: optional object
+5. `command`: required for `command` and `external_or_command`
+
+`command` fields:
+
+1. `cwd`
+2. `program`
+3. `args`
+4. `env`
+
+`healthcheck` fields:
+
+1. `kind`: for V1 only `connector`
+2. `timeout_ms`
+3. `interval_ms`
+4. `max_attempts`
+
+Frozen V1 rule:
+
+1. health means "the connector transport can answer enough to be safely registered";
+2. V1 does not define per-app semantic readiness beyond connector health.
+
+### 5.4 `apps`
+
+`apps` is a map keyed by `app_id`.
+
+Each app entry contains:
+
+1. `connector`: reference into `connectors`
+2. `session_id`: optional
+3. `transport`: optional transport overrides
+
+`transport` fields mirror current AppFS registration payload:
+
+1. `http_timeout_ms`
+2. `grpc_timeout_ms`
+3. `bridge_max_retries`
+4. `bridge_initial_backoff_ms`
+5. `bridge_max_backoff_ms`
+6. `bridge_circuit_breaker_failures`
+7. `bridge_circuit_breaker_cooldown_ms`
+
+Compose does **not** duplicate app-specific structure config here.
+
+If an app needs startup specialization, that belongs in the referenced connector definition.
+
+## 6. Lifecycle
+
+### 6.1 Startup sequence
+
+`compose up` should execute in this order:
+
+1. locate and parse compose YAML;
+2. normalize paths relative to the compose file;
+3. validate the runtime/app/connector graph;
+4. initialize or reset the AgentFS database if configured;
+5. prepare the connector supervisors;
+6. for each connector:
+   1. if `external`, wait for endpoint health;
+   2. if `command`, launch child process and wait for health;
+   3. if `external_or_command`, probe endpoint first and launch only on failure;
+7. synthesize a managed registry document from `apps`;
+8. persist that registry before runtime startup;
+9. start the shared managed AppFS orchestrator;
+10. keep running in the foreground and stream logs until shutdown.
+
+### 6.2 Shutdown sequence
+
+On Ctrl+C or fatal error:
+
+1. stop AppFS runtime first;
+2. unmount AppFS;
+3. terminate connector child processes started by compose;
+4. leave externally managed connectors alone.
+
+### 6.3 Runtime mutations after startup
+
+After compose startup, the operator may still:
+
+1. register new apps dynamically;
+2. unregister apps dynamically;
+3. refresh structure;
+4. enter scope;
+5. trigger actions through ordinary AppFS paths.
+
+Frozen rule:
+
+1. the next `compose up` re-seeds the initial registry from the compose file again;
+2. compose is authoritative for startup state, not for every runtime mutation after boot.
+
+## 7. Internal Architecture
+
+### 7.1 Reuse the managed AppFS orchestrator
+
+`compose up` should not shell out to a second full CLI process as its long-term architecture.
+
+Instead, extract a shared internal orchestration layer used by both:
+
+1. `agentfs appfs up`
+2. `agentfs appfs compose up`
+
+Suggested boundary:
+
+1. a reusable managed-runtime launcher that starts mount + runtime and owns shutdown order;
+2. compose-specific preparation layered above it.
+
+### 7.2 Add a compose domain model
+
+Recommended modules:
+
+1. `cli/src/cmd/appfs_compose.rs`
+2. `cli/src/cmd/appfs_compose/schema.rs`
+3. `cli/src/cmd/appfs_compose/loader.rs`
+4. `cli/src/cmd/appfs_compose/connector_supervisor.rs`
+5. `cli/src/cmd/appfs_compose/reconcile.rs`
+
+Responsibilities:
+
+1. schema/validation
+2. path normalization
+3. connector process management
+4. compose-to-registry synthesis
+5. orchestration entrypoint
+
+### 7.3 Registry synthesis should use existing runtime config types
+
+Do not invent a second registration model.
+
+Compose should normalize into the same internal structures already used for:
+
+1. managed registry documents
+2. runtime transport config
+3. connector builders
+
+That keeps compose as a UX layer rather than a second runtime stack.
+
+## 8. Non-Goals
+
+V1 does not include:
+
+1. background daemonization;
+2. persistent supervisor state outside the AgentFS DB;
+3. compose-driven hot reload when `appfs-compose.yaml` changes;
+4. standardized app-specific bootstrap semantics;
+5. full `docker compose` parity;
+6. ownership-aware pruning of runtime-only apps after startup.
+
+## 9. Why This Helps Real App Pilots
+
+This directly improves real-app onboarding:
+
+1. one checked-in file documents how the app is mounted, how the connector is reached, and which app IDs exist;
+2. host applications such as `chat-server` can call one startup command instead of recreating AppFS boot logic;
+3. env-heavy connectors such as Huoyan become reproducible and reviewable;
+4. multi-app startup no longer depends on shell snippets that write JSON into `register_app.act`.
+
+## 10. Implementation Order
+
+### CP1. Freeze the design
+
+1. add this design doc;
+2. link it from `docs/v4/README.md`.
+
+### CP2. Compose schema and loader
+
+1. add YAML schema structs;
+2. add file discovery and path normalization;
+3. add validation and tests.
+
+### CP3. Connector supervision
+
+1. implement `external`, `command`, and `external_or_command`;
+2. add connector health wait logic;
+3. add process shutdown handling.
+
+### CP4. Runtime bootstrap from compose
+
+1. synthesize managed registry from compose apps;
+2. persist it before runtime startup;
+3. extract shared AppFS managed orchestrator used by both `appfs up` and `compose up`.
+
+### CP5. CLI and docs
+
+1. add `agentfs appfs compose up`;
+2. add examples for Windows and Linux;
+3. document the `chat-server` integration path.
+
+## 11. Acceptance Criteria
+
+This design is complete when:
+
+1. `agentfs appfs compose up` can start AppFS from one YAML file;
+2. compose can use both external endpoints and locally launched connectors;
+3. declared apps appear at startup without manual `register_app.act`;
+4. one compose file can bootstrap more than one app;
+5. `appfs up` still works as a lower-level primitive for debugging.

--- a/docs/v4/README.md
+++ b/docs/v4/README.md
@@ -8,6 +8,7 @@
 2. [Connector structure interface](./APPFS-v0.4-Connector结构接口.zh-CN.md)
 3. [Runtime closure design plan](../plans/2026-03-26-appfs-runtime-closure-design.md)
 4. [AppConnector unversioned cleanup plan](../plans/2026-03-30-appconnector-unversioned-cleanup.md)
+5. [AppFS compose up design](../plans/2026-04-22-appfs-compose-up-design.md)
 
 ## What Lives Here
 

--- a/examples/appfs/appfs-compose.huoyan-attached-case.example.yaml
+++ b/examples/appfs/appfs-compose.huoyan-attached-case.example.yaml
@@ -1,0 +1,42 @@
+version: 1
+name: huoyan-attached-case
+
+runtime:
+  db: .agentfs/huoyan-compose.db
+  mountpoint: C:/mnt/appfs-huoyan
+  backend: winfsp
+  init: if_missing
+  reset: false
+  poll_ms: 0
+
+connectors:
+  huoyan-http:
+    mode: external_or_command
+    transport: http
+    endpoint: http://127.0.0.1:8080
+    healthcheck:
+      kind: connector
+      interval_ms: 1000
+      timeout_ms: 3000
+      max_attempts: 20
+    command:
+      cwd: ./examples/appfs/bridges/http-python
+      program: uv
+      args: ["run", "python", "bridge_server.py"]
+      env:
+        APPFS_HTTP_BRIDGE_BACKEND: huoyan
+        APPFS_HUOYAN_HOST: http://127.0.0.1:7777
+        APPFS_HUOYAN_CASE_ID: "1"
+        APPFS_HUOYAN_BOOTSTRAP_MODE: attached_case
+
+apps:
+  huoyan:
+    connector: huoyan-http
+    transport:
+      http_timeout_ms: 5000
+      grpc_timeout_ms: 5000
+      bridge_max_retries: 2
+      bridge_initial_backoff_ms: 100
+      bridge_max_backoff_ms: 1000
+      bridge_circuit_breaker_failures: 5
+      bridge_circuit_breaker_cooldown_ms: 3000

--- a/examples/appfs/bridges/http-python/appfs_http_bridge/huoyan_backend.py
+++ b/examples/appfs/bridges/http-python/appfs_http_bridge/huoyan_backend.py
@@ -255,6 +255,9 @@ class HuoyanBackend:
     app_id: str = field(default_factory=lambda: os.getenv("APPFS_HUOYAN_APP_ID", "huoyan"))
     user_id: int = field(default_factory=lambda: _env_int("APPFS_HUOYAN_USER_ID", 1))
     case_mode: str = field(default_factory=lambda: os.getenv("APPFS_HUOYAN_CASE_MODE", "singlebox").strip().lower() or "singlebox")
+    bootstrap_mode: str = field(
+        default_factory=lambda: os.getenv("APPFS_HUOYAN_BOOTSTRAP_MODE", "").strip().lower()
+    )
     default_case_id: int | None = field(
         default_factory=lambda: (_env_int("APPFS_HUOYAN_CASE_ID", 0) or None)
     )
@@ -274,6 +277,14 @@ class HuoyanBackend:
     def __post_init__(self) -> None:
         if self.client is None:
             self.client = HuoyanClient()
+        if self.bootstrap_mode == "":
+            self.bootstrap_mode = "case" if self.default_scope == "case" else "home"
+        if self.bootstrap_mode not in {"home", "case", "attached_case"}:
+            raise ValueError(f"unsupported huoyan bootstrap mode: {self.bootstrap_mode}")
+        if self.bootstrap_mode in {"case", "attached_case"} and self.default_case_id is None:
+            raise ValueError(
+                f"APPFS_HUOYAN_BOOTSTRAP_MODE={self.bootstrap_mode} requires APPFS_HUOYAN_CASE_ID"
+            )
 
     def _snapshot_manifest(self, template: str) -> dict[str, Any]:
         return {
@@ -298,9 +309,23 @@ class HuoyanBackend:
         }
 
     def _initial_scope(self) -> str:
-        if self.default_scope == "case" and self.default_case_id is not None:
-            return self._case_scope(self.default_case_id)
+        if self.bootstrap_mode in {"case", "attached_case"}:
+            return self._attached_case_scope()
         return DEFAULT_HOME_SCOPE
+
+    def _attached_case_scope(self) -> str:
+        if self.default_case_id is None:
+            raise ValueError("huoyan case bootstrap requires default_case_id")
+        return self._case_scope(self.default_case_id)
+
+    def _assert_attached_scope(self, scope: str) -> None:
+        if self.bootstrap_mode != "attached_case":
+            return
+        attached_scope = self._attached_case_scope()
+        if scope != attached_scope:
+            raise ValueError(
+                f"attached_case bootstrap only supports current case scope {attached_scope}, got {scope}"
+            )
 
     def _case_scope(self, case_id: int) -> str:
         return f"case:{case_id}"
@@ -328,7 +353,12 @@ class HuoyanBackend:
             "supports_snapshot": True,
             "supports_live": False,
             "supports_action": False,
-            "optional_features": ["structure_sync", "case_scope", "fireeye_tree"],
+            "optional_features": [
+                "structure_sync",
+                "case_scope",
+                "fireeye_tree",
+                "attached_case_bootstrap",
+            ],
         }
 
     def health(self, context: dict[str, Any]) -> dict[str, Any]:
@@ -345,6 +375,7 @@ class HuoyanBackend:
     def get_app_structure(self, request: dict[str, Any], context: dict[str, Any]) -> dict[str, Any]:
         session_id = str(context.get("session_id", ""))
         scope = self.session_scopes.get(session_id, self._initial_scope())
+        self._assert_attached_scope(scope)
         built = self._build_scope(scope, force_refresh=True)
         self.session_scopes[session_id] = scope
         return self._structure_response(request, built.snapshot)
@@ -360,6 +391,15 @@ class HuoyanBackend:
             scope = target_scope.strip()
         else:
             scope = previous_scope
+
+        if self.bootstrap_mode == "attached_case":
+            attached_scope = self._attached_case_scope()
+            if previous_scope != attached_scope:
+                previous_scope = attached_scope
+            if scope != attached_scope:
+                raise ValueError(
+                    f"attached_case bootstrap does not support leaving current case scope {attached_scope}"
+                )
 
         self._transition_scope(previous_scope, scope, reason)
         built = self._build_scope(scope, force_refresh=True)
@@ -475,6 +515,16 @@ class HuoyanBackend:
             time.sleep(self.open_wait_sec)
 
     def _transition_scope(self, previous_scope: str, next_scope: str, reason: str) -> None:
+        if self.bootstrap_mode == "attached_case":
+            attached_scope = self._attached_case_scope()
+            if previous_scope != attached_scope:
+                previous_scope = attached_scope
+            if next_scope != attached_scope:
+                raise ValueError(
+                    f"attached_case bootstrap does not support leaving current case scope {attached_scope}"
+                )
+            return
+
         if previous_scope == next_scope:
             return
 

--- a/examples/appfs/bridges/http-python/tests/test_huoyan_backend.py
+++ b/examples/appfs/bridges/http-python/tests/test_huoyan_backend.py
@@ -216,6 +216,109 @@ class HuoyanBackendTests(unittest.TestCase):
         self.assertEqual(self.client.last_fetch_params["pid"], 4000000302)
         self.assertEqual(self.client.last_fetch_params["datatype"], "immsginfo")
 
+    def test_attached_case_bootstrap_starts_inside_case_without_open(self) -> None:
+        backend = HuoyanBackend(
+            client=self.client,
+            open_wait_sec=0,
+            bootstrap_mode="attached_case",
+            default_case_id=7,
+        )
+        body = backend.get_app_structure({"app_id": "huoyan"}, self.context)
+        snapshot = body["result"]["snapshot"]
+        paths = {node["path"] for node in snapshot["nodes"]}
+        self.assertEqual(snapshot["active_scope"], "case:7")
+        self.assertIn("检材A/微信/mzs(wxid_ykx86h8vvs7v12)/好友消息_张三.res.jsonl", paths)
+        self.assertEqual(self.client.opened_paths, [])
+        self.assertEqual(self.client.exited_case_ids, [])
+
+    def test_attached_case_same_scope_refresh_is_noop_for_host_case_state(self) -> None:
+        backend = HuoyanBackend(
+            client=self.client,
+            open_wait_sec=0,
+            bootstrap_mode="attached_case",
+            default_case_id=7,
+        )
+        backend.get_app_structure({"app_id": "huoyan"}, self.context)
+        refreshed = backend.refresh_app_structure(
+            {
+                "app_id": "huoyan",
+                "reason": "enter_scope",
+                "target_scope": "case:7",
+                "trigger_action_path": "/_app/enter_scope.act",
+            },
+            self.context,
+        )
+        snapshot = refreshed["result"]["snapshot"]
+        self.assertEqual(snapshot["active_scope"], "case:7")
+        self.assertEqual(self.client.opened_paths, [])
+        self.assertEqual(self.client.exited_case_ids, [])
+
+    def test_attached_case_rejects_enter_scope_home(self) -> None:
+        backend = HuoyanBackend(
+            client=self.client,
+            open_wait_sec=0,
+            bootstrap_mode="attached_case",
+            default_case_id=7,
+        )
+        backend.get_app_structure({"app_id": "huoyan"}, self.context)
+        with self.assertRaisesRegex(
+            ValueError,
+            r"attached_case bootstrap does not support leaving current case scope case:7",
+        ):
+            backend.refresh_app_structure(
+                {
+                    "app_id": "huoyan",
+                    "reason": "enter_scope",
+                    "target_scope": "home",
+                    "trigger_action_path": "/_app/enter_scope.act",
+                },
+                self.context,
+            )
+
+    def test_attached_case_rejects_switching_to_other_case(self) -> None:
+        backend = HuoyanBackend(
+            client=self.client,
+            open_wait_sec=0,
+            bootstrap_mode="attached_case",
+            default_case_id=7,
+        )
+        backend.get_app_structure({"app_id": "huoyan"}, self.context)
+        with self.assertRaisesRegex(
+            ValueError,
+            r"attached_case bootstrap does not support leaving current case scope case:7",
+        ):
+            backend.refresh_app_structure(
+                {
+                    "app_id": "huoyan",
+                    "reason": "enter_scope",
+                    "target_scope": "case:8",
+                    "trigger_action_path": "/_app/enter_scope.act",
+                },
+                self.context,
+            )
+
+    def test_attached_case_snapshot_reads_work_without_case_open(self) -> None:
+        backend = HuoyanBackend(
+            client=self.client,
+            open_wait_sec=0,
+            bootstrap_mode="attached_case",
+            default_case_id=7,
+        )
+        backend.get_app_structure({"app_id": "huoyan"}, self.context)
+        target_path = "检材A/微信/mzs(wxid_ykx86h8vvs7v12)/好友消息_张三.res.jsonl"
+        fetched = backend.fetch_snapshot_chunk(
+            {
+                "resource_path": f"/{target_path}",
+                "resume": {"kind": "start"},
+                "budget_bytes": 4096,
+            },
+            self.context,
+        )
+        self.assertEqual(len(fetched["records"]), 2)
+        self.assertEqual(fetched["records"][0]["line"]["Content"], "文本")
+        self.assertEqual(self.client.opened_paths, [])
+        self.assertEqual(self.client.exited_case_ids, [])
+
     def test_enter_scope_home_exits_current_case(self) -> None:
         self.backend.refresh_app_structure(
             {


### PR DESCRIPTION
## Summary
- add `agentfs appfs compose up` with compose schema loading, connector supervision, and managed registry bootstrap
- add a Huoyan attached-case bootstrap mode plus example compose config for real-app pilot startup
- update README and README.zh-CN with compose-first usage, Windows WinFsp mountpoint notes, and Huoyan startup guidance

## Validation
- `cargo test cmd::appfs:: --package agentfs`
- `uv run python -m unittest tests/test_huoyan_backend.py`
- manual Windows smoke test: AIIM compose mount/read
- manual Windows smoke test: Huoyan attached-case compose mount/read