### PR TITLE
appfs: sanitize Huoyan bridge path names

### DIFF
--- a/examples/appfs/bridges/http-python/appfs_http_bridge/huoyan_backend.py
+++ b/examples/appfs/bridges/http-python/appfs_http_bridge/huoyan_backend.py
@@ -16,6 +16,8 @@ from typing import Any, Protocol
 ROOT_NODE_ID = 1
 DEFAULT_CASES_LIMIT = 100
 DEFAULT_HOME_SCOPE = "home"
+SAFE_PATH_SEGMENT_MAX_BYTES = 96
+SNAPSHOT_SUFFIX = ".res.jsonl"
 
 
 def _now_iso() -> str:
@@ -53,7 +55,35 @@ def _env_float(name: str, default: float) -> float:
         return default
 
 
-def _safe_segment(name: str, fallback: str) -> str:
+def _truncate_utf8_prefix(text: str, max_bytes: int) -> str:
+    used = 0
+    out: list[str] = []
+    for ch in text:
+        size = len(ch.encode("utf-8"))
+        if used + size > max_bytes:
+            break
+        out.append(ch)
+        used += size
+    return "".join(out).strip().rstrip(".")
+
+
+def _short_hash(value: str) -> str:
+    return hashlib.sha1(value.encode("utf-8")).hexdigest()[:12]
+
+
+def _shorten_segment(name: str, *, suffix: str = "") -> str:
+    full = f"{name}{suffix}"
+    if len(full.encode("utf-8")) <= SAFE_PATH_SEGMENT_MAX_BYTES:
+        return full
+
+    digest = _short_hash(full)
+    tail = f"__{digest}{suffix}"
+    prefix_budget = max(1, SAFE_PATH_SEGMENT_MAX_BYTES - len(tail.encode("utf-8")))
+    prefix = _truncate_utf8_prefix(name, prefix_budget) or "item"
+    return f"{prefix}{tail}"
+
+
+def _sanitize_segment(name: str, fallback: str) -> str:
     raw = (name or "").strip()
     if raw == "":
         raw = fallback
@@ -63,15 +93,21 @@ def _safe_segment(name: str, fallback: str) -> str:
             out_chars.append("_")
         elif ord(ch) < 32:
             out_chars.append("_")
+        elif ord(ch) > 0xFFFF:
+            out_chars.append(f"U{ord(ch):08X}")
         else:
             out_chars.append(ch)
     out = "".join(out_chars).strip().rstrip(".")
     return out or fallback
 
 
+def _safe_segment(name: str, fallback: str) -> str:
+    return _shorten_segment(_sanitize_segment(name, fallback))
+
+
 def _safe_leaf_name(name: str, fallback: str) -> str:
-    base = _safe_segment(name.replace("/", "_"), fallback)
-    return f"{base}.res.jsonl"
+    base = _sanitize_segment(name.replace("/", "_"), fallback)
+    return _shorten_segment(base, suffix=SNAPSHOT_SUFFIX)
 
 
 def _dedupe_name(name: str, seen: dict[str, int], suffix_seed: str) -> str:

--- a/examples/appfs/bridges/http-python/tests/test_huoyan_backend.py
+++ b/examples/appfs/bridges/http-python/tests/test_huoyan_backend.py
@@ -10,7 +10,12 @@ from unittest import mock
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from appfs_http_bridge.huoyan_backend import HuoyanBackend, _json_request
+from appfs_http_bridge.huoyan_backend import (
+    HuoyanBackend,
+    _json_request,
+    _safe_leaf_name,
+    _safe_segment,
+)
 
 
 class _FakeHuoyanClient:
@@ -161,6 +166,37 @@ class HuoyanBackendTests(unittest.TestCase):
 
     def tearDown(self) -> None:
         self.tempdir.cleanup()
+
+    def test_safe_names_preserve_short_values(self) -> None:
+        self.assertEqual(_safe_segment("微信", "节点-1"), "微信")
+        self.assertEqual(_safe_leaf_name("好友消息/张三", "节点-1"), "好友消息_张三.res.jsonl")
+
+    def test_safe_names_encode_non_bmp_emoji_as_unicode_codepoint(self) -> None:
+        self.assertEqual(
+            _safe_leaf_name("🏦银行转移（19414801983@chatroom）", "节点-1"),
+            "U0001F3E6银行转移（19414801983@chatroom）.res.jsonl",
+        )
+
+    def test_safe_names_shorten_long_utf8_components_with_hash(self) -> None:
+        raw = (
+            "AAAAA租房管家六安市区单间独卫"
+            "(v3_020b3826fd030100000000007bfd31c6b4938d000000501ea9a3dba12f95f6b60a0536a1adb6e5be76923a804307b075b0d836f0346a37779b7e6e699959002aded90e980a238b5cf26bdb2c3905da256adc7ef8415510fa0b9fc26380003ebce051@stranger)"
+        )
+        leaf = _safe_leaf_name(raw, "节点-1")
+        segment = _safe_segment(raw, "节点-1")
+
+        self.assertLessEqual(len(leaf.encode("utf-8")), 96)
+        self.assertLessEqual(len(segment.encode("utf-8")), 96)
+        self.assertTrue(leaf.endswith(".res.jsonl"))
+        self.assertRegex(leaf, r"__[0-9a-f]{12}\.res\.jsonl$")
+        self.assertRegex(segment, r"__[0-9a-f]{12}$")
+        self.assertNotEqual(leaf, raw + ".res.jsonl")
+
+    def test_safe_names_hash_avoids_long_name_collisions(self) -> None:
+        prefix = "AAAAA租房管家六安市区单间独卫" + "x" * 200
+        first = _safe_leaf_name(prefix + "1", "节点-1")
+        second = _safe_leaf_name(prefix + "2", "节点-2")
+        self.assertNotEqual(first, second)
 
     def test_home_structure_contains_case_directory_and_info_snapshot(self) -> None:
         body = self.backend.get_app_structure({"app_id": "huoyan"}, self.context)


### PR DESCRIPTION
## Summary
- Shorten long Huoyan path segments with a readable prefix plus a stable 12-char SHA-1 suffix
- Encode non-BMP emoji/code points as `UXXXXXXXX` so WinFSP/Windows paths remain safe while preserving traceability
- Add Huoyan backend tests for short names, long UTF-8 names, emoji names, and hash collision avoidance

## Tests
- `python -m unittest tests.test_huoyan_backend`