### PR TITLE
[codex] stage AppFS DB bulk materialization and Windows listing fixes

### DIFF
--- a/cli/src/cmd/appfs.rs
+++ b/cli/src/cmd/appfs.rs
@@ -1,4 +1,4 @@
-use agentfs_sdk::{AgentFSOptions, AppConnector};
+use agentfs_sdk::{AgentFS as SdkAgentFS, AgentFSOptions, AppConnector};
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
@@ -73,6 +73,17 @@ const MAX_SEGMENT_BYTES: usize = 255;
 
 const ALLOWED_SEGMENT_CHARS: &str =
     "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789._-~";
+
+#[derive(Clone, Debug)]
+enum ManagedRuntimeBootstrapEntry {
+    Dir { rel_path: String },
+    File { rel_path: String, bytes: Vec<u8> },
+}
+
+#[derive(Clone, Debug, Default)]
+struct ManagedRuntimeBootstrapPlan {
+    entries: Vec<ManagedRuntimeBootstrapEntry>,
+}
 
 #[derive(Clone)]
 pub struct ActionWakeHandle {
@@ -837,6 +848,110 @@ fn wait_for_managed_runtime_paths_ready(
     }
 }
 
+async fn build_managed_runtime_bootstrap_plan(
+    agent: &SdkAgentFS,
+    app_ids: &[String],
+) -> Result<ManagedRuntimeBootstrapPlan> {
+    let mut plan = ManagedRuntimeBootstrapPlan::default();
+    plan.entries.push(ManagedRuntimeBootstrapEntry::Dir {
+        rel_path: "_appfs".to_string(),
+    });
+    if let Some(bytes) = agent.fs.read_file("/_appfs/apps.registry.json").await? {
+        plan.entries.push(ManagedRuntimeBootstrapEntry::File {
+            rel_path: "_appfs/apps.registry.json".to_string(),
+            bytes,
+        });
+    }
+
+    for app_id in app_ids {
+        let app_root = app_id.clone();
+        for rel_path in [
+            app_root.clone(),
+            format!("{app_root}/_meta"),
+            format!("{app_root}/_stream"),
+            format!("{app_root}/_stream/from-seq"),
+        ] {
+            plan.entries
+                .push(ManagedRuntimeBootstrapEntry::Dir { rel_path });
+        }
+
+        for rel_path in [
+            format!("{app_root}/_meta/manifest.res.json"),
+            format!("{app_root}/_stream/events.evt.jsonl"),
+            format!("{app_root}/_stream/cursor.res.json"),
+            format!("{app_root}/_stream/inflight.jobs.res.json"),
+            format!("{app_root}/_stream/{ACTION_CURSORS_FILENAME}"),
+            format!("{app_root}/_stream/{SNAPSHOT_EXPAND_JOURNAL_FILENAME}"),
+        ] {
+            let abs = format!("/{rel_path}");
+            let Some(bytes) = agent.fs.read_file(&abs).await? else {
+                anyhow::bail!("managed runtime bootstrap source missing from db: {abs}");
+            };
+            plan.entries
+                .push(ManagedRuntimeBootstrapEntry::File { rel_path, bytes });
+        }
+    }
+
+    Ok(plan)
+}
+
+fn apply_managed_runtime_bootstrap_plan(
+    mount_root: &Path,
+    plan: &ManagedRuntimeBootstrapPlan,
+) -> Result<()> {
+    for entry in &plan.entries {
+        match entry {
+            ManagedRuntimeBootstrapEntry::Dir { rel_path } => {
+                let path = mount_root.join(rel_path);
+                std::fs::create_dir_all(&path).with_context(|| {
+                    format!(
+                        "failed to precreate managed runtime dir on mount {}",
+                        path.display()
+                    )
+                })?;
+                #[cfg(target_os = "windows")]
+                wait_for_runtime_path_visibility(&path, true).with_context(|| {
+                    format!(
+                        "managed runtime startup path is not visible yet after directory bootstrap: {}",
+                        path.display()
+                    )
+                })?;
+            }
+            ManagedRuntimeBootstrapEntry::File { rel_path, bytes } => {
+                let path = mount_root.join(rel_path);
+                if let Some(parent) = path.parent() {
+                    std::fs::create_dir_all(parent).with_context(|| {
+                        format!(
+                            "failed to precreate managed runtime parent dir {}",
+                            parent.display()
+                        )
+                    })?;
+                }
+                let needs_write = match std::fs::read(&path) {
+                    Ok(existing) => existing != *bytes,
+                    Err(_) => true,
+                };
+                if needs_write {
+                    std::fs::write(&path, bytes).with_context(|| {
+                        format!(
+                            "failed to precreate managed runtime file on mount {}",
+                            path.display()
+                        )
+                    })?;
+                }
+                #[cfg(target_os = "windows")]
+                wait_for_runtime_path_visibility(&path, false).with_context(|| {
+                    format!(
+                        "managed runtime startup path is not readable yet after file bootstrap: {}",
+                        path.display()
+                    )
+                })?;
+            }
+        }
+    }
+    Ok(())
+}
+
 #[cfg(target_os = "windows")]
 fn wait_for_runtime_path_visibility(path: &Path, expect_dir: bool) -> Result<()> {
     const MAX_ATTEMPTS: usize = 40;
@@ -897,6 +1012,11 @@ pub async fn handle_appfs_compose_up_command(compose_path: Option<PathBuf>) -> R
         )
         .await?;
     }
+    let startup_app_ids = resolved_apps
+        .values()
+        .map(|app| app.app_id.clone())
+        .collect::<Vec<_>>();
+    let startup_plan = build_managed_runtime_bootstrap_plan(&agent, &startup_app_ids).await?;
     drop(agent);
 
     let result = run_managed_appfs_with_bootstrap(
@@ -911,7 +1031,7 @@ pub async fn handle_appfs_compose_up_command(compose_path: Option<PathBuf>) -> R
             gid: compose_doc.runtime.gid,
             poll_ms: compose_doc.runtime.poll_ms,
         },
-        |_| Ok(()),
+        move |mount_root| apply_managed_runtime_bootstrap_plan(mount_root, &startup_plan),
     )
     .await;
 

--- a/cli/src/cmd/appfs.rs
+++ b/cli/src/cmd/appfs.rs
@@ -1,4 +1,7 @@
-use agentfs_sdk::{AgentFS as SdkAgentFS, AgentFSOptions, AppConnector};
+use agentfs_sdk::{
+    AgentFS as SdkAgentFS, AgentFSOptions, AgentFsGlobQuery, AgentFsGlobQueryResult,
+    AgentFsQueryEntryKind, AgentFsTreeQuery, AgentFsTreeQueryResult, AppConnector,
+};
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
@@ -11,6 +14,8 @@ use std::sync::{
 };
 use std::time::{Duration, Instant};
 use uuid::Uuid;
+
+use crate::opts::AppfsQueryFormat;
 
 mod action_dispatcher;
 mod bridge_resilience;
@@ -199,6 +204,31 @@ pub struct AppfsLaunchArgs {
     pub attach_role: Option<String>,
     pub startup_timeout_ms: u64,
     pub agent_args: Vec<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct AppfsQueryTreeArgs {
+    pub db: PathBuf,
+    pub root: String,
+    pub max_depth: usize,
+    pub max_entries_per_dir: usize,
+    pub include_files: bool,
+    pub include_internal: bool,
+    pub format: AppfsQueryFormat,
+}
+
+#[derive(Debug, Clone)]
+pub struct AppfsQueryGlobArgs {
+    pub db: PathBuf,
+    pub root: String,
+    pub pattern: String,
+    pub max_depth: usize,
+    pub max_results: usize,
+    pub max_scanned_entries: usize,
+    pub include_dirs: bool,
+    pub ignore_case: bool,
+    pub include_internal: bool,
+    pub format: AppfsQueryFormat,
 }
 
 fn build_managed_mount_args(args: &AppfsUpArgs) -> crate::cmd::MountArgs {
@@ -761,7 +791,7 @@ async fn handle_appfs_adapter_command_with_startup_context(
         match (action_wake.as_ref(), interval.as_mut()) {
             (Some(wake), Some(interval)) => {
                 tokio::select! {
-                    _ = tokio::signal::ctrl_c() => {
+                    _ = crate::shutdown_signal::wait_for_shutdown_signal() => {
                         eprintln!("AppFS adapter stopping...");
                         return Ok(());
                     }
@@ -779,7 +809,7 @@ async fn handle_appfs_adapter_command_with_startup_context(
             }
             (Some(wake), None) => {
                 tokio::select! {
-                    _ = tokio::signal::ctrl_c() => {
+                    _ = crate::shutdown_signal::wait_for_shutdown_signal() => {
                         eprintln!("AppFS adapter stopping...");
                         return Ok(());
                     }
@@ -792,7 +822,7 @@ async fn handle_appfs_adapter_command_with_startup_context(
             }
             (None, Some(interval)) => {
                 tokio::select! {
-                    _ = tokio::signal::ctrl_c() => {
+                    _ = crate::shutdown_signal::wait_for_shutdown_signal() => {
                         eprintln!("AppFS adapter stopping...");
                         return Ok(());
                     }
@@ -804,7 +834,7 @@ async fn handle_appfs_adapter_command_with_startup_context(
                 }
             }
             (None, None) => {
-                tokio::signal::ctrl_c().await?;
+                crate::shutdown_signal::wait_for_shutdown_signal().await?;
                 eprintln!("AppFS adapter stopping...");
                 return Ok(());
             }
@@ -1082,6 +1112,89 @@ fn refresh_runtime_parent_directory(path: &Path) {
 
 pub async fn handle_appfs_up_command(args: AppfsUpArgs) -> Result<()> {
     run_managed_appfs_with_bootstrap(args, |_| Ok(()), None).await
+}
+
+pub async fn handle_appfs_query_tree_command(args: AppfsQueryTreeArgs) -> Result<()> {
+    let db_path = args
+        .db
+        .to_str()
+        .ok_or_else(|| anyhow::anyhow!("query db path must be valid UTF-8: {}", args.db.display()))?
+        .to_string();
+    let agent = crate::cmd::init::open_agentfs(AgentFSOptions::with_path(db_path)).await?;
+    let result = agent
+        .query_tree(AgentFsTreeQuery {
+            root: args.root,
+            max_depth: args.max_depth,
+            max_entries_per_dir: args.max_entries_per_dir,
+            include_files: args.include_files,
+            exclude_internal: !args.include_internal,
+        })
+        .await?;
+    match args.format {
+        AppfsQueryFormat::Json => {
+            println!("{}", serde_json::to_string_pretty(&result)?);
+        }
+        AppfsQueryFormat::Text => print_tree_query_text(&result),
+    }
+    Ok(())
+}
+
+pub async fn handle_appfs_query_glob_command(args: AppfsQueryGlobArgs) -> Result<()> {
+    let db_path = args
+        .db
+        .to_str()
+        .ok_or_else(|| anyhow::anyhow!("query db path must be valid UTF-8: {}", args.db.display()))?
+        .to_string();
+    let agent = crate::cmd::init::open_agentfs(AgentFSOptions::with_path(db_path)).await?;
+    let result = agent
+        .query_glob(AgentFsGlobQuery {
+            root: args.root,
+            pattern: args.pattern,
+            max_depth: args.max_depth,
+            max_results: args.max_results,
+            max_scanned_entries: args.max_scanned_entries,
+            include_dirs: args.include_dirs,
+            case_sensitive: !args.ignore_case,
+            exclude_internal: !args.include_internal,
+        })
+        .await?;
+    match args.format {
+        AppfsQueryFormat::Json => {
+            println!("{}", serde_json::to_string_pretty(&result)?);
+        }
+        AppfsQueryFormat::Text => print_glob_query_text(&result),
+    }
+    Ok(())
+}
+
+fn print_tree_query_text(result: &AgentFsTreeQueryResult) {
+    for entry in &result.entries {
+        let indent = "  ".repeat(entry.depth.saturating_sub(1));
+        let suffix = if entry.kind == AgentFsQueryEntryKind::Directory {
+            "/"
+        } else {
+            ""
+        };
+        println!("{indent}{}{suffix}", entry.name);
+    }
+    if result.truncated {
+        eprintln!(
+            "tree output truncated after scanning {} entries",
+            result.scanned_entries
+        );
+    }
+}
+
+fn print_glob_query_text(result: &AgentFsGlobQueryResult) {
+    for entry in &result.results {
+        println!("{}", entry.path);
+    }
+    if result.truncated {
+        eprintln!(
+            "glob output truncated after scanning {} entries",
+            result.scanned_entries
+        );
+    }
 }
 
 pub async fn handle_appfs_compose_up_command(compose_path: Option<PathBuf>) -> Result<()> {

--- a/cli/src/cmd/appfs.rs
+++ b/cli/src/cmd/appfs.rs
@@ -38,7 +38,7 @@ mod supervisor_control;
 mod tests;
 mod tree_sync;
 
-use journal::SnapshotExpandJournalEntry;
+use journal::{SnapshotExpandJournalDoc, SnapshotExpandJournalEntry};
 pub(crate) use runtime_config::{
     build_appfs_bridge_config, build_runtime_cli_args, normalize_appfs_session_id,
     resolve_runtime_cli_args, AppfsBridgeCliArgs, AppfsBridgeConfig, AppfsRuntimeCliArgs,
@@ -77,12 +77,27 @@ const ALLOWED_SEGMENT_CHARS: &str =
 #[derive(Clone, Debug)]
 enum ManagedRuntimeBootstrapEntry {
     Dir { rel_path: String },
-    File { rel_path: String, bytes: Vec<u8> },
 }
 
 #[derive(Clone, Debug, Default)]
 struct ManagedRuntimeBootstrapPlan {
     entries: Vec<ManagedRuntimeBootstrapEntry>,
+}
+
+#[derive(Clone, Debug)]
+struct AppRuntimeStartupBootstrap {
+    manifest_json: String,
+    cursor: CursorState,
+    action_cursors: HashMap<String, ActionCursorState>,
+    snapshot_expand_journal: HashMap<String, SnapshotExpandJournalEntry>,
+    streaming_jobs: Vec<StreamingJob>,
+}
+
+#[derive(Clone)]
+struct ManagedRuntimeStartupContext {
+    runtime_args: Vec<ResolvedAppfsRuntimeCliArgs>,
+    existing_registry: Option<registry::AppfsAppsRegistryDoc>,
+    app_bootstrap: HashMap<String, AppRuntimeStartupBootstrap>,
 }
 
 #[derive(Clone)]
@@ -552,7 +567,11 @@ async fn prepare_compose_runtime(runtime: &compose::schema::AppfsComposeRuntime)
     Ok(db_path)
 }
 
-async fn run_managed_appfs_with_bootstrap<F>(args: AppfsUpArgs, bootstrap: F) -> Result<()>
+async fn run_managed_appfs_with_bootstrap<F>(
+    args: AppfsUpArgs,
+    bootstrap: F,
+    startup_context: Option<ManagedRuntimeStartupContext>,
+) -> Result<()>
 where
     F: FnOnce(&Path) -> Result<()>,
 {
@@ -592,24 +611,27 @@ where
 
     bootstrap(&mountpoint)?;
 
-    let runtime_result = handle_appfs_adapter_command(AppfsServeArgs {
-        root: mountpoint,
-        managed: true,
-        app_id: None,
-        app_ids: Vec::new(),
-        session_id: None,
-        poll_ms: args.poll_ms,
-        action_wake: Some(action_wake),
-        adapter_http_endpoint: None,
-        adapter_http_timeout_ms: 5_000,
-        adapter_grpc_endpoint: None,
-        adapter_grpc_timeout_ms: 5_000,
-        adapter_bridge_max_retries: 2,
-        adapter_bridge_initial_backoff_ms: 100,
-        adapter_bridge_max_backoff_ms: 1_000,
-        adapter_bridge_circuit_breaker_failures: 5,
-        adapter_bridge_circuit_breaker_cooldown_ms: 3_000,
-    })
+    let runtime_result = handle_appfs_adapter_command_with_startup_context(
+        AppfsServeArgs {
+            root: mountpoint,
+            managed: true,
+            app_id: None,
+            app_ids: Vec::new(),
+            session_id: None,
+            poll_ms: args.poll_ms,
+            action_wake: Some(action_wake),
+            adapter_http_endpoint: None,
+            adapter_http_timeout_ms: 5_000,
+            adapter_grpc_endpoint: None,
+            adapter_grpc_timeout_ms: 5_000,
+            adapter_bridge_max_retries: 2,
+            adapter_bridge_initial_backoff_ms: 100,
+            adapter_bridge_max_backoff_ms: 1_000,
+            adapter_bridge_circuit_breaker_failures: 5,
+            adapter_bridge_circuit_breaker_cooldown_ms: 3_000,
+        },
+        startup_context,
+    )
     .await;
 
     if let Err(err) = runtime_result {
@@ -626,6 +648,13 @@ where
 }
 
 pub async fn handle_appfs_adapter_command(args: AppfsServeArgs) -> Result<()> {
+    handle_appfs_adapter_command_with_startup_context(args, None).await
+}
+
+async fn handle_appfs_adapter_command_with_startup_context(
+    args: AppfsServeArgs,
+    startup_context: Option<ManagedRuntimeStartupContext>,
+) -> Result<()> {
     let AppfsServeArgs {
         root,
         managed,
@@ -656,32 +685,46 @@ pub async fn handle_appfs_adapter_command(args: AppfsServeArgs) -> Result<()> {
         adapter_bridge_circuit_breaker_failures,
         adapter_bridge_circuit_breaker_cooldown_ms,
     };
-    let (runtime_args, existing_registry) = if managed {
-        if app_id.is_some()
-            || !app_ids.is_empty()
-            || session_id.is_some()
-            || bridge_args.adapter_http_endpoint.is_some()
-            || bridge_args.adapter_grpc_endpoint.is_some()
-        {
-            anyhow::bail!(
-                "--managed does not accept explicit --app-id/--app/--session-id/adapter endpoint bootstrap flags; load them from the persisted AppFS registry instead"
-            );
+    let (resolved_runtime_args, existing_registry) = if managed {
+        if let Some(context) = startup_context.as_ref() {
+            (
+                context.runtime_args.clone(),
+                context.existing_registry.clone(),
+            )
+        } else {
+            if app_id.is_some()
+                || !app_ids.is_empty()
+                || session_id.is_some()
+                || bridge_args.adapter_http_endpoint.is_some()
+                || bridge_args.adapter_grpc_endpoint.is_some()
+            {
+                anyhow::bail!(
+                    "--managed does not accept explicit --app-id/--app/--session-id/adapter endpoint bootstrap flags; load them from the persisted AppFS registry instead"
+                );
+            }
+            let existing = registry::read_app_registry(&root)?;
+            let runtime_args = match existing.as_ref() {
+                Some(doc) => registry::runtime_args_from_registry(doc)?,
+                None => Vec::new(),
+            };
+            (resolve_runtime_cli_args(runtime_args), existing)
         }
-        let existing = registry::read_app_registry(&root)?;
-        let runtime_args = match existing.as_ref() {
-            Some(doc) => registry::runtime_args_from_registry(doc)?,
-            None => Vec::new(),
-        };
-        (runtime_args, existing)
     } else {
         (
-            build_runtime_cli_args(app_id, app_ids, session_id, bridge_args, Some("aiim"))?,
+            resolve_runtime_cli_args(build_runtime_cli_args(
+                app_id,
+                app_ids,
+                session_id,
+                bridge_args,
+                Some("aiim"),
+            )?),
             None,
         )
     };
-    let resolved_runtime_args = resolve_runtime_cli_args(runtime_args);
-    wait_for_managed_runtime_paths_ready(&root, &resolved_runtime_args)?;
-    let mut supervisor = AppfsRuntimeSupervisor::new(root, resolved_runtime_args, managed)?;
+    wait_for_managed_runtime_paths_ready(&root, &resolved_runtime_args, startup_context.as_ref())?;
+    let startup_bootstrap = startup_context.map(|context| context.app_bootstrap);
+    let mut supervisor =
+        AppfsRuntimeSupervisor::new(root, resolved_runtime_args, managed, startup_bootstrap)?;
     supervisor.prepare_action_sinks()?;
     supervisor.sync_registry_to_disk(existing_registry.as_ref())?;
     supervisor.log_started();
@@ -771,11 +814,13 @@ pub async fn handle_appfs_adapter_command(args: AppfsServeArgs) -> Result<()> {
 fn wait_for_managed_runtime_paths_ready(
     root: &Path,
     runtime_args: &[ResolvedAppfsRuntimeCliArgs],
+    startup_context: Option<&ManagedRuntimeStartupContext>,
 ) -> Result<()> {
     #[cfg(not(target_os = "windows"))]
     {
         let _ = root;
         let _ = runtime_args;
+        let _ = startup_context;
         Ok(())
     }
 
@@ -794,44 +839,56 @@ fn wait_for_managed_runtime_paths_ready(
 
         for runtime in runtime_args {
             let app_dir = root.join(&runtime.app_id);
-            let critical_paths = [
-                (app_dir.clone(), true, "app root"),
-                (app_dir.join("_meta"), true, "manifest parent"),
-                (
-                    app_dir.join("_meta").join("manifest.res.json"),
-                    false,
-                    "manifest",
-                ),
-                (app_dir.join("_stream"), true, "stream dir"),
-                (app_dir.join("_stream").join("from-seq"), true, "replay dir"),
-                (
-                    app_dir.join("_stream").join("events.evt.jsonl"),
-                    false,
-                    "events stream",
-                ),
-                (
-                    app_dir.join("_stream").join("cursor.res.json"),
-                    false,
-                    "cursor file",
-                ),
-                (
-                    app_dir.join("_stream").join("inflight.jobs.res.json"),
-                    false,
-                    "jobs file",
-                ),
-                (
-                    app_dir.join("_stream").join(ACTION_CURSORS_FILENAME),
-                    false,
-                    "action cursors file",
-                ),
-                (
-                    app_dir
-                        .join("_stream")
-                        .join(SNAPSHOT_EXPAND_JOURNAL_FILENAME),
-                    false,
-                    "snapshot journal",
-                ),
-            ];
+            let has_db_bootstrap = startup_context
+                .and_then(|ctx| ctx.app_bootstrap.get(&runtime.app_id))
+                .is_some();
+            let critical_paths = if has_db_bootstrap {
+                vec![
+                    (app_dir.clone(), true, "app root"),
+                    (app_dir.join("_meta"), true, "manifest parent"),
+                    (app_dir.join("_stream"), true, "stream dir"),
+                    (app_dir.join("_stream").join("from-seq"), true, "replay dir"),
+                ]
+            } else {
+                vec![
+                    (app_dir.clone(), true, "app root"),
+                    (app_dir.join("_meta"), true, "manifest parent"),
+                    (
+                        app_dir.join("_meta").join("manifest.res.json"),
+                        false,
+                        "manifest",
+                    ),
+                    (app_dir.join("_stream"), true, "stream dir"),
+                    (app_dir.join("_stream").join("from-seq"), true, "replay dir"),
+                    (
+                        app_dir.join("_stream").join("events.evt.jsonl"),
+                        false,
+                        "events stream",
+                    ),
+                    (
+                        app_dir.join("_stream").join("cursor.res.json"),
+                        false,
+                        "cursor file",
+                    ),
+                    (
+                        app_dir.join("_stream").join("inflight.jobs.res.json"),
+                        false,
+                        "jobs file",
+                    ),
+                    (
+                        app_dir.join("_stream").join(ACTION_CURSORS_FILENAME),
+                        false,
+                        "action cursors file",
+                    ),
+                    (
+                        app_dir
+                            .join("_stream")
+                            .join(SNAPSHOT_EXPAND_JOURNAL_FILENAME),
+                        false,
+                        "snapshot journal",
+                    ),
+                ]
+            };
 
             for (path, expect_dir, label) in critical_paths {
                 wait_for_runtime_path_visibility(&path, expect_dir).with_context(|| {
@@ -849,19 +906,13 @@ fn wait_for_managed_runtime_paths_ready(
 }
 
 async fn build_managed_runtime_bootstrap_plan(
-    agent: &SdkAgentFS,
+    _agent: &SdkAgentFS,
     app_ids: &[String],
 ) -> Result<ManagedRuntimeBootstrapPlan> {
     let mut plan = ManagedRuntimeBootstrapPlan::default();
     plan.entries.push(ManagedRuntimeBootstrapEntry::Dir {
         rel_path: "_appfs".to_string(),
     });
-    if let Some(bytes) = agent.fs.read_file("/_appfs/apps.registry.json").await? {
-        plan.entries.push(ManagedRuntimeBootstrapEntry::File {
-            rel_path: "_appfs/apps.registry.json".to_string(),
-            bytes,
-        });
-    }
 
     for app_id in app_ids {
         let app_root = app_id.clone();
@@ -874,25 +925,96 @@ async fn build_managed_runtime_bootstrap_plan(
             plan.entries
                 .push(ManagedRuntimeBootstrapEntry::Dir { rel_path });
         }
-
-        for rel_path in [
-            format!("{app_root}/_meta/manifest.res.json"),
-            format!("{app_root}/_stream/events.evt.jsonl"),
-            format!("{app_root}/_stream/cursor.res.json"),
-            format!("{app_root}/_stream/inflight.jobs.res.json"),
-            format!("{app_root}/_stream/{ACTION_CURSORS_FILENAME}"),
-            format!("{app_root}/_stream/{SNAPSHOT_EXPAND_JOURNAL_FILENAME}"),
-        ] {
-            let abs = format!("/{rel_path}");
-            let Some(bytes) = agent.fs.read_file(&abs).await? else {
-                anyhow::bail!("managed runtime bootstrap source missing from db: {abs}");
-            };
-            plan.entries
-                .push(ManagedRuntimeBootstrapEntry::File { rel_path, bytes });
-        }
     }
 
     Ok(plan)
+}
+
+async fn build_managed_runtime_startup_context(
+    agent: &SdkAgentFS,
+    registry_doc: registry::AppfsAppsRegistryDoc,
+    runtime_args: Vec<ResolvedAppfsRuntimeCliArgs>,
+) -> Result<ManagedRuntimeStartupContext> {
+    let mut app_bootstrap = HashMap::new();
+    for runtime in &runtime_args {
+        let app_id = &runtime.app_id;
+        let manifest_path = format!("/{app_id}/_meta/manifest.res.json");
+        let manifest_bytes = agent.fs.read_file(&manifest_path).await?.ok_or_else(|| {
+            anyhow::anyhow!("managed runtime bootstrap source missing from db: {manifest_path}")
+        })?;
+        let manifest_json = String::from_utf8(manifest_bytes).with_context(|| {
+            format!("managed runtime bootstrap manifest is not valid UTF-8: {manifest_path}")
+        })?;
+
+        let cursor_path = format!("/{app_id}/_stream/cursor.res.json");
+        let cursor: CursorState =
+            serde_json::from_slice(&agent.fs.read_file(&cursor_path).await?.ok_or_else(|| {
+                anyhow::anyhow!("managed runtime bootstrap source missing from db: {cursor_path}")
+            })?)
+            .with_context(|| {
+                format!(
+                    "failed to parse managed runtime bootstrap cursor {}",
+                    cursor_path
+                )
+            })?;
+
+        let action_cursors_path = format!("/{app_id}/_stream/{ACTION_CURSORS_FILENAME}");
+        let action_cursors: ActionCursorDoc =
+            serde_json::from_slice(&agent.fs.read_file(&action_cursors_path).await?.ok_or_else(
+                || {
+                    anyhow::anyhow!(
+                        "managed runtime bootstrap source missing from db: {action_cursors_path}"
+                    )
+                },
+            )?)
+            .with_context(|| {
+                format!(
+                    "failed to parse managed runtime bootstrap action cursors {}",
+                    action_cursors_path
+                )
+            })?;
+
+        let journal_path = format!("/{app_id}/_stream/{SNAPSHOT_EXPAND_JOURNAL_FILENAME}");
+        let snapshot_expand_journal: SnapshotExpandJournalDoc =
+            serde_json::from_slice(&agent.fs.read_file(&journal_path).await?.ok_or_else(|| {
+                anyhow::anyhow!("managed runtime bootstrap source missing from db: {journal_path}")
+            })?)
+            .with_context(|| {
+                format!(
+                    "failed to parse managed runtime bootstrap snapshot journal {}",
+                    journal_path
+                )
+            })?;
+
+        let jobs_path = format!("/{app_id}/_stream/inflight.jobs.res.json");
+        let streaming_jobs: Vec<StreamingJob> =
+            serde_json::from_slice(&agent.fs.read_file(&jobs_path).await?.ok_or_else(|| {
+                anyhow::anyhow!("managed runtime bootstrap source missing from db: {jobs_path}")
+            })?)
+            .with_context(|| {
+                format!(
+                    "failed to parse managed runtime bootstrap jobs {}",
+                    jobs_path
+                )
+            })?;
+
+        app_bootstrap.insert(
+            app_id.clone(),
+            AppRuntimeStartupBootstrap {
+                manifest_json,
+                cursor,
+                action_cursors: action_cursors.actions,
+                snapshot_expand_journal: snapshot_expand_journal.resources,
+                streaming_jobs,
+            },
+        );
+    }
+
+    Ok(ManagedRuntimeStartupContext {
+        runtime_args,
+        existing_registry: Some(registry_doc),
+        app_bootstrap,
+    })
 }
 
 fn apply_managed_runtime_bootstrap_plan(
@@ -913,36 +1035,6 @@ fn apply_managed_runtime_bootstrap_plan(
                 wait_for_runtime_path_visibility(&path, true).with_context(|| {
                     format!(
                         "managed runtime startup path is not visible yet after directory bootstrap: {}",
-                        path.display()
-                    )
-                })?;
-            }
-            ManagedRuntimeBootstrapEntry::File { rel_path, bytes } => {
-                let path = mount_root.join(rel_path);
-                if let Some(parent) = path.parent() {
-                    std::fs::create_dir_all(parent).with_context(|| {
-                        format!(
-                            "failed to precreate managed runtime parent dir {}",
-                            parent.display()
-                        )
-                    })?;
-                }
-                let needs_write = match std::fs::read(&path) {
-                    Ok(existing) => existing != *bytes,
-                    Err(_) => true,
-                };
-                if needs_write {
-                    std::fs::write(&path, bytes).with_context(|| {
-                        format!(
-                            "failed to precreate managed runtime file on mount {}",
-                            path.display()
-                        )
-                    })?;
-                }
-                #[cfg(target_os = "windows")]
-                wait_for_runtime_path_visibility(&path, false).with_context(|| {
-                    format!(
-                        "managed runtime startup path is not readable yet after file bootstrap: {}",
                         path.display()
                     )
                 })?;
@@ -986,7 +1078,7 @@ fn refresh_runtime_parent_directory(path: &Path) {
 }
 
 pub async fn handle_appfs_up_command(args: AppfsUpArgs) -> Result<()> {
-    run_managed_appfs_with_bootstrap(args, |_| Ok(())).await
+    run_managed_appfs_with_bootstrap(args, |_| Ok(()), None).await
 }
 
 pub async fn handle_appfs_compose_up_command(compose_path: Option<PathBuf>) -> Result<()> {
@@ -998,8 +1090,11 @@ pub async fn handle_appfs_compose_up_command(compose_path: Option<PathBuf>) -> R
         compose::connector_supervisor::ComposeConnectorSupervisor::resolve_apps(&compose_doc)?;
 
     let agent = agentfs_sdk::AgentFS::open(AgentFSOptions::with_path(db_path.clone())).await?;
-    compose::reconcile::bootstrap_registry_from_resolved_apps_in_agentfs(&agent, &resolved_apps)
-        .await?;
+    let registry_doc = compose::reconcile::bootstrap_registry_from_resolved_apps_in_agentfs(
+        &agent,
+        &resolved_apps,
+    )
+    .await?;
     for resolved_app in resolved_apps.values() {
         let session_id = normalize_appfs_session_id(resolved_app.session_id.clone());
         let bridge_config =
@@ -1017,6 +1112,10 @@ pub async fn handle_appfs_compose_up_command(compose_path: Option<PathBuf>) -> R
         .map(|app| app.app_id.clone())
         .collect::<Vec<_>>();
     let startup_plan = build_managed_runtime_bootstrap_plan(&agent, &startup_app_ids).await?;
+    let resolved_runtime_args =
+        resolve_runtime_cli_args(registry::runtime_args_from_registry(&registry_doc)?);
+    let startup_context =
+        build_managed_runtime_startup_context(&agent, registry_doc, resolved_runtime_args).await?;
     drop(agent);
 
     let result = run_managed_appfs_with_bootstrap(
@@ -1032,6 +1131,7 @@ pub async fn handle_appfs_compose_up_command(compose_path: Option<PathBuf>) -> R
             poll_ms: compose_doc.runtime.poll_ms,
         },
         move |mount_root| apply_managed_runtime_bootstrap_plan(mount_root, &startup_plan),
+        Some(startup_context),
     )
     .await;
 
@@ -1688,6 +1788,7 @@ mod supervisor_tests {
             temp.path().to_path_buf(),
             resolve_runtime_cli_args(runtime_args),
             false,
+            None,
         )
         .expect("supervisor");
         supervisor.prepare_action_sinks().expect("prepare sinks");
@@ -1737,6 +1838,7 @@ mod supervisor_tests {
             temp.path().to_path_buf(),
             resolve_runtime_cli_args(runtime_args),
             false,
+            None,
         )
         .expect("supervisor");
         supervisor.prepare_action_sinks().expect("prepare sinks");
@@ -1781,6 +1883,7 @@ mod supervisor_tests {
             temp.path().to_path_buf(),
             resolve_runtime_cli_args(runtime_args),
             false,
+            None,
         )
         .expect("supervisor");
         supervisor.prepare_action_sinks().expect("prepare sinks");
@@ -1815,6 +1918,7 @@ mod supervisor_tests {
             temp.path().to_path_buf(),
             resolve_runtime_cli_args(runtime_args),
             false,
+            None,
         )
         .expect("supervisor");
         supervisor.prepare_action_sinks().expect("prepare sinks");
@@ -1870,7 +1974,7 @@ mod supervisor_tests {
     fn supervisor_can_register_app_dynamically_from_empty_runtime() {
         let temp = TempDir::new().expect("tempdir");
         let mut supervisor =
-            AppfsRuntimeSupervisor::new(temp.path().to_path_buf(), Vec::new(), false)
+            AppfsRuntimeSupervisor::new(temp.path().to_path_buf(), Vec::new(), false, None)
                 .expect("supervisor");
         supervisor.prepare_action_sinks().expect("prepare sinks");
 
@@ -1912,6 +2016,7 @@ mod supervisor_tests {
             temp.path().to_path_buf(),
             resolve_runtime_cli_args(runtime_args),
             false,
+            None,
         )
         .expect("supervisor");
         supervisor.prepare_action_sinks().expect("prepare sinks");

--- a/cli/src/cmd/appfs.rs
+++ b/cli/src/cmd/appfs.rs
@@ -768,6 +768,23 @@ pub async fn handle_appfs_compose_up_command(compose_path: Option<PathBuf>) -> R
     let (mut connector_supervisor, resolved_apps) =
         compose::connector_supervisor::ComposeConnectorSupervisor::resolve_apps(&compose_doc)?;
 
+    let agent = agentfs_sdk::AgentFS::open(AgentFSOptions::with_path(db_path.clone())).await?;
+    compose::reconcile::bootstrap_registry_from_resolved_apps_in_agentfs(&agent, &resolved_apps)
+        .await?;
+    for resolved_app in resolved_apps.values() {
+        let session_id = normalize_appfs_session_id(resolved_app.session_id.clone());
+        let bridge_config =
+            build_appfs_bridge_config(bridge_args_from_resolved_compose_app(resolved_app));
+        tree_sync::ensure_app_structure_initialized_in_db(
+            &agent,
+            &resolved_app.app_id,
+            &session_id,
+            &bridge_config,
+        )
+        .await?;
+    }
+    drop(agent);
+
     let result = run_managed_appfs_with_bootstrap(
         AppfsUpArgs {
             id_or_path: db_path,
@@ -780,15 +797,36 @@ pub async fn handle_appfs_compose_up_command(compose_path: Option<PathBuf>) -> R
             gid: compose_doc.runtime.gid,
             poll_ms: compose_doc.runtime.poll_ms,
         },
-        |root| {
-            compose::reconcile::bootstrap_registry_from_resolved_apps(root, &resolved_apps)?;
-            Ok(())
-        },
+        |_| Ok(()),
     )
     .await;
 
     connector_supervisor.shutdown();
     result
+}
+
+fn bridge_args_from_resolved_compose_app(
+    app: &compose::connector_supervisor::ResolvedComposeApp,
+) -> AppfsBridgeCliArgs {
+    AppfsBridgeCliArgs {
+        adapter_http_endpoint: match app.transport_kind {
+            compose::schema::AppfsComposeTransportKind::Http => Some(app.endpoint.clone()),
+            compose::schema::AppfsComposeTransportKind::Grpc => None,
+        },
+        adapter_http_timeout_ms: app.transport.http_timeout_ms,
+        adapter_grpc_endpoint: match app.transport_kind {
+            compose::schema::AppfsComposeTransportKind::Http => None,
+            compose::schema::AppfsComposeTransportKind::Grpc => Some(app.endpoint.clone()),
+        },
+        adapter_grpc_timeout_ms: app.transport.grpc_timeout_ms,
+        adapter_bridge_max_retries: app.transport.bridge_max_retries,
+        adapter_bridge_initial_backoff_ms: app.transport.bridge_initial_backoff_ms,
+        adapter_bridge_max_backoff_ms: app.transport.bridge_max_backoff_ms,
+        adapter_bridge_circuit_breaker_failures: app.transport.bridge_circuit_breaker_failures,
+        adapter_bridge_circuit_breaker_cooldown_ms: app
+            .transport
+            .bridge_circuit_breaker_cooldown_ms,
+    }
 }
 
 pub async fn handle_appfs_launch_command(args: AppfsLaunchArgs) -> Result<()> {

--- a/cli/src/cmd/appfs.rs
+++ b/cli/src/cmd/appfs.rs
@@ -86,6 +86,7 @@ struct ManagedRuntimeBootstrapPlan {
 
 #[derive(Clone, Debug)]
 struct AppRuntimeStartupBootstrap {
+    db_path: String,
     manifest_json: String,
     cursor: CursorState,
     action_cursors: HashMap<String, ActionCursorState>,
@@ -934,6 +935,7 @@ async fn build_managed_runtime_startup_context(
     agent: &SdkAgentFS,
     registry_doc: registry::AppfsAppsRegistryDoc,
     runtime_args: Vec<ResolvedAppfsRuntimeCliArgs>,
+    db_path: &str,
 ) -> Result<ManagedRuntimeStartupContext> {
     let mut app_bootstrap = HashMap::new();
     for runtime in &runtime_args {
@@ -1001,6 +1003,7 @@ async fn build_managed_runtime_startup_context(
         app_bootstrap.insert(
             app_id.clone(),
             AppRuntimeStartupBootstrap {
+                db_path: db_path.to_string(),
                 manifest_json,
                 cursor,
                 action_cursors: action_cursors.actions,
@@ -1114,8 +1117,13 @@ pub async fn handle_appfs_compose_up_command(compose_path: Option<PathBuf>) -> R
     let startup_plan = build_managed_runtime_bootstrap_plan(&agent, &startup_app_ids).await?;
     let resolved_runtime_args =
         resolve_runtime_cli_args(registry::runtime_args_from_registry(&registry_doc)?);
-    let startup_context =
-        build_managed_runtime_startup_context(&agent, registry_doc, resolved_runtime_args).await?;
+    let startup_context = build_managed_runtime_startup_context(
+        &agent,
+        registry_doc,
+        resolved_runtime_args,
+        &db_path,
+    )
+    .await?;
     drop(agent);
 
     let result = run_managed_appfs_with_bootstrap(
@@ -1394,6 +1402,7 @@ struct AppfsAdapter {
     app_id: String,
     session_id: String,
     app_dir: PathBuf,
+    direct_db_path: Option<String>,
     action_specs: Vec<ActionSpec>,
     snapshot_specs: Vec<SnapshotSpec>,
     events_path: PathBuf,

--- a/cli/src/cmd/appfs.rs
+++ b/cli/src/cmd/appfs.rs
@@ -669,6 +669,7 @@ pub async fn handle_appfs_adapter_command(args: AppfsServeArgs) -> Result<()> {
         )
     };
     let resolved_runtime_args = resolve_runtime_cli_args(runtime_args);
+    wait_for_managed_runtime_paths_ready(&root, &resolved_runtime_args)?;
     let mut supervisor = AppfsRuntimeSupervisor::new(root, resolved_runtime_args, managed)?;
     supervisor.prepare_action_sinks()?;
     supervisor.sync_registry_to_disk(existing_registry.as_ref())?;
@@ -753,6 +754,119 @@ pub async fn handle_appfs_adapter_command(args: AppfsServeArgs) -> Result<()> {
                 return Ok(());
             }
         }
+    }
+}
+
+fn wait_for_managed_runtime_paths_ready(
+    root: &Path,
+    runtime_args: &[ResolvedAppfsRuntimeCliArgs],
+) -> Result<()> {
+    #[cfg(not(target_os = "windows"))]
+    {
+        let _ = root;
+        let _ = runtime_args;
+        Ok(())
+    }
+
+    #[cfg(target_os = "windows")]
+    {
+        if runtime_args.is_empty() {
+            return Ok(());
+        }
+
+        wait_for_runtime_path_visibility(root, true).with_context(|| {
+            format!(
+                "AppFS mount root is not visible yet for managed runtime startup: {}",
+                root.display()
+            )
+        })?;
+
+        for runtime in runtime_args {
+            let app_dir = root.join(&runtime.app_id);
+            let critical_paths = [
+                (app_dir.clone(), true, "app root"),
+                (app_dir.join("_meta"), true, "manifest parent"),
+                (
+                    app_dir.join("_meta").join("manifest.res.json"),
+                    false,
+                    "manifest",
+                ),
+                (app_dir.join("_stream"), true, "stream dir"),
+                (app_dir.join("_stream").join("from-seq"), true, "replay dir"),
+                (
+                    app_dir.join("_stream").join("events.evt.jsonl"),
+                    false,
+                    "events stream",
+                ),
+                (
+                    app_dir.join("_stream").join("cursor.res.json"),
+                    false,
+                    "cursor file",
+                ),
+                (
+                    app_dir.join("_stream").join("inflight.jobs.res.json"),
+                    false,
+                    "jobs file",
+                ),
+                (
+                    app_dir.join("_stream").join(ACTION_CURSORS_FILENAME),
+                    false,
+                    "action cursors file",
+                ),
+                (
+                    app_dir
+                        .join("_stream")
+                        .join(SNAPSHOT_EXPAND_JOURNAL_FILENAME),
+                    false,
+                    "snapshot journal",
+                ),
+            ];
+
+            for (path, expect_dir, label) in critical_paths {
+                wait_for_runtime_path_visibility(&path, expect_dir).with_context(|| {
+                    format!(
+                        "managed runtime startup path is not visible yet for app {} ({label}): {}",
+                        runtime.app_id,
+                        path.display()
+                    )
+                })?;
+            }
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(target_os = "windows")]
+fn wait_for_runtime_path_visibility(path: &Path, expect_dir: bool) -> Result<()> {
+    const MAX_ATTEMPTS: usize = 40;
+    for attempt in 0..MAX_ATTEMPTS {
+        refresh_runtime_parent_directory(path);
+        let visible = if expect_dir {
+            path.is_dir()
+        } else {
+            path.is_file()
+        };
+        if visible {
+            return Ok(());
+        }
+        if attempt + 1 < MAX_ATTEMPTS {
+            std::thread::sleep(Duration::from_millis(20 * (attempt + 1) as u64));
+        }
+    }
+    anyhow::bail!(
+        "path did not become visible in time: {} (expect_dir={expect_dir})",
+        path.display()
+    )
+}
+
+#[cfg(target_os = "windows")]
+fn refresh_runtime_parent_directory(path: &Path) {
+    let Some(parent) = path.parent() else {
+        return;
+    };
+    if let Ok(entries) = std::fs::read_dir(parent) {
+        for _ in entries.take(1) {}
     }
 }
 

--- a/cli/src/cmd/appfs.rs
+++ b/cli/src/cmd/appfs.rs
@@ -842,12 +842,12 @@ fn wait_for_runtime_path_visibility(path: &Path, expect_dir: bool) -> Result<()>
     const MAX_ATTEMPTS: usize = 40;
     for attempt in 0..MAX_ATTEMPTS {
         refresh_runtime_parent_directory(path);
-        let visible = if expect_dir {
+        let ready = if expect_dir {
             path.is_dir()
         } else {
-            path.is_file()
+            path.is_file() && std::fs::read(path).is_ok()
         };
-        if visible {
+        if ready {
             return Ok(());
         }
         if attempt + 1 < MAX_ATTEMPTS {

--- a/cli/src/cmd/appfs/compose/reconcile.rs
+++ b/cli/src/cmd/appfs/compose/reconcile.rs
@@ -1,6 +1,7 @@
 use super::connector_supervisor::ResolvedComposeApp;
 use crate::cmd::appfs::normalize_appfs_session_id;
 use crate::cmd::appfs::registry;
+use agentfs_sdk::{AgentFS as SdkAgentFS, BulkMaterializeEntry, BulkMaterializePlan};
 use anyhow::Result;
 use std::collections::{BTreeMap, HashMap};
 use std::path::Path;
@@ -48,6 +49,27 @@ pub(crate) fn bootstrap_registry_from_resolved_apps(
     let doc = build_registry_doc_from_resolved_apps(resolved_apps, existing.as_ref());
     if existing.as_ref() != Some(&doc) {
         registry::write_app_registry(root, &doc)?;
+    }
+    Ok(doc)
+}
+
+pub(crate) async fn bootstrap_registry_from_resolved_apps_in_agentfs(
+    agent: &SdkAgentFS,
+    resolved_apps: &BTreeMap<String, ResolvedComposeApp>,
+) -> Result<registry::AppfsAppsRegistryDoc> {
+    let existing = match agent.fs.read_file("/_appfs/apps.registry.json").await? {
+        Some(bytes) => Some(registry::parse_app_registry_bytes(&bytes)?),
+        None => None,
+    };
+    let doc = build_registry_doc_from_resolved_apps(resolved_apps, existing.as_ref());
+    if existing.as_ref() != Some(&doc) {
+        let mut plan = BulkMaterializePlan::new();
+        plan.push(BulkMaterializeEntry::ensure_dir("/_appfs"));
+        plan.push(BulkMaterializeEntry::write_file(
+            "/_appfs/apps.registry.json",
+            serde_json::to_vec_pretty(&doc)?,
+        ));
+        agent.bulk_materialize_tree(&plan).await?;
     }
     Ok(doc)
 }

--- a/cli/src/cmd/appfs/core.rs
+++ b/cli/src/cmd/appfs/core.rs
@@ -1,9 +1,9 @@
 use agentfs_sdk::{
-    connector_error_codes, ActionExecutionMode, AppAdapterV1, AppConnector, AppStructureSyncReason,
-    AuthStatus, ConnectorContext, ConnectorError, ConnectorInfo, ConnectorTransport,
-    DemoAppConnector, FetchLivePageRequest, FetchLivePageResponse, FetchSnapshotChunkRequest,
-    FetchSnapshotChunkResponse, HealthStatus, SnapshotMeta, SubmitActionOutcome,
-    SubmitActionRequest, SubmitActionResponse,
+    connector_error_codes, ActionExecutionMode, AgentFS as SdkAgentFS, AgentFSOptions,
+    AppAdapterV1, AppConnector, AppStructureSyncReason, AuthStatus, ConnectorContext,
+    ConnectorError, ConnectorInfo, ConnectorTransport, DemoAppConnector, FetchLivePageRequest,
+    FetchLivePageResponse, FetchSnapshotChunkRequest, FetchSnapshotChunkResponse, HealthStatus,
+    SnapshotMeta, SubmitActionOutcome, SubmitActionRequest, SubmitActionResponse,
 };
 use anyhow::{Context, Result};
 use serde_json::Value as JsonValue;
@@ -26,7 +26,9 @@ use super::shared::{
     is_transient_action_sink_busy, parse_snapshot_on_timeout_policy, template_specificity,
     MultilineRecoveryOutcome,
 };
-use super::tree_sync::{ensure_app_structure_initialized, refresh_app_structure};
+use super::tree_sync::{
+    ensure_app_structure_initialized, refresh_app_structure, refresh_app_structure_in_db,
+};
 use super::{
     ActionCursorDoc, ActionCursorState, ActionSpec, AppRuntimeStartupBootstrap, AppfsAdapter,
     AppfsBridgeConfig, CursorState, ExecutionMode, InputMode, ManifestContract, ManifestDoc,
@@ -370,6 +372,9 @@ impl AppfsAdapter {
             app_id,
             session_id,
             app_dir,
+            direct_db_path: startup_bootstrap
+                .as_ref()
+                .map(|bootstrap| bootstrap.db_path.clone()),
             action_specs: manifest_contract.action_specs,
             snapshot_specs: manifest_contract.snapshot_specs,
             events_path,
@@ -404,6 +409,31 @@ impl AppfsAdapter {
         adapter.load_known_handles()?;
         adapter.startup_prewarm_snapshots();
         Ok(adapter)
+    }
+
+    fn apply_manifest_contract(
+        &mut self,
+        manifest_contract: ManifestContract,
+        validate_paging_controls_on_mount: bool,
+    ) -> Result<()> {
+        if validate_paging_controls_on_mount && manifest_contract.requires_paging_controls {
+            let fetch_path = self.app_dir.join("_paging").join("fetch_next.act");
+            let close_path = self.app_dir.join("_paging").join("close.act");
+            if !fetch_path.exists() || !close_path.exists() {
+                anyhow::bail!(
+                    "live pageable resources require paging control files to exist: {} and {}",
+                    fetch_path.display(),
+                    close_path.display()
+                );
+            }
+        }
+
+        self.action_specs = manifest_contract.action_specs;
+        self.snapshot_specs = manifest_contract.snapshot_specs;
+        self.snapshot_states.clear();
+        self.initialize_snapshot_states();
+        self.prepare_action_sinks()?;
+        Ok(())
     }
 
     pub(super) fn prepare_action_sinks(&mut self) -> Result<()> {
@@ -1226,24 +1256,13 @@ impl AppfsAdapter {
     pub(super) fn reload_manifest_contract(&mut self) -> Result<()> {
         let manifest_path = self.app_dir.join("_meta").join("manifest.res.json");
         let manifest_contract = Self::load_manifest_contract(&manifest_path)?;
-        if manifest_contract.requires_paging_controls {
-            let fetch_path = self.app_dir.join("_paging").join("fetch_next.act");
-            let close_path = self.app_dir.join("_paging").join("close.act");
-            if !fetch_path.exists() || !close_path.exists() {
-                anyhow::bail!(
-                    "live pageable resources require paging control files to exist: {} and {}",
-                    fetch_path.display(),
-                    close_path.display()
-                );
-            }
-        }
+        self.apply_manifest_contract(manifest_contract, true)
+    }
 
-        self.action_specs = manifest_contract.action_specs;
-        self.snapshot_specs = manifest_contract.snapshot_specs;
-        self.snapshot_states.clear();
-        self.initialize_snapshot_states();
-        self.prepare_action_sinks()?;
-        Ok(())
+    pub(super) fn reload_manifest_contract_from_json(&mut self, manifest_json: &str) -> Result<()> {
+        let manifest_contract =
+            parse_manifest_contract_json(manifest_json, "<db-structure-refresh>")?;
+        self.apply_manifest_contract(manifest_contract, false)
     }
 
     pub(super) fn handle_enter_scope(
@@ -1253,21 +1272,17 @@ impl AppfsAdapter {
         target_scope: &str,
         client_token: Option<String>,
     ) -> Result<ProcessOutcome> {
-        let root = self
-            .app_dir
-            .parent()
-            .ok_or_else(|| anyhow::anyhow!("app directory has no parent root"))?;
-        match refresh_app_structure(
-            root,
-            &self.app_id,
-            &self.session_id,
-            &mut *self.connector,
+        match self.refresh_structure(
             AppStructureSyncReason::EnterScope,
             Some(target_scope.to_string()),
             Some(action_path.to_string()),
         ) {
             Ok(outcome) => {
-                self.reload_manifest_contract()?;
+                if let Some(manifest_json) = outcome.manifest_json.as_deref() {
+                    self.reload_manifest_contract_from_json(manifest_json)?;
+                } else {
+                    self.reload_manifest_contract()?;
+                }
                 self.emit_event(
                     action_path,
                     request_id,
@@ -1311,21 +1326,17 @@ impl AppfsAdapter {
         target_scope: Option<&str>,
         client_token: Option<String>,
     ) -> Result<ProcessOutcome> {
-        let root = self
-            .app_dir
-            .parent()
-            .ok_or_else(|| anyhow::anyhow!("app directory has no parent root"))?;
-        match refresh_app_structure(
-            root,
-            &self.app_id,
-            &self.session_id,
-            &mut *self.connector,
+        match self.refresh_structure(
             AppStructureSyncReason::Refresh,
             target_scope.map(ToOwned::to_owned),
             Some(action_path.to_string()),
         ) {
             Ok(outcome) => {
-                self.reload_manifest_contract()?;
+                if let Some(manifest_json) = outcome.manifest_json.as_deref() {
+                    self.reload_manifest_contract_from_json(manifest_json)?;
+                } else {
+                    self.reload_manifest_contract()?;
+                }
                 self.emit_event(
                     action_path,
                     request_id,
@@ -1360,6 +1371,46 @@ impl AppfsAdapter {
                 Ok(ProcessOutcome::Consumed)
             }
         }
+    }
+
+    fn refresh_structure(
+        &mut self,
+        reason: AppStructureSyncReason,
+        target_scope: Option<String>,
+        trigger_action_path: Option<String>,
+    ) -> Result<super::tree_sync::StructureSyncOutcome> {
+        if let Some(db_path) = self.direct_db_path.clone() {
+            let app_id = self.app_id.clone();
+            let session_id = self.session_id.clone();
+            let connector = &mut self.connector;
+            return crate::get_runtime().block_on(async move {
+                let agent = SdkAgentFS::open(AgentFSOptions::with_path(db_path)).await?;
+                refresh_app_structure_in_db(
+                    &agent,
+                    &app_id,
+                    &session_id,
+                    &mut **connector,
+                    reason,
+                    target_scope,
+                    trigger_action_path,
+                )
+                .await
+            });
+        }
+
+        let root = self
+            .app_dir
+            .parent()
+            .ok_or_else(|| anyhow::anyhow!("app directory has no parent root"))?;
+        refresh_app_structure(
+            root,
+            &self.app_id,
+            &self.session_id,
+            &mut *self.connector,
+            reason,
+            target_scope,
+            trigger_action_path,
+        )
     }
 
     fn new_request_id() -> String {

--- a/cli/src/cmd/appfs/core.rs
+++ b/cli/src/cmd/appfs/core.rs
@@ -28,11 +28,12 @@ use super::shared::{
 };
 use super::tree_sync::{ensure_app_structure_initialized, refresh_app_structure};
 use super::{
-    ActionCursorDoc, ActionCursorState, ActionSpec, AppfsAdapter, AppfsBridgeConfig, CursorState,
-    ExecutionMode, InputMode, ManifestContract, ManifestDoc, ProcessOutcome, SnapshotSpec,
-    StreamingJob, ACTION_CURSORS_FILENAME, DEFAULT_RETENTION_HINT_SEC,
-    DEFAULT_SNAPSHOT_MAX_MATERIALIZED_BYTES, DEFAULT_SNAPSHOT_PREWARM_TIMEOUT_MS,
-    DEFAULT_SNAPSHOT_READ_THROUGH_TIMEOUT_MS, SNAPSHOT_EXPAND_JOURNAL_FILENAME,
+    ActionCursorDoc, ActionCursorState, ActionSpec, AppRuntimeStartupBootstrap, AppfsAdapter,
+    AppfsBridgeConfig, CursorState, ExecutionMode, InputMode, ManifestContract, ManifestDoc,
+    ProcessOutcome, SnapshotSpec, StreamingJob, ACTION_CURSORS_FILENAME,
+    DEFAULT_RETENTION_HINT_SEC, DEFAULT_SNAPSHOT_MAX_MATERIALIZED_BYTES,
+    DEFAULT_SNAPSHOT_PREWARM_TIMEOUT_MS, DEFAULT_SNAPSHOT_READ_THROUGH_TIMEOUT_MS,
+    SNAPSHOT_EXPAND_JOURNAL_FILENAME,
 };
 
 #[cfg_attr(not(test), allow(dead_code))]
@@ -278,7 +279,19 @@ impl AppfsAdapter {
         session_id: String,
         bridge_config: AppfsBridgeConfig,
     ) -> Result<Self> {
-        ensure_app_structure_initialized(&root, &app_id, &session_id, &bridge_config)?;
+        Self::new_with_bootstrap(root, app_id, session_id, bridge_config, None)
+    }
+
+    pub(super) fn new_with_bootstrap(
+        root: PathBuf,
+        app_id: String,
+        session_id: String,
+        bridge_config: AppfsBridgeConfig,
+        startup_bootstrap: Option<AppRuntimeStartupBootstrap>,
+    ) -> Result<Self> {
+        if startup_bootstrap.is_none() {
+            ensure_app_structure_initialized(&root, &app_id, &session_id, &bridge_config)?;
+        }
         let app_dir = root.join(&app_id);
         let manifest_path = app_dir.join("_meta").join("manifest.res.json");
         let events_path = app_dir.join("_stream").join("events.evt.jsonl");
@@ -293,22 +306,29 @@ impl AppfsAdapter {
         if !app_dir.exists() {
             anyhow::bail!("App directory not found: {}", app_dir.display());
         }
-        if !manifest_path.exists() {
+        if startup_bootstrap.is_none() && !manifest_path.exists() {
             anyhow::bail!("Missing manifest file: {}", manifest_path.display());
         }
-        if !events_path.exists() {
+        if startup_bootstrap.is_none() && !events_path.exists() {
             anyhow::bail!("Missing events stream file: {}", events_path.display());
         }
-        if !cursor_path.exists() {
+        if startup_bootstrap.is_none() && !cursor_path.exists() {
             anyhow::bail!("Missing cursor file: {}", cursor_path.display());
         }
         if !replay_dir.exists() {
             anyhow::bail!("Missing replay directory: {}", replay_dir.display());
         }
 
-        let cursor = Self::load_cursor(&cursor_path)?;
+        let cursor = match startup_bootstrap.as_ref() {
+            Some(bootstrap) => bootstrap.cursor.clone(),
+            None => Self::load_cursor(&cursor_path)?,
+        };
         let next_seq = cursor.max_seq + 1;
-        let manifest_contract = Self::load_manifest_contract(&manifest_path)?;
+        let manifest_contract = if let Some(bootstrap) = startup_bootstrap.as_ref() {
+            parse_manifest_contract_json(&bootstrap.manifest_json, "<managed-runtime-bootstrap>")?
+        } else {
+            Self::load_manifest_contract(&manifest_path)?
+        };
         if manifest_contract.requires_paging_controls {
             let has_fetch = manifest_contract
                 .action_specs
@@ -360,15 +380,22 @@ impl AppfsAdapter {
             snapshot_expand_journal_path: snapshot_expand_journal_path.clone(),
             cursor,
             next_seq,
-            action_cursors: Self::load_action_cursors(&action_cursors_path)?,
+            action_cursors: match startup_bootstrap.as_ref() {
+                Some(bootstrap) => bootstrap.action_cursors.clone(),
+                None => Self::load_action_cursors(&action_cursors_path)?,
+            },
             handles: HashMap::new(),
             handle_aliases: HashMap::new(),
             snapshot_states: HashMap::new(),
             snapshot_recent_expands: HashMap::new(),
-            snapshot_expand_journal: Self::load_snapshot_expand_journal(
-                &snapshot_expand_journal_path,
-            )?,
-            streaming_jobs: Self::load_streaming_jobs(&jobs_path)?,
+            snapshot_expand_journal: match startup_bootstrap.as_ref() {
+                Some(bootstrap) => bootstrap.snapshot_expand_journal.clone(),
+                None => Self::load_snapshot_expand_journal(&snapshot_expand_journal_path)?,
+            },
+            streaming_jobs: match startup_bootstrap.as_ref() {
+                Some(bootstrap) => bootstrap.streaming_jobs.clone(),
+                None => Self::load_streaming_jobs(&jobs_path)?,
+            },
             actionline_strict: env_flag_enabled("APPFS_ACTIONLINE_STRICT"),
             connector,
         };

--- a/cli/src/cmd/appfs/mount_runtime.rs
+++ b/cli/src/cmd/appfs/mount_runtime.rs
@@ -947,6 +947,9 @@ impl SnapshotReadThroughFile {
 #[async_trait]
 impl agentfs_sdk::File for SnapshotReadThroughFile {
     async fn pread(&self, offset: u64, size: u64) -> Result<Vec<u8>, agentfs_sdk::error::Error> {
+        if size == 0 {
+            return Ok(Vec::new());
+        }
         self.ensure_read_prepared().await?;
         let file = self.open_backing_file().await?;
         file.pread(offset, size).await
@@ -1686,6 +1689,14 @@ mod tests {
                 fetch_count.load(Ordering::SeqCst),
                 0,
                 "open/fstat must not trigger connector expansion"
+            );
+
+            let empty_probe = file.pread(0, 0).await.expect("zero-byte read");
+            assert!(empty_probe.is_empty());
+            assert_eq!(
+                fetch_count.load(Ordering::SeqCst),
+                0,
+                "zero-byte read probes must not trigger connector expansion"
             );
 
             let bytes = file.pread(0, 4096).await.expect("read snapshot");

--- a/cli/src/cmd/appfs/mount_runtime.rs
+++ b/cli/src/cmd/appfs/mount_runtime.rs
@@ -311,6 +311,9 @@ impl SnapshotReadThroughContext {
             .collect::<HashMap<_, _>>();
         *self.runtime_configs.lock().await = runtime_configs;
         *self.registry_fingerprint.lock().await = Some(bytes);
+        let mut path_cache = self.path_cache.lock().await;
+        path_cache.clear();
+        path_cache.insert(ROOT_INO, String::new());
         self.runtimes.lock().await.clear();
         Ok(())
     }

--- a/cli/src/cmd/appfs/mount_runtime.rs
+++ b/cli/src/cmd/appfs/mount_runtime.rs
@@ -34,6 +34,11 @@ const OPEN_READ_WRITE: i32 = 2;
 const OPEN_ACCESS_MODE_MASK: i32 = 0x0003;
 const OPEN_WRITE_ONLY: i32 = 1;
 const OPEN_NO_READ_HINT: i32 = 0x2000_0000;
+const SNAPSHOT_PROBE_READ_SUPPRESS_BYTES_ENV: &str = "APPFS_SNAPSHOT_PROBE_READ_SUPPRESS_BYTES";
+#[cfg(target_os = "windows")]
+const DEFAULT_SNAPSHOT_PROBE_READ_SUPPRESS_BYTES: u64 = 4;
+#[cfg(not(target_os = "windows"))]
+const DEFAULT_SNAPSHOT_PROBE_READ_SUPPRESS_BYTES: u64 = 0;
 
 #[cfg(target_os = "windows")]
 const RAW_IO_ERROR: i32 = 1117;
@@ -160,6 +165,17 @@ fn open_requests_read(flags: i32) -> bool {
     }
     let access_mode = flags & OPEN_ACCESS_MODE_MASK;
     access_mode != OPEN_WRITE_ONLY
+}
+
+fn snapshot_probe_read_suppress_bytes() -> u64 {
+    std::env::var(SNAPSHOT_PROBE_READ_SUPPRESS_BYTES_ENV)
+        .ok()
+        .and_then(|value| value.trim().parse::<u64>().ok())
+        .unwrap_or(DEFAULT_SNAPSHOT_PROBE_READ_SUPPRESS_BYTES)
+}
+
+fn should_suppress_snapshot_probe_read(offset: u64, size: u64, suppress_bytes: u64) -> bool {
+    suppress_bytes > 0 && offset == 0 && size > 0 && size <= suppress_bytes
 }
 
 fn action_wake_is_relevant_path(rel_path: &str) -> bool {
@@ -430,7 +446,8 @@ impl SnapshotReadThroughContext {
         };
         let resource_fs_rel = format!("{}/{}", app_id, resource_rel);
         let has_journal = self.journal_contains(app_id, resource_rel).await?;
-        let force_expand_existing = trigger == "open" && snapshot_force_expand_on_refresh();
+        let force_expand_existing =
+            matches!(trigger, "open" | "read") && snapshot_force_expand_on_refresh();
         let current_stats = self.lookup_path(&resource_fs_rel).await?;
         if should_skip_existing_expand(current_stats.as_ref(), has_journal, force_expand_existing) {
             if trigger == "lookup_miss" {
@@ -885,6 +902,19 @@ impl SnapshotReadThroughContext {
 }
 
 impl SnapshotReadThroughFile {
+    async fn is_read_prepared(&self) -> bool {
+        self.state.lock().await.read_prepared
+    }
+
+    async fn is_cold_empty_placeholder(&self) -> Result<bool, agentfs_sdk::error::Error> {
+        let stats = self
+            .ctx
+            .lookup_path(&self.rel_path)
+            .await
+            .map_err(|err| map_anyhow_to_sdk_error(err, RAW_IO_ERROR))?;
+        Ok(stats.is_some_and(|stats| stats.size == 0))
+    }
+
     async fn open_backing_file(&self) -> Result<BoxedFile, agentfs_sdk::error::Error> {
         {
             let state = self.state.lock().await;
@@ -929,10 +959,8 @@ impl SnapshotReadThroughFile {
             state.file = None;
         }
 
-        // Preserve the existing ordinary-read contract label even though the
-        // actual expansion is deferred until the first pread().
         self.ctx
-            .ensure_snapshot_materialized(&self.app_id, &self.resource_rel, "open")
+            .ensure_snapshot_materialized(&self.app_id, &self.resource_rel, "read")
             .await
             .map_err(|err| map_anyhow_to_sdk_error(err, RAW_IO_ERROR))?;
         let file = self.open_backing_file().await?;
@@ -948,6 +976,21 @@ impl SnapshotReadThroughFile {
 impl agentfs_sdk::File for SnapshotReadThroughFile {
     async fn pread(&self, offset: u64, size: u64) -> Result<Vec<u8>, agentfs_sdk::error::Error> {
         if size == 0 {
+            return Ok(Vec::new());
+        }
+        let suppress_bytes = snapshot_probe_read_suppress_bytes();
+        if should_suppress_snapshot_probe_read(offset, size, suppress_bytes)
+            && !self.is_read_prepared().await
+            && self.is_cold_empty_placeholder().await?
+        {
+            tracing::debug!(
+                app_id = self.app_id,
+                resource = format!("/{}", self.resource_rel),
+                offset,
+                size,
+                suppress_bytes,
+                "mount snapshot probe read suppressed"
+            );
             return Ok(Vec::new());
         }
         self.ensure_read_prepared().await?;
@@ -1391,9 +1434,10 @@ fn map_anyhow_to_sdk_error(err: anyhow::Error, default_errno: i32) -> agentfs_sd
 mod tests {
     use super::{
         action_wake_is_relevant_path, open_requests_read, should_skip_existing_expand,
-        ActionWakeHandle, AppfsRuntimeCliArgs, MountSnapshotReadThroughConfig,
-        MountSnapshotReadThroughFs, MountSnapshotRuntime, SnapshotOnTimeoutPolicy, SnapshotSpec,
-        OPEN_NO_READ_HINT, OPEN_READ_ONLY, OPEN_READ_WRITE, OPEN_WRITE_ONLY, ROOT_INO,
+        should_suppress_snapshot_probe_read, ActionWakeHandle, AppfsRuntimeCliArgs,
+        MountSnapshotReadThroughConfig, MountSnapshotReadThroughFs, MountSnapshotRuntime,
+        SnapshotOnTimeoutPolicy, SnapshotSpec, OPEN_NO_READ_HINT, OPEN_READ_ONLY, OPEN_READ_WRITE,
+        OPEN_WRITE_ONLY, ROOT_INO,
     };
     use crate::cmd::appfs::AppfsBridgeCliArgs;
     use agentfs_sdk::{
@@ -1463,6 +1507,15 @@ mod tests {
         assert!(open_requests_read(OPEN_READ_WRITE));
         assert!(!open_requests_read(OPEN_WRITE_ONLY));
         assert!(!open_requests_read(OPEN_READ_ONLY | OPEN_NO_READ_HINT));
+    }
+
+    #[test]
+    fn small_prefix_reads_can_be_classified_as_snapshot_probes() {
+        assert!(!should_suppress_snapshot_probe_read(0, 1, 0));
+        assert!(should_suppress_snapshot_probe_read(0, 1, 4));
+        assert!(should_suppress_snapshot_probe_read(0, 4, 4));
+        assert!(!should_suppress_snapshot_probe_read(0, 5, 4));
+        assert!(!should_suppress_snapshot_probe_read(1, 1, 4));
     }
 
     fn build_wrapper(root: &TempDir, wake: Option<ActionWakeHandle>) -> MountSnapshotReadThroughFs {

--- a/cli/src/cmd/appfs/runtime_entry.rs
+++ b/cli/src/cmd/appfs/runtime_entry.rs
@@ -1,6 +1,6 @@
 use super::{
-    build_appfs_bridge_config, AppfsAdapter, AppfsBridgeCliArgs, ResolvedAppfsRuntimeCliArgs,
-    APP_STRUCTURE_SYNC_STATE_FILENAME,
+    build_appfs_bridge_config, AppRuntimeStartupBootstrap, AppfsAdapter, AppfsBridgeCliArgs,
+    ResolvedAppfsRuntimeCliArgs, APP_STRUCTURE_SYNC_STATE_FILENAME,
 };
 use anyhow::Result;
 use serde_json::Value as JsonValue;
@@ -15,13 +15,23 @@ pub(super) struct AppRuntimeEntry {
 pub(super) fn build_runtime_entry(
     root: &Path,
     runtime: ResolvedAppfsRuntimeCliArgs,
+    startup_bootstrap: Option<AppRuntimeStartupBootstrap>,
 ) -> Result<AppRuntimeEntry> {
-    let adapter = AppfsAdapter::new(
-        root.to_path_buf(),
-        runtime.app_id.clone(),
-        runtime.session_id.clone(),
-        build_appfs_bridge_config(runtime.bridge.clone()),
-    )?;
+    let adapter = match startup_bootstrap {
+        Some(startup_bootstrap) => AppfsAdapter::new_with_bootstrap(
+            root.to_path_buf(),
+            runtime.app_id.clone(),
+            runtime.session_id.clone(),
+            build_appfs_bridge_config(runtime.bridge.clone()),
+            Some(startup_bootstrap),
+        )?,
+        None => AppfsAdapter::new(
+            root.to_path_buf(),
+            runtime.app_id.clone(),
+            runtime.session_id.clone(),
+            build_appfs_bridge_config(runtime.bridge.clone()),
+        )?,
+    };
     Ok(AppRuntimeEntry { runtime, adapter })
 }
 

--- a/cli/src/cmd/appfs/runtime_supervisor.rs
+++ b/cli/src/cmd/appfs/runtime_supervisor.rs
@@ -6,9 +6,9 @@ use super::runtime_entry::{
 };
 use super::runtime_manifest;
 use super::supervisor_control;
-use super::ResolvedAppfsRuntimeCliArgs;
+use super::{AppRuntimeStartupBootstrap, ResolvedAppfsRuntimeCliArgs};
 use anyhow::Result;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 use std::path::PathBuf;
 
 pub(super) struct AppfsRuntimeSupervisor {
@@ -24,10 +24,13 @@ impl AppfsRuntimeSupervisor {
         root: PathBuf,
         runtime_args: Vec<ResolvedAppfsRuntimeCliArgs>,
         managed: bool,
+        startup_bootstrap: Option<HashMap<String, AppRuntimeStartupBootstrap>>,
     ) -> Result<Self> {
         let mut runtimes = BTreeMap::new();
+        let mut startup_bootstrap = startup_bootstrap.unwrap_or_default();
         for runtime in runtime_args {
-            let entry = build_runtime_entry(&root, runtime)?;
+            let app_id = runtime.app_id.clone();
+            let entry = build_runtime_entry(&root, runtime, startup_bootstrap.remove(&app_id))?;
             if runtimes
                 .insert(entry.runtime.app_id.clone(), entry)
                 .is_some()
@@ -163,7 +166,7 @@ impl AppfsRuntimeSupervisor {
             }
         };
 
-        match build_runtime_entry(&self.root, runtime.clone()) {
+        match build_runtime_entry(&self.root, runtime.clone(), None) {
             Ok(mut entry) => {
                 entry.adapter.prepare_action_sinks()?;
                 let app_id = entry.runtime.app_id.clone();

--- a/cli/src/cmd/appfs/tree_sync.rs
+++ b/cli/src/cmd/appfs/tree_sync.rs
@@ -31,6 +31,7 @@ pub(super) struct StructureSyncOutcome {
     pub(super) changed: bool,
     pub(super) revision: Option<String>,
     pub(super) active_scope: Option<String>,
+    pub(super) manifest_json: Option<String>,
 }
 
 pub(super) fn ensure_app_structure_initialized(
@@ -121,7 +122,7 @@ pub(super) async fn ensure_app_structure_initialized_in_db(
                 active_scope: snapshot.active_scope.clone(),
                 owned_paths: desired_owned_paths.into_iter().collect(),
             };
-            let plan = build_bulk_materialize_plan(app_id, &snapshot, &next_state)?;
+            let plan = build_bulk_materialize_plan(app_id, &snapshot, &next_state, true)?;
             agent.bulk_materialize_tree(&plan).await?;
             eprintln!(
                 "[structure.sync] result app={} changed=true revision={} active_scope={}",
@@ -130,6 +131,102 @@ pub(super) async fn ensure_app_structure_initialized_in_db(
                 snapshot.active_scope.as_deref().unwrap_or("<none>")
             );
             Ok(())
+        }
+    }
+}
+
+pub(super) async fn refresh_app_structure_in_db(
+    agent: &SdkAgentFS,
+    app_id: &str,
+    session_id: &str,
+    connector: &mut dyn AppConnector,
+    reason: AppStructureSyncReason,
+    target_scope: Option<String>,
+    trigger_action_path: Option<String>,
+) -> Result<StructureSyncOutcome> {
+    let state = load_state_from_agentfs(agent, app_id).await?;
+    let ctx = ConnectorContext {
+        app_id: app_id.to_string(),
+        session_id: session_id.to_string(),
+        request_id: "structure-refresh".to_string(),
+        client_token: None,
+        trace_id: None,
+    };
+    eprintln!(
+        "[structure.sync] op=refresh_app_structure app={} reason={} target_scope={} trigger_action_path={} known_revision={}",
+        app_id,
+        structure_reason_label(reason),
+        target_scope.as_deref().unwrap_or("<none>"),
+        trigger_action_path.as_deref().unwrap_or("<none>"),
+        state.revision.as_deref().unwrap_or("<none>")
+    );
+    let response = connector.refresh_app_structure(
+        RefreshAppStructureRequest {
+            app_id: app_id.to_string(),
+            known_revision: state.revision.clone(),
+            reason,
+            target_scope,
+            trigger_action_path,
+        },
+        &ctx,
+    )?;
+
+    match response.result {
+        AppStructureSyncResult::Unchanged {
+            revision,
+            active_scope,
+            ..
+        } => {
+            eprintln!(
+                "[structure.sync] result app={} changed=false revision={} active_scope={}",
+                app_id,
+                revision,
+                active_scope.as_deref().unwrap_or("<none>")
+            );
+            Ok(StructureSyncOutcome {
+                changed: false,
+                revision: Some(revision),
+                active_scope,
+                manifest_json: None,
+            })
+        }
+        AppStructureSyncResult::Snapshot { snapshot } => {
+            if snapshot.app_id != app_id {
+                anyhow::bail!(
+                    "structure snapshot app_id mismatch: snapshot={} runtime={}",
+                    snapshot.app_id,
+                    app_id
+                );
+            }
+            let desired_owned_paths = desired_owned_paths_for_snapshot(&snapshot);
+            prune_removed_owned_paths_in_agentfs(
+                agent,
+                app_id,
+                &state.owned_paths,
+                &desired_owned_paths,
+            )
+            .await?;
+            let next_state = AppStructureSyncStateDoc {
+                revision: Some(snapshot.revision.clone()),
+                active_scope: snapshot.active_scope.clone(),
+                owned_paths: desired_owned_paths.into_iter().collect(),
+            };
+            let manifest_json =
+                serde_json::to_string_pretty(&build_manifest_doc(app_id, &snapshot)?)?;
+            let plan = build_bulk_materialize_plan(app_id, &snapshot, &next_state, false)?;
+            agent.bulk_materialize_tree(&plan).await?;
+            eprintln!(
+                "[structure.sync] result app={} changed=true revision={} active_scope={}",
+                app_id,
+                snapshot.revision,
+                snapshot.active_scope.as_deref().unwrap_or("<none>")
+            );
+            Ok(StructureSyncOutcome {
+                changed: true,
+                revision: Some(snapshot.revision),
+                active_scope: snapshot.active_scope,
+                manifest_json: Some(manifest_json),
+            })
         }
     }
 }
@@ -252,6 +349,7 @@ impl AppTreeSyncService {
                     changed: false,
                     revision: Some(revision),
                     active_scope,
+                    manifest_json: None,
                 })
             }
             AppStructureSyncResult::Snapshot { snapshot } => {
@@ -268,6 +366,7 @@ impl AppTreeSyncService {
                     changed: true,
                     revision: Some(revision),
                     active_scope,
+                    manifest_json: None,
                 })
             }
         }
@@ -593,9 +692,9 @@ fn build_bulk_materialize_plan(
     app_id: &str,
     snapshot: &AppStructureSnapshot,
     state: &AppStructureSyncStateDoc,
+    include_runtime_scaffolding: bool,
 ) -> Result<BulkMaterializePlan> {
     let mut plan = BulkMaterializePlan::new();
-    let mut manifest_nodes = BTreeMap::new();
     let mut dir_paths = BTreeSet::new();
     dir_paths.insert(format!("/{app_id}"));
     dir_paths.insert(format!("/{app_id}/_meta"));
@@ -610,19 +709,6 @@ fn build_bulk_materialize_plan(
         }
         if matches!(node.kind, AppStructureNodeKind::Directory) {
             dir_paths.insert(format!("/{app_id}/{}", node.path));
-        }
-        if let Some(entry) = &node.manifest_entry {
-            let template = entry
-                .get("template")
-                .and_then(|value| value.as_str())
-                .ok_or_else(|| {
-                    anyhow::anyhow!("manifest_entry missing template for {}", node.path)
-                })?;
-            let mut normalized = entry.clone();
-            if let Some(obj) = normalized.as_object_mut() {
-                obj.remove("template");
-            }
-            manifest_nodes.insert(template.to_string(), normalized);
         }
     }
 
@@ -647,10 +733,7 @@ fn build_bulk_materialize_plan(
         }
     }
 
-    let manifest_json = json!({
-        "app_id": app_id,
-        "nodes": manifest_nodes,
-    });
+    let manifest_json = build_manifest_doc(app_id, snapshot)?;
     plan.push(BulkMaterializeEntry::write_file(
         format!("/{app_id}/_meta/manifest.res.json"),
         serde_json::to_vec_pretty(&manifest_json)?,
@@ -659,9 +742,34 @@ fn build_bulk_materialize_plan(
         format!("/{app_id}/_meta/{APP_STRUCTURE_SYNC_STATE_FILENAME}"),
         serde_json::to_vec_pretty(state)?,
     ));
-    append_runtime_scaffolding_plan(&mut plan, app_id)?;
+    if include_runtime_scaffolding {
+        append_runtime_scaffolding_plan(&mut plan, app_id)?;
+    }
 
     Ok(plan)
+}
+
+fn build_manifest_doc(app_id: &str, snapshot: &AppStructureSnapshot) -> Result<JsonValue> {
+    let mut manifest_nodes = BTreeMap::new();
+    for node in &snapshot.nodes {
+        if let Some(entry) = &node.manifest_entry {
+            let template = entry
+                .get("template")
+                .and_then(|value| value.as_str())
+                .ok_or_else(|| {
+                    anyhow::anyhow!("manifest_entry missing template for {}", node.path)
+                })?;
+            let mut normalized = entry.clone();
+            if let Some(obj) = normalized.as_object_mut() {
+                obj.remove("template");
+            }
+            manifest_nodes.insert(template.to_string(), normalized);
+        }
+    }
+    Ok(json!({
+        "app_id": app_id,
+        "nodes": manifest_nodes,
+    }))
 }
 
 fn append_runtime_scaffolding_plan(plan: &mut BulkMaterializePlan, app_id: &str) -> Result<()> {
@@ -1107,5 +1215,78 @@ mod tests {
             .await
             .expect("snapshot journal")
             .is_some());
+    }
+
+    #[tokio::test]
+    async fn db_structure_refresh_updates_scope_and_preserves_runtime_state() {
+        let temp = TempDir::new().expect("tempdir");
+        let db_path = temp.path().join("test.db");
+        let agent = AgentFS::open(AgentFSOptions::with_path(
+            db_path.to_string_lossy().to_string(),
+        ))
+        .await
+        .expect("open agentfs");
+        let bridge = build_appfs_bridge_config(AppfsBridgeCliArgs {
+            adapter_http_endpoint: None,
+            adapter_http_timeout_ms: 5_000,
+            adapter_grpc_endpoint: None,
+            adapter_grpc_timeout_ms: 5_000,
+            adapter_bridge_max_retries: 2,
+            adapter_bridge_initial_backoff_ms: 100,
+            adapter_bridge_max_backoff_ms: 1_000,
+            adapter_bridge_circuit_breaker_failures: 5,
+            adapter_bridge_circuit_breaker_cooldown_ms: 3_000,
+        });
+
+        super::ensure_app_structure_initialized_in_db(&agent, "aiim", "sess-test", &bridge)
+            .await
+            .expect("db structure init");
+        let before_cursor = agent
+            .fs
+            .read_file("/aiim/_stream/cursor.res.json")
+            .await
+            .expect("cursor")
+            .expect("cursor exists");
+
+        let mut connector = super::build_app_connector("aiim", &bridge).expect("connector");
+        let outcome = super::refresh_app_structure_in_db(
+            &agent,
+            "aiim",
+            "sess-test",
+            &mut *connector,
+            agentfs_sdk::AppStructureSyncReason::EnterScope,
+            Some("chat-long".to_string()),
+            Some("/_app/enter_scope.act".to_string()),
+        )
+        .await
+        .expect("db structure refresh");
+
+        assert!(outcome.changed);
+        assert_eq!(outcome.active_scope.as_deref(), Some("chat-long"));
+        assert!(outcome
+            .manifest_json
+            .as_deref()
+            .unwrap_or_default()
+            .contains("chat-long/messages.res.jsonl"));
+        assert!(agent
+            .fs
+            .stat("/aiim/chats/chat-long")
+            .await
+            .expect("stat")
+            .unwrap()
+            .is_directory());
+        assert!(agent
+            .fs
+            .stat("/aiim/chats/chat-001")
+            .await
+            .expect("stat old")
+            .is_none());
+        let after_cursor = agent
+            .fs
+            .read_file("/aiim/_stream/cursor.res.json")
+            .await
+            .expect("cursor after")
+            .expect("cursor exists after");
+        assert_eq!(before_cursor, after_cursor);
     }
 }

--- a/cli/src/cmd/appfs/tree_sync.rs
+++ b/cli/src/cmd/appfs/tree_sync.rs
@@ -659,8 +659,41 @@ fn build_bulk_materialize_plan(
         format!("/{app_id}/_meta/{APP_STRUCTURE_SYNC_STATE_FILENAME}"),
         serde_json::to_vec_pretty(state)?,
     ));
+    append_runtime_scaffolding_plan(&mut plan, app_id)?;
 
     Ok(plan)
+}
+
+fn append_runtime_scaffolding_plan(plan: &mut BulkMaterializePlan, app_id: &str) -> Result<()> {
+    let stream_dir = format!("/{app_id}/_stream");
+    plan.push(BulkMaterializeEntry::ensure_dir(stream_dir.clone()));
+    plan.push(BulkMaterializeEntry::ensure_dir(format!(
+        "{stream_dir}/from-seq"
+    )));
+    plan.push(BulkMaterializeEntry::ensure_empty_file(format!(
+        "{stream_dir}/events.evt.jsonl"
+    )));
+    plan.push(BulkMaterializeEntry::write_file(
+        format!("{stream_dir}/cursor.res.json"),
+        serde_json::to_vec_pretty(&json!(CursorState {
+            min_seq: 0,
+            max_seq: 0,
+            retention_hint_sec: DEFAULT_RETENTION_HINT_SEC,
+        }))?,
+    ));
+    plan.push(BulkMaterializeEntry::write_file(
+        format!("{stream_dir}/inflight.jobs.res.json"),
+        serde_json::to_vec_pretty(&json!([]))?,
+    ));
+    plan.push(BulkMaterializeEntry::write_file(
+        format!("{stream_dir}/{}", super::ACTION_CURSORS_FILENAME),
+        serde_json::to_vec_pretty(&serde_json::to_value(ActionCursorDoc::default())?)?,
+    ));
+    plan.push(BulkMaterializeEntry::write_file(
+        format!("{stream_dir}/{SNAPSHOT_EXPAND_JOURNAL_FILENAME}"),
+        serde_json::to_vec_pretty(&json!({"resources": {}}))?,
+    ));
+    Ok(())
 }
 
 fn bootstrap_runtime_scaffolding(root: &Path, app_id: &str) -> Result<()> {
@@ -886,7 +919,8 @@ fn structure_reason_label(reason: AppStructureSyncReason) -> &'static str {
 #[cfg(test)]
 mod tests {
     use super::{bootstrap_runtime_scaffolding, AppTreeSyncService};
-    use agentfs_sdk::DemoAppConnector;
+    use crate::cmd::appfs::{build_appfs_bridge_config, AppfsBridgeCliArgs};
+    use agentfs_sdk::{AgentFS, AgentFSOptions, DemoAppConnector};
     use std::fs;
     use tempfile::TempDir;
 
@@ -999,5 +1033,79 @@ mod tests {
             .path()
             .join("aiim/_stream/action-cursors.res.json")
             .exists());
+    }
+
+    #[tokio::test]
+    async fn db_structure_init_materializes_runtime_scaffolding() {
+        let temp = TempDir::new().expect("tempdir");
+        let db_path = temp.path().join("test.db");
+        let agent = AgentFS::open(AgentFSOptions::with_path(
+            db_path.to_string_lossy().to_string(),
+        ))
+        .await
+        .expect("open agentfs");
+        let bridge = build_appfs_bridge_config(AppfsBridgeCliArgs {
+            adapter_http_endpoint: None,
+            adapter_http_timeout_ms: 5_000,
+            adapter_grpc_endpoint: None,
+            adapter_grpc_timeout_ms: 5_000,
+            adapter_bridge_max_retries: 2,
+            adapter_bridge_initial_backoff_ms: 100,
+            adapter_bridge_max_backoff_ms: 1_000,
+            adapter_bridge_circuit_breaker_failures: 5,
+            adapter_bridge_circuit_breaker_cooldown_ms: 3_000,
+        });
+
+        super::ensure_app_structure_initialized_in_db(&agent, "aiim", "sess-test", &bridge)
+            .await
+            .expect("db structure init");
+
+        assert!(agent
+            .fs
+            .stat("/aiim/_stream")
+            .await
+            .expect("stat")
+            .unwrap()
+            .is_directory());
+        assert!(agent
+            .fs
+            .stat("/aiim/_stream/from-seq")
+            .await
+            .expect("stat")
+            .unwrap()
+            .is_directory());
+        assert_eq!(
+            agent
+                .fs
+                .read_file("/aiim/_stream/events.evt.jsonl")
+                .await
+                .expect("events")
+                .unwrap(),
+            Vec::<u8>::new()
+        );
+        assert!(agent
+            .fs
+            .read_file("/aiim/_stream/cursor.res.json")
+            .await
+            .expect("cursor")
+            .is_some());
+        assert!(agent
+            .fs
+            .read_file("/aiim/_stream/inflight.jobs.res.json")
+            .await
+            .expect("jobs")
+            .is_some());
+        assert!(agent
+            .fs
+            .read_file("/aiim/_stream/action-cursors.res.json")
+            .await
+            .expect("action cursors")
+            .is_some());
+        assert!(agent
+            .fs
+            .read_file("/aiim/_stream/snapshot-expand.state.res.json")
+            .await
+            .expect("snapshot journal")
+            .is_some());
     }
 }

--- a/cli/src/cmd/appfs/tree_sync.rs
+++ b/cli/src/cmd/appfs/tree_sync.rs
@@ -4,9 +4,9 @@ use super::{
     DEFAULT_RETENTION_HINT_SEC, SNAPSHOT_EXPAND_JOURNAL_FILENAME,
 };
 use agentfs_sdk::{
-    AppConnector, AppStructureNode, AppStructureNodeKind, AppStructureSnapshot,
-    AppStructureSyncReason, AppStructureSyncResult, ConnectorContext, GetAppStructureRequest,
-    RefreshAppStructureRequest,
+    AgentFS as SdkAgentFS, AppConnector, AppStructureNode, AppStructureNodeKind,
+    AppStructureSnapshot, AppStructureSyncReason, AppStructureSyncResult, BulkMaterializeEntry,
+    BulkMaterializePlan, ConnectorContext, GetAppStructureRequest, RefreshAppStructureRequest,
 };
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
@@ -56,6 +56,82 @@ pub(super) fn ensure_app_structure_initialized(
     );
     service.sync_initial(&mut *connector)?;
     Ok(())
+}
+
+pub(super) async fn ensure_app_structure_initialized_in_db(
+    agent: &SdkAgentFS,
+    app_id: &str,
+    session_id: &str,
+    bridge_config: &AppfsBridgeConfig,
+) -> Result<()> {
+    let state = load_state_from_agentfs(agent, app_id).await?;
+    let ctx = ConnectorContext {
+        app_id: app_id.to_string(),
+        session_id: session_id.to_string(),
+        request_id: "structure-init".to_string(),
+        client_token: None,
+        trace_id: None,
+    };
+    let mut connector = build_app_connector(app_id, bridge_config)?;
+    eprintln!(
+        "[structure.sync] op=get_app_structure app={} known_revision={}",
+        app_id,
+        state.revision.as_deref().unwrap_or("<none>")
+    );
+    let response = connector.get_app_structure(
+        GetAppStructureRequest {
+            app_id: app_id.to_string(),
+            known_revision: state.revision.clone(),
+        },
+        &ctx,
+    )?;
+
+    match response.result {
+        AppStructureSyncResult::Unchanged {
+            revision,
+            active_scope,
+            ..
+        } => {
+            eprintln!(
+                "[structure.sync] result app={} changed=false revision={} active_scope={}",
+                app_id,
+                revision,
+                active_scope.as_deref().unwrap_or("<none>")
+            );
+            Ok(())
+        }
+        AppStructureSyncResult::Snapshot { snapshot } => {
+            if snapshot.app_id != app_id {
+                anyhow::bail!(
+                    "structure snapshot app_id mismatch: snapshot={} runtime={}",
+                    snapshot.app_id,
+                    app_id
+                );
+            }
+            let desired_owned_paths = desired_owned_paths_for_snapshot(&snapshot);
+            prune_removed_owned_paths_in_agentfs(
+                agent,
+                app_id,
+                &state.owned_paths,
+                &desired_owned_paths,
+            )
+            .await?;
+            let next_state = AppStructureSyncStateDoc {
+                revision: Some(snapshot.revision.clone()),
+                active_scope: snapshot.active_scope.clone(),
+                owned_paths: desired_owned_paths.into_iter().collect(),
+            };
+            let plan = build_bulk_materialize_plan(app_id, &snapshot, &next_state)?;
+            agent.bulk_materialize_tree(&plan).await?;
+            eprintln!(
+                "[structure.sync] result app={} changed=true revision={} active_scope={}",
+                app_id,
+                snapshot.revision,
+                snapshot.active_scope.as_deref().unwrap_or("<none>")
+            );
+            Ok(())
+        }
+    }
 }
 
 pub(super) fn refresh_app_structure(
@@ -341,25 +417,7 @@ impl AppTreeSyncService {
     }
 
     fn desired_owned_paths(&self, snapshot: &AppStructureSnapshot) -> BTreeSet<String> {
-        let mut owned = BTreeSet::new();
-        owned.insert("_meta".to_string());
-        owned.insert("_meta/manifest.res.json".to_string());
-        for node in &snapshot.nodes {
-            owned.insert(node.path.clone());
-            let mut current = Path::new(&node.path).parent();
-            while let Some(parent) = current {
-                let rel = parent.to_string_lossy().replace('\\', "/");
-                if rel.is_empty() {
-                    break;
-                }
-                if is_runtime_protected_path(&rel) {
-                    break;
-                }
-                owned.insert(rel.clone());
-                current = parent.parent();
-            }
-        }
-        owned
+        desired_owned_paths_for_snapshot(snapshot)
     }
 
     fn ensure_snapshot_paths_visible(
@@ -403,27 +461,7 @@ impl AppTreeSyncService {
     }
 
     fn validate_node(&self, node: &AppStructureNode) -> Result<()> {
-        if node.path.trim().is_empty() {
-            anyhow::bail!("structure node path cannot be empty");
-        }
-        let rel = Path::new(&node.path);
-        if rel.is_absolute() {
-            anyhow::bail!("structure node path must be relative: {}", node.path);
-        }
-        for component in rel.components() {
-            use std::path::Component;
-            match component {
-                Component::Normal(_) => {}
-                _ => anyhow::bail!("structure node path is invalid: {}", node.path),
-            }
-        }
-        if is_runtime_protected_path(&node.path) {
-            anyhow::bail!(
-                "connector-owned node may not target runtime-protected path: {}",
-                node.path
-            );
-        }
-        Ok(())
+        validate_structure_node(node)
     }
 
     fn context(&self, request_id: &str) -> ConnectorContext {
@@ -462,6 +500,167 @@ impl AppTreeSyncService {
     fn app_dir(&self) -> PathBuf {
         self.root.join(&self.app_id)
     }
+}
+
+async fn load_state_from_agentfs(
+    agent: &SdkAgentFS,
+    app_id: &str,
+) -> Result<AppStructureSyncStateDoc> {
+    let path = format!("/{app_id}/_meta/{APP_STRUCTURE_SYNC_STATE_FILENAME}");
+    let Some(bytes) = agent.fs.read_file(&path).await? else {
+        return Ok(AppStructureSyncStateDoc::default());
+    };
+    Ok(serde_json::from_slice(&bytes)?)
+}
+
+async fn prune_removed_owned_paths_in_agentfs(
+    agent: &SdkAgentFS,
+    app_id: &str,
+    previous_owned_paths: &[String],
+    desired_owned_paths: &BTreeSet<String>,
+) -> Result<()> {
+    let mut to_remove: Vec<String> = previous_owned_paths
+        .iter()
+        .filter(|path| !desired_owned_paths.contains(path.as_str()))
+        .cloned()
+        .collect();
+    to_remove.sort_by_key(|path| std::cmp::Reverse(path.len()));
+
+    for rel in to_remove {
+        if is_runtime_protected_path(&rel) {
+            continue;
+        }
+        let abs = format!("/{app_id}/{rel}");
+        match agent.fs.remove(&abs).await {
+            Ok(()) => {}
+            Err(agentfs_sdk::error::Error::Fs(agentfs_sdk::FsError::NotFound)) => {}
+            Err(err) => {
+                return Err(err)
+                    .with_context(|| format!("failed to prune stale structure path {abs}"));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn desired_owned_paths_for_snapshot(snapshot: &AppStructureSnapshot) -> BTreeSet<String> {
+    let mut owned = BTreeSet::new();
+    owned.insert("_meta".to_string());
+    owned.insert("_meta/manifest.res.json".to_string());
+    for node in &snapshot.nodes {
+        owned.insert(node.path.clone());
+        let mut current = Path::new(&node.path).parent();
+        while let Some(parent) = current {
+            let rel = parent.to_string_lossy().replace('\\', "/");
+            if rel.is_empty() {
+                break;
+            }
+            if is_runtime_protected_path(&rel) {
+                break;
+            }
+            owned.insert(rel.clone());
+            current = parent.parent();
+        }
+    }
+    owned
+}
+
+fn validate_structure_node(node: &AppStructureNode) -> Result<()> {
+    if node.path.trim().is_empty() {
+        anyhow::bail!("structure node path cannot be empty");
+    }
+    let rel = Path::new(&node.path);
+    if rel.is_absolute() {
+        anyhow::bail!("structure node path must be relative: {}", node.path);
+    }
+    for component in rel.components() {
+        use std::path::Component;
+        match component {
+            Component::Normal(_) => {}
+            _ => anyhow::bail!("structure node path is invalid: {}", node.path),
+        }
+    }
+    if is_runtime_protected_path(&node.path) {
+        anyhow::bail!(
+            "connector-owned node may not target runtime-protected path: {}",
+            node.path
+        );
+    }
+    Ok(())
+}
+
+fn build_bulk_materialize_plan(
+    app_id: &str,
+    snapshot: &AppStructureSnapshot,
+    state: &AppStructureSyncStateDoc,
+) -> Result<BulkMaterializePlan> {
+    let mut plan = BulkMaterializePlan::new();
+    let mut manifest_nodes = BTreeMap::new();
+    let mut dir_paths = BTreeSet::new();
+    dir_paths.insert(format!("/{app_id}"));
+    dir_paths.insert(format!("/{app_id}/_meta"));
+
+    for node in &snapshot.nodes {
+        validate_structure_node(node)?;
+        if let Some(parent) = Path::new(&node.path).parent() {
+            let rel = parent.to_string_lossy().replace('\\', "/");
+            if !rel.is_empty() {
+                dir_paths.insert(format!("/{app_id}/{rel}"));
+            }
+        }
+        if matches!(node.kind, AppStructureNodeKind::Directory) {
+            dir_paths.insert(format!("/{app_id}/{}", node.path));
+        }
+        if let Some(entry) = &node.manifest_entry {
+            let template = entry
+                .get("template")
+                .and_then(|value| value.as_str())
+                .ok_or_else(|| {
+                    anyhow::anyhow!("manifest_entry missing template for {}", node.path)
+                })?;
+            let mut normalized = entry.clone();
+            if let Some(obj) = normalized.as_object_mut() {
+                obj.remove("template");
+            }
+            manifest_nodes.insert(template.to_string(), normalized);
+        }
+    }
+
+    for dir in dir_paths {
+        plan.push(BulkMaterializeEntry::ensure_dir(dir));
+    }
+
+    for node in &snapshot.nodes {
+        let full = format!("/{app_id}/{}", node.path);
+        match node.kind {
+            AppStructureNodeKind::Directory => {}
+            AppStructureNodeKind::ActionFile | AppStructureNodeKind::SnapshotResource => {
+                plan.push(BulkMaterializeEntry::ensure_empty_file(full));
+            }
+            AppStructureNodeKind::LiveResource | AppStructureNodeKind::StaticJsonResource => {
+                let content = node.seed_content.clone().unwrap_or_else(|| json!({}));
+                plan.push(BulkMaterializeEntry::write_file(
+                    full,
+                    serde_json::to_vec_pretty(&content)?,
+                ));
+            }
+        }
+    }
+
+    let manifest_json = json!({
+        "app_id": app_id,
+        "nodes": manifest_nodes,
+    });
+    plan.push(BulkMaterializeEntry::write_file(
+        format!("/{app_id}/_meta/manifest.res.json"),
+        serde_json::to_vec_pretty(&manifest_json)?,
+    ));
+    plan.push(BulkMaterializeEntry::write_file(
+        format!("/{app_id}/_meta/{APP_STRUCTURE_SYNC_STATE_FILENAME}"),
+        serde_json::to_vec_pretty(state)?,
+    ));
+
+    Ok(plan)
 }
 
 fn bootstrap_runtime_scaffolding(root: &Path, app_id: &str) -> Result<()> {

--- a/cli/src/cmd/mount.rs
+++ b/cli/src/cmd/mount.rs
@@ -738,8 +738,8 @@ async fn mount_winfsp_backend(args: MountArgs, ready_tx: Option<MountReadyTx>) -
     eprintln!("Mounted at {}", mountpoint.display());
     eprintln!("Press Ctrl+C to unmount and exit.");
 
-    // Wait for Ctrl+C
-    tokio::signal::ctrl_c().await?;
+    // Wait for a console shutdown signal so the MountHandle can unmount cleanly.
+    crate::shutdown_signal::wait_for_shutdown_signal().await?;
 
     // MountHandle will be dropped automatically and unmount
     Ok(())
@@ -877,7 +877,7 @@ fn mount_fuse(args: MountArgs, ready_tx: Option<MountReadyTx>) -> Result<()> {
             eprintln!("Mounted at {}", mountpoint.display());
             eprintln!("Press Ctrl+C to unmount and exit.");
             tokio::select! {
-                _ = tokio::signal::ctrl_c() => {}
+                _ = crate::shutdown_signal::wait_for_shutdown_signal() => {}
                 _ = wait_for_external_unmount(mountpoint.clone()) => {
                     eprintln!(
                         "Mountpoint {} was unmounted externally; exiting foreground mode.",
@@ -1089,7 +1089,7 @@ async fn mount_nfs_backend(args: MountArgs, ready_tx: Option<MountReadyTx>) -> R
 
         eprintln!("Mounted at {}", mountpoint.display());
         eprintln!("Press Ctrl+C to unmount and exit.");
-        tokio::signal::ctrl_c().await?;
+        crate::shutdown_signal::wait_for_shutdown_signal().await?;
 
         // Handle drops automatically when we exit this scope
     } else {

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod cmd;
 pub mod opts;
 pub mod sandbox;
+pub mod shutdown_signal;
 
 #[cfg(target_os = "linux")]
 pub mod daemon;

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -2,8 +2,8 @@ use agentfs::{
     cmd::{self, completions::handle_completions},
     get_runtime,
     opts::{
-        AppfsCommand, AppfsComposeCommand, Args, Command, FsCommand, PruneCommand, ServeCommand,
-        SyncCommand,
+        AppfsCommand, AppfsComposeCommand, AppfsQueryCommand, Args, Command, FsCommand,
+        PruneCommand, ServeCommand, SyncCommand,
     },
 };
 use clap::{CommandFactory, Parser};
@@ -507,6 +507,64 @@ fn main() {
                 AppfsComposeCommand::Up { file } => {
                     let rt = get_runtime();
                     if let Err(e) = rt.block_on(cmd::appfs::handle_appfs_compose_up_command(file)) {
+                        eprintln!("Error: {}", e);
+                        std::process::exit(1);
+                    }
+                }
+            },
+            AppfsCommand::Query { command } => match command {
+                AppfsQueryCommand::Tree {
+                    db,
+                    root,
+                    max_depth,
+                    max_entries_per_dir,
+                    include_files,
+                    include_internal,
+                    format,
+                } => {
+                    let rt = get_runtime();
+                    if let Err(e) = rt.block_on(cmd::appfs::handle_appfs_query_tree_command(
+                        cmd::appfs::AppfsQueryTreeArgs {
+                            db,
+                            root,
+                            max_depth,
+                            max_entries_per_dir,
+                            include_files,
+                            include_internal,
+                            format,
+                        },
+                    )) {
+                        eprintln!("Error: {}", e);
+                        std::process::exit(1);
+                    }
+                }
+                AppfsQueryCommand::Glob {
+                    db,
+                    root,
+                    pattern,
+                    max_depth,
+                    max_results,
+                    max_scanned_entries,
+                    include_dirs,
+                    ignore_case,
+                    include_internal,
+                    format,
+                } => {
+                    let rt = get_runtime();
+                    if let Err(e) = rt.block_on(cmd::appfs::handle_appfs_query_glob_command(
+                        cmd::appfs::AppfsQueryGlobArgs {
+                            db,
+                            root,
+                            pattern,
+                            max_depth,
+                            max_results,
+                            max_scanned_entries,
+                            include_dirs,
+                            ignore_case,
+                            include_internal,
+                            format,
+                        },
+                    )) {
                         eprintln!("Error: {}", e);
                         std::process::exit(1);
                     }

--- a/cli/src/opts.rs
+++ b/cli/src/opts.rs
@@ -687,6 +687,11 @@ pub enum AppfsCommand {
         #[command(subcommand)]
         command: AppfsComposeCommand,
     },
+    /// Query an AppFS database without walking the mounted filesystem
+    Query {
+        #[command(subcommand)]
+        command: AppfsQueryCommand,
+    },
 }
 
 #[derive(Subcommand, Debug)]
@@ -702,6 +707,97 @@ pub enum AppfsComposeCommand {
             add = ArgValueCompleter::new(PathCompleter::file())
         )]
         file: Option<PathBuf>,
+    },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
+pub enum AppfsQueryFormat {
+    Json,
+    Text,
+}
+
+impl std::fmt::Display for AppfsQueryFormat {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            AppfsQueryFormat::Json => write!(f, "json"),
+            AppfsQueryFormat::Text => write!(f, "text"),
+        }
+    }
+}
+
+#[derive(Subcommand, Debug)]
+pub enum AppfsQueryCommand {
+    /// Return a bounded directory tree from the AppFS database
+    Tree {
+        /// AgentFS database path
+        #[arg(long, value_name = "DB", add = ArgValueCompleter::new(PathCompleter::file()))]
+        db: PathBuf,
+
+        /// Root path inside AppFS
+        #[arg(long, default_value = "huoyan")]
+        root: String,
+
+        /// Maximum depth below root
+        #[arg(long, default_value_t = 2)]
+        max_depth: usize,
+
+        /// Maximum entries returned per directory, 0 means unlimited
+        #[arg(long, default_value_t = 100)]
+        max_entries_per_dir: usize,
+
+        /// Include files in addition to directories
+        #[arg(long)]
+        include_files: bool,
+
+        /// Include internal AppFS paths such as _meta and _stream
+        #[arg(long)]
+        include_internal: bool,
+
+        /// Output format
+        #[arg(long, value_enum, default_value_t = AppfsQueryFormat::Json)]
+        format: AppfsQueryFormat,
+    },
+    /// Return paths matching a glob from the AppFS database
+    Glob {
+        /// AgentFS database path
+        #[arg(long, value_name = "DB", add = ArgValueCompleter::new(PathCompleter::file()))]
+        db: PathBuf,
+
+        /// Root path inside AppFS. The pattern is evaluated relative to this root.
+        #[arg(long, default_value = "huoyan")]
+        root: String,
+
+        /// Glob pattern, for example "**/*.res.jsonl"
+        #[arg(long)]
+        pattern: String,
+
+        /// Maximum depth below root
+        #[arg(long, default_value_t = 64)]
+        max_depth: usize,
+
+        /// Maximum returned results
+        #[arg(long, default_value_t = 100)]
+        max_results: usize,
+
+        /// Maximum entries scanned before truncating
+        #[arg(long, default_value_t = 500000)]
+        max_scanned_entries: usize,
+
+        /// Include directories in results
+        #[arg(long)]
+        include_dirs: bool,
+
+        /// Match case-insensitively
+        #[arg(long)]
+        ignore_case: bool,
+
+        /// Include internal AppFS paths such as _meta and _stream
+        #[arg(long)]
+        include_internal: bool,
+
+        /// Output format
+        #[arg(long, value_enum, default_value_t = AppfsQueryFormat::Json)]
+        format: AppfsQueryFormat,
     },
 }
 

--- a/cli/src/shutdown_signal.rs
+++ b/cli/src/shutdown_signal.rs
@@ -1,0 +1,26 @@
+use anyhow::Result;
+
+#[cfg(target_os = "windows")]
+pub async fn wait_for_shutdown_signal() -> Result<()> {
+    let mut ctrl_c = tokio::signal::windows::ctrl_c()?;
+    let mut ctrl_break = tokio::signal::windows::ctrl_break()?;
+    let mut ctrl_close = tokio::signal::windows::ctrl_close()?;
+    let mut ctrl_logoff = tokio::signal::windows::ctrl_logoff()?;
+    let mut ctrl_shutdown = tokio::signal::windows::ctrl_shutdown()?;
+
+    tokio::select! {
+        _ = ctrl_c.recv() => {}
+        _ = ctrl_break.recv() => {}
+        _ = ctrl_close.recv() => {}
+        _ = ctrl_logoff.recv() => {}
+        _ = ctrl_shutdown.recv() => {}
+    }
+
+    Ok(())
+}
+
+#[cfg(not(target_os = "windows"))]
+pub async fn wait_for_shutdown_signal() -> Result<()> {
+    tokio::signal::ctrl_c().await?;
+    Ok(())
+}

--- a/cli/src/winfsp.rs
+++ b/cli/src/winfsp.rs
@@ -231,6 +231,8 @@ struct OpenFile {
     deleted: std::sync::atomic::AtomicBool,
     /// Path to the file (for deletion on close)
     path: String,
+    /// Cached directory entries for a directory handle.
+    dir_entries: Mutex<Option<Vec<(String, Stats)>>>,
 }
 
 /// WinFsp filesystem adapter wrapping an AgentFS FileSystem.
@@ -500,6 +502,78 @@ impl AgentFSWinFsp {
                 Ok(all_entries)
             }
             Ok(None) => Err(FspError::NTSTATUS(STATUS_OBJECT_NAME_NOT_FOUND)),
+            Err(e) => Err(FspError::NTSTATUS(error_to_ntstatus(&e))),
+        }
+    }
+
+    fn cached_directory_entries(
+        &self,
+        fh: u64,
+        dir_ino: i64,
+        dir_path: &str,
+    ) -> winfsp::Result<Vec<(String, Stats)>> {
+        if let Some(cached) = {
+            let open_files = self.open_files.lock();
+            open_files
+                .get(&fh)
+                .and_then(|open_file| open_file.dir_entries.lock().clone())
+        } {
+            return Ok(cached);
+        }
+
+        let entries = self.list_directory_entries(dir_ino, dir_path)?;
+        {
+            let open_files = self.open_files.lock();
+            if let Some(open_file) = open_files.get(&fh) {
+                *open_file.dir_entries.lock() = Some(entries.clone());
+            }
+        }
+        Ok(entries)
+    }
+
+    fn lookup_directory_entry(
+        &self,
+        dir_ino: i64,
+        dir_path: &str,
+        query_name: &str,
+    ) -> winfsp::Result<Option<(String, Stats)>> {
+        let name = Self::sanitize_dir_entry_name(Self::normalize_directory_pattern(query_name));
+        if name.is_empty() {
+            return Ok(None);
+        }
+        if name == "." {
+            let fs = self.fs.clone();
+            let stats = self.block_on(async move { fs.lock().getattr(dir_ino).await });
+            return match stats {
+                Ok(Some(stats)) => Ok(Some((".".to_string(), stats))),
+                Ok(None) => Err(FspError::NTSTATUS(STATUS_OBJECT_NAME_NOT_FOUND)),
+                Err(e) => Err(FspError::NTSTATUS(error_to_ntstatus(&e))),
+            };
+        }
+        if name == ".." {
+            let parent_ino = if dir_path == "/" {
+                1
+            } else {
+                match self.parse_path(dir_path) {
+                    Ok((parent_ino, _)) => parent_ino,
+                    Err(e) => return Err(FspError::NTSTATUS(anyhow_to_ntstatus(&e))),
+                }
+            };
+            let fs = self.fs.clone();
+            let stats = self.block_on(async move { fs.lock().getattr(parent_ino).await });
+            return match stats {
+                Ok(Some(stats)) => Ok(Some(("..".to_string(), stats))),
+                Ok(None) => Err(FspError::NTSTATUS(STATUS_OBJECT_NAME_NOT_FOUND)),
+                Err(e) => Err(FspError::NTSTATUS(error_to_ntstatus(&e))),
+            };
+        }
+
+        let fs = self.fs.clone();
+        let name_owned = name.to_string();
+        let stats = self.block_on(async move { fs.lock().lookup(dir_ino, &name_owned).await });
+        match stats {
+            Ok(Some(stats)) => Ok(Some((name.to_string(), stats))),
+            Ok(None) => Ok(None),
             Err(e) => Err(FspError::NTSTATUS(error_to_ntstatus(&e))),
         }
     }
@@ -778,6 +852,7 @@ impl FileSystemContext for AgentFSWinFsp {
                             delete_on_close: std::sync::atomic::AtomicBool::new(delete_on_close),
                             deleted: std::sync::atomic::AtomicBool::new(false),
                             path: path_owned,
+                            dir_entries: Mutex::new(None),
                         },
                     );
                     Ok(FileContext { fh })
@@ -793,6 +868,7 @@ impl FileSystemContext for AgentFSWinFsp {
                             delete_on_close: std::sync::atomic::AtomicBool::new(delete_on_close),
                             deleted: std::sync::atomic::AtomicBool::new(false),
                             path: path_owned,
+                            dir_entries: Mutex::new(None),
                         },
                     );
                     Ok(FileContext { fh })
@@ -826,6 +902,7 @@ impl FileSystemContext for AgentFSWinFsp {
                                     ),
                                     deleted: std::sync::atomic::AtomicBool::new(false),
                                     path: path_owned,
+                                    dir_entries: Mutex::new(None),
                                 },
                             );
                             Ok(FileContext { fh })
@@ -899,6 +976,7 @@ impl FileSystemContext for AgentFSWinFsp {
                             delete_on_close: std::sync::atomic::AtomicBool::new(delete_on_close),
                             deleted: std::sync::atomic::AtomicBool::new(false),
                             path: path_owned,
+                            dir_entries: Mutex::new(None),
                         },
                     );
                     Ok(FileContext { fh })
@@ -914,6 +992,7 @@ impl FileSystemContext for AgentFSWinFsp {
                             delete_on_close: std::sync::atomic::AtomicBool::new(delete_on_close),
                             deleted: std::sync::atomic::AtomicBool::new(false),
                             path: path_owned,
+                            dir_entries: Mutex::new(None),
                         },
                     );
                     Ok(FileContext { fh })
@@ -946,6 +1025,7 @@ impl FileSystemContext for AgentFSWinFsp {
                                     ),
                                     deleted: std::sync::atomic::AtomicBool::new(false),
                                     path: path_owned,
+                                    dir_entries: Mutex::new(None),
                                 },
                             );
                             Ok(FileContext { fh })
@@ -1014,6 +1094,7 @@ impl FileSystemContext for AgentFSWinFsp {
                                     ),
                                     deleted: std::sync::atomic::AtomicBool::new(false),
                                     path: path_owned,
+                                    dir_entries: Mutex::new(None),
                                 },
                             );
                             Ok(FileContext { fh })
@@ -1030,6 +1111,7 @@ impl FileSystemContext for AgentFSWinFsp {
                                     ),
                                     deleted: std::sync::atomic::AtomicBool::new(false),
                                     path: path_owned,
+                                    dir_entries: Mutex::new(None),
                                 },
                             );
                             Ok(FileContext { fh })
@@ -1055,6 +1137,7 @@ impl FileSystemContext for AgentFSWinFsp {
                                             ),
                                             deleted: std::sync::atomic::AtomicBool::new(false),
                                             path: path_owned,
+                                            dir_entries: Mutex::new(None),
                                         },
                                     );
                                     Ok(FileContext { fh })
@@ -1344,7 +1427,7 @@ impl FileSystemContext for AgentFSWinFsp {
             }
         };
 
-        let all_entries = self.list_directory_entries(dir_ino, &dir_path)?;
+        let all_entries = self.cached_directory_entries(context.fh, dir_ino, &dir_path)?;
         let original_entry_count = all_entries.len();
         let filtered_entries: Vec<(String, Stats)> = all_entries
             .into_iter()
@@ -1428,14 +1511,18 @@ impl FileSystemContext for AgentFSWinFsp {
             }
         };
 
-        let entries = self.list_directory_entries(dir_ino, &dir_path)?;
         let normalized_query = Self::normalize_directory_pattern(&query_name);
-        let entry = entries.into_iter().find(|(name, _stats)| {
-            Self::should_include_dir_entry(
-                Self::sanitize_dir_entry_name(name),
-                Some(normalized_query),
-            )
-        });
+        let entry = if normalized_query.contains(['*', '?', DOS_STAR, DOS_QM, DOS_DOT]) {
+            let entries = self.cached_directory_entries(context.fh, dir_ino, &dir_path)?;
+            entries.into_iter().find(|(name, _stats)| {
+                Self::should_include_dir_entry(
+                    Self::sanitize_dir_entry_name(name),
+                    Some(normalized_query),
+                )
+            })
+        } else {
+            self.lookup_directory_entry(dir_ino, &dir_path, normalized_query)?
+        };
 
         match entry {
             Some((name, stats)) => Self::fill_dir_info(out_dir_info, &name, &stats),
@@ -1451,6 +1538,9 @@ impl FileSystemContext for AgentFSWinFsp {
     ) -> winfsp::Result<u32> {
         let open_files = self.open_files.lock();
         if let Some(open_file) = open_files.get(&context.fh) {
+            if buffer.is_empty() {
+                return Ok(0);
+            }
             let file = open_file.file.clone();
             let buf_len = buffer.len();
             let is_dir = open_file.is_dir;
@@ -1952,6 +2042,8 @@ mod tests {
     struct MockFs {
         by_parent: HashMap<(i64, String), Stats>,
         by_ino: HashMap<i64, Stats>,
+        lookup_calls: Arc<std::sync::atomic::AtomicUsize>,
+        readdir_plus_calls: Arc<std::sync::atomic::AtomicUsize>,
     }
 
     impl MockFs {
@@ -1962,6 +2054,8 @@ mod tests {
             Self {
                 by_parent: HashMap::new(),
                 by_ino,
+                lookup_calls: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+                readdir_plus_calls: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
             }
         }
 
@@ -1976,6 +2070,8 @@ mod tests {
     #[async_trait]
     impl FileSystem for MockFs {
         async fn lookup(&self, parent_ino: i64, name: &str) -> SdkResult<Option<Stats>> {
+            self.lookup_calls
+                .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
             Ok(self.by_parent.get(&(parent_ino, name.to_string())).cloned())
         }
 
@@ -1992,6 +2088,8 @@ mod tests {
         }
 
         async fn readdir_plus(&self, _ino: i64) -> SdkResult<Option<Vec<DirEntry>>> {
+            self.readdir_plus_calls
+                .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
             let mut entries: Vec<DirEntry> = self
                 .by_parent
                 .iter()
@@ -2144,6 +2242,7 @@ mod tests {
                     delete_on_close: AtomicBool::new(false),
                     deleted: AtomicBool::new(false),
                     path: dir_path.to_string(),
+                    dir_entries: Mutex::new(None),
                 },
             );
             f(adapter, FileContext { fh })
@@ -2263,6 +2362,60 @@ mod tests {
             "ab.txt", "a>>.txt"
         ));
         assert!(AgentFSWinFsp::directory_pattern_matches("a", "a\""));
+    }
+
+    #[test]
+    fn directory_entries_are_cached_per_open_directory_handle() {
+        let fs = MockFs::new()
+            .with_child(1, "a.txt", test_stats(2, 0o100644, 7))
+            .with_child(1, "b.txt", test_stats(3, 0o100644, 9));
+        let readdir_plus_calls = fs.readdir_plus_calls.clone();
+
+        with_open_directory_context(fs, 1, "/", |adapter, context| {
+            let first = adapter
+                .cached_directory_entries(context.fh, 1, "/")
+                .expect("first directory scan");
+            let second = adapter
+                .cached_directory_entries(context.fh, 1, "/")
+                .expect("cached directory scan");
+
+            assert_eq!(first.len(), second.len());
+            assert_eq!(
+                readdir_plus_calls.load(std::sync::atomic::Ordering::SeqCst),
+                1,
+                "repeated WinFsp read_directory calls on one handle should not rescan the DB"
+            );
+        });
+    }
+
+    #[test]
+    fn get_dir_info_by_name_exact_lookup_does_not_scan_directory() {
+        let fs = MockFs::new()
+            .with_child(1, "notes.txt", test_stats(2, 0o100644, 7))
+            .with_child(1, "账户信息.res.jsonl", test_stats(3, 0o100644, 123));
+        let lookup_calls = fs.lookup_calls.clone();
+        let readdir_plus_calls = fs.readdir_plus_calls.clone();
+
+        with_open_directory_context(fs, 1, "/", |adapter, context| {
+            let query = U16CString::from_str("账户信息.res.jsonl").expect("exact query");
+            let mut dir_info = DirInfo::<255>::default();
+
+            <AgentFSWinFsp as FileSystemContext>::get_dir_info_by_name(
+                adapter,
+                &context,
+                query.as_ucstr(),
+                &mut dir_info,
+            )
+            .expect("exact lookup should resolve matching entry");
+
+            assert_eq!(dir_info.file_info_mut().file_size, 123);
+            assert_eq!(lookup_calls.load(std::sync::atomic::Ordering::SeqCst), 1);
+            assert_eq!(
+                readdir_plus_calls.load(std::sync::atomic::Ordering::SeqCst),
+                0,
+                "exact WinFsp get_dir_info_by_name should avoid full directory scans"
+            );
+        });
     }
 
     #[test]

--- a/cli/src/winfsp.rs
+++ b/cli/src/winfsp.rs
@@ -215,6 +215,44 @@ fn granted_access_to_open_flags(granted_access: u32) -> i32 {
     flags
 }
 
+struct CachedDirectoryEntries {
+    entries: Vec<(String, Stats)>,
+    name_index: HashMap<String, usize>,
+}
+
+impl CachedDirectoryEntries {
+    fn new(entries: Vec<(String, Stats)>) -> Self {
+        let mut name_index = HashMap::with_capacity(entries.len());
+        for (index, (name, _stats)) in entries.iter().enumerate() {
+            name_index.insert(
+                AgentFSWinFsp::sanitize_dir_entry_name(name).to_string(),
+                index,
+            );
+        }
+        Self {
+            entries,
+            name_index,
+        }
+    }
+
+    fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    fn index_of(&self, name: &str) -> Option<usize> {
+        self.name_index.get(name).copied()
+    }
+
+    fn get(&self, name: &str) -> Option<&(String, Stats)> {
+        self.index_of(name)
+            .and_then(|index| self.entries.get(index))
+    }
+
+    fn iter(&self) -> impl Iterator<Item = &(String, Stats)> {
+        self.entries.iter()
+    }
+}
+
 /// Tracks an open file or directory handle
 struct OpenFile {
     /// The file handle (None for directories)
@@ -232,7 +270,7 @@ struct OpenFile {
     /// Path to the file (for deletion on close)
     path: String,
     /// Cached directory entries for a directory handle.
-    dir_entries: Mutex<Option<Arc<Vec<(String, Stats)>>>>,
+    dir_entries: Mutex<Option<Arc<CachedDirectoryEntries>>>,
 }
 
 /// WinFsp filesystem adapter wrapping an AgentFS FileSystem.
@@ -240,7 +278,8 @@ pub struct AgentFSWinFsp {
     fs: Arc<Mutex<dyn FileSystem + Send>>,
     handle: Handle,
     open_files: Mutex<HashMap<u64, OpenFile>>,
-    path_ino_cache: Mutex<HashMap<String, i64>>,
+    path_stats_cache: Mutex<HashMap<String, Stats>>,
+    dir_entries_cache: Mutex<HashMap<i64, Arc<CachedDirectoryEntries>>>,
     next_fh: AtomicU64,
 }
 
@@ -251,7 +290,8 @@ impl AgentFSWinFsp {
             fs,
             handle,
             open_files: Mutex::new(HashMap::new()),
-            path_ino_cache: Mutex::new(HashMap::new()),
+            path_stats_cache: Mutex::new(HashMap::new()),
+            dir_entries_cache: Mutex::new(HashMap::new()),
             next_fh: AtomicU64::new(1),
         }
     }
@@ -292,27 +332,22 @@ impl AgentFSWinFsp {
         }
     }
 
-    fn remember_path_ino(&self, path: &str, ino: i64) {
-        self.path_ino_cache
+    fn remember_path_stats(&self, path: &str, stats: &Stats) {
+        self.path_stats_cache
             .lock()
-            .insert(Self::normalize_cache_path(path), ino);
+            .insert(Self::normalize_cache_path(path), stats.clone());
     }
 
-    fn forget_path_ino(&self, path: &str) {
-        self.path_ino_cache
-            .lock()
-            .remove(&Self::normalize_cache_path(path));
+    fn clear_metadata_caches(&self) {
+        self.path_stats_cache.lock().clear();
+        self.dir_entries_cache.lock().clear();
     }
 
-    fn clear_path_ino_cache(&self) {
-        self.path_ino_cache.lock().clear();
-    }
-
-    fn lookup_cached_path_ino(&self, path: &str) -> Option<i64> {
-        self.path_ino_cache
+    fn lookup_cached_path_stats(&self, path: &str) -> Option<Stats> {
+        self.path_stats_cache
             .lock()
             .get(&Self::normalize_cache_path(path))
-            .copied()
+            .cloned()
     }
 
     /// Parse a path into (parent_ino, name) for operations that need a parent directory.
@@ -362,12 +397,8 @@ impl AgentFSWinFsp {
 
     /// Look up a path and return its stats. Walks the entire path.
     fn path_lookup(&self, path: &str) -> Result<Option<Stats>> {
-        if let Some(ino) = self.lookup_cached_path_ino(path) {
-            let fs = self.fs.clone();
-            match self.block_on(async move { fs.lock().getattr(ino).await })? {
-                Some(stats) => return Ok(Some(stats)),
-                None => self.forget_path_ino(path),
-            }
+        if let Some(stats) = self.lookup_cached_path_stats(path) {
+            return Ok(Some(stats));
         }
 
         let path = path.trim_start_matches('/');
@@ -380,7 +411,7 @@ impl AgentFSWinFsp {
         let fs = self.fs.clone();
         let stats = self.block_on(async move { fs.lock().lookup(parent_ino, &name).await })?;
         if let Some(stats) = stats.as_ref() {
-            self.remember_path_ino(path, stats.ino);
+            self.remember_path_stats(path, stats);
         }
         Ok(stats)
     }
@@ -550,15 +581,15 @@ impl AgentFSWinFsp {
                     Ok(None) => dir_stats.clone(),
                     Err(e) => return Err(FspError::NTSTATUS(error_to_ntstatus(&e))),
                 };
-                self.remember_path_ino(dir_path, dir_stats.ino);
+                self.remember_path_stats(dir_path, &dir_stats);
 
                 let mut all_entries: Vec<(String, Stats)> = Vec::with_capacity(entries.len() + 2);
                 all_entries.push((".".to_string(), dir_stats));
                 all_entries.push(("..".to_string(), parent_stats));
                 for entry in entries {
-                    self.remember_path_ino(
+                    self.remember_path_stats(
                         &Self::join_child_path(dir_path, &entry.name),
-                        entry.stats.ino,
+                        &entry.stats,
                     );
                     all_entries.push((entry.name, entry.stats));
                 }
@@ -574,7 +605,7 @@ impl AgentFSWinFsp {
         fh: u64,
         dir_ino: i64,
         dir_path: &str,
-    ) -> winfsp::Result<Arc<Vec<(String, Stats)>>> {
+    ) -> winfsp::Result<Arc<CachedDirectoryEntries>> {
         if let Some(cached) = {
             let open_files = self.open_files.lock();
             open_files
@@ -584,14 +615,34 @@ impl AgentFSWinFsp {
             return Ok(cached);
         }
 
-        let entries = Arc::new(self.list_directory_entries(dir_ino, dir_path)?);
+        if let Some(cached) = self.dir_entries_cache.lock().get(&dir_ino).cloned() {
+            let open_files = self.open_files.lock();
+            if let Some(open_file) = open_files.get(&fh) {
+                *open_file.dir_entries.lock() = Some(cached.clone());
+            }
+            return Ok(cached);
+        }
+
+        let entries = Arc::new(CachedDirectoryEntries::new(
+            self.list_directory_entries(dir_ino, dir_path)?,
+        ));
         {
             let open_files = self.open_files.lock();
             if let Some(open_file) = open_files.get(&fh) {
                 *open_file.dir_entries.lock() = Some(entries.clone());
             }
         }
+        self.dir_entries_cache
+            .lock()
+            .insert(dir_ino, entries.clone());
         Ok(entries)
+    }
+
+    fn cached_directory_entries_if_loaded(&self, fh: u64) -> Option<Arc<CachedDirectoryEntries>> {
+        let open_files = self.open_files.lock();
+        open_files
+            .get(&fh)
+            .and_then(|open_file| open_file.dir_entries.lock().clone())
     }
 
     fn lookup_directory_entry(
@@ -636,7 +687,7 @@ impl AgentFSWinFsp {
         let stats = self.block_on(async move { fs.lock().lookup(dir_ino, &name_owned).await });
         match stats {
             Ok(Some(stats)) => {
-                self.remember_path_ino(&Self::join_child_path(dir_path, name), stats.ino);
+                self.remember_path_stats(&Self::join_child_path(dir_path, name), &stats);
                 Ok(Some((name.to_string(), stats)))
             }
             Ok(None) => Ok(None),
@@ -660,7 +711,7 @@ impl AgentFSWinFsp {
                 fs_guard.unlink(parent_ino, &name).await
             }
         })?;
-        self.clear_path_ino_cache();
+        self.clear_metadata_caches();
         Ok(())
     }
 
@@ -1020,7 +1071,7 @@ impl FileSystemContext for AgentFSWinFsp {
 
         match existing {
             Ok(Some(stats)) => {
-                self.remember_path_ino(&path, stats.ino);
+                self.remember_path_stats(&path, &stats);
                 // File already exists - open it directly
                 // WinFsp will call overwrite() if truncation is needed
                 tracing::trace!(
@@ -1143,8 +1194,8 @@ impl FileSystemContext for AgentFSWinFsp {
 
                 match result {
                     Ok(stats) => {
-                        self.clear_path_ino_cache();
-                        self.remember_path_ino(&path, stats.ino);
+                        self.clear_metadata_caches();
+                        self.remember_path_stats(&path, &stats);
                         fill_file_info(&stats, file_info.as_mut());
 
                         let fh = self.alloc_fh();
@@ -1362,6 +1413,7 @@ impl FileSystemContext for AgentFSWinFsp {
 
             match result {
                 Ok(()) => {
+                    self.clear_metadata_caches();
                     let fs = self.fs.clone();
                     let stats = self.block_on(async move { fs.lock().getattr(ino).await });
                     match stats {
@@ -1463,7 +1515,7 @@ impl FileSystemContext for AgentFSWinFsp {
 
         match result {
             Ok(()) => {
-                self.clear_path_ino_cache();
+                self.clear_metadata_caches();
                 Ok(())
             }
             Err(e) => Err(FspError::NTSTATUS(error_to_ntstatus(&e))),
@@ -1515,18 +1567,15 @@ impl FileSystemContext for AgentFSWinFsp {
             .as_deref()
             .map(Self::sanitize_dir_entry_name)
             .filter(|name| !name.is_empty());
-        let mut marker_seen = marker_name.is_none();
+        let start_idx = marker_name
+            .and_then(|name| all_entries.index_of(name))
+            .map(|index| index + 1)
+            .unwrap_or(0);
         let mut cursor = 0u32;
 
-        for (name, stats) in all_entries.iter() {
+        for (name, stats) in all_entries.entries.iter().skip(start_idx) {
             let name = Self::sanitize_dir_entry_name(name);
             if !Self::should_include_dir_entry(name, pattern_str.as_deref()) {
-                continue;
-            }
-            if !marker_seen {
-                if Some(name) == marker_name {
-                    marker_seen = true;
-                }
                 continue;
             }
             let mut dir_info: DirInfo<255> = DirInfo::default();
@@ -1574,7 +1623,7 @@ impl FileSystemContext for AgentFSWinFsp {
         let normalized_query = Self::normalize_directory_pattern(&query_name);
         let entry = if normalized_query.contains(['*', '?', DOS_STAR, DOS_QM, DOS_DOT]) {
             let entries = self.cached_directory_entries(context.fh, dir_ino, &dir_path)?;
-            entries
+            let found = entries
                 .iter()
                 .find(|(name, _stats)| {
                     Self::should_include_dir_entry(
@@ -1582,10 +1631,15 @@ impl FileSystemContext for AgentFSWinFsp {
                         Some(normalized_query),
                     )
                 })
-                .map(|(name, stats)| (name.clone(), stats.clone()))
+                .map(|(name, stats)| (name.clone(), stats.clone()));
+            Ok(found)
+        } else if let Some(entries) = self.cached_directory_entries_if_loaded(context.fh) {
+            Ok(entries
+                .get(Self::sanitize_dir_entry_name(normalized_query))
+                .map(|(name, stats)| (name.clone(), stats.clone())))
         } else {
-            self.lookup_directory_entry(dir_ino, &dir_path, normalized_query)?
-        };
+            self.lookup_directory_entry(dir_ino, &dir_path, normalized_query)
+        }?;
 
         match entry {
             Some((name, stats)) => Self::fill_dir_info(out_dir_info, &name, &stats),
@@ -1630,6 +1684,9 @@ impl FileSystemContext for AgentFSWinFsp {
                 Ok(data) => {
                     let len = data.len().min(buffer.len());
                     buffer[..len].copy_from_slice(&data[..len]);
+                    if len > 0 {
+                        self.clear_metadata_caches();
+                    }
                     Ok(len as u32)
                 }
                 Err(e) => Err(FspError::NTSTATUS(error_to_ntstatus(&e))),
@@ -1693,6 +1750,7 @@ impl FileSystemContext for AgentFSWinFsp {
 
             match result {
                 Ok(()) => {
+                    self.clear_metadata_caches();
                     let fs = self.fs.clone();
                     let stats = self.block_on(async move { fs.lock().getattr(ino).await });
                     if let Ok(Some(stats)) = stats {
@@ -1763,6 +1821,7 @@ impl FileSystemContext for AgentFSWinFsp {
 
             match result {
                 Ok(()) => {
+                    self.clear_metadata_caches();
                     let fs = self.fs.clone();
                     if let Ok(Some(stats)) =
                         self.block_on(async move { fs.lock().getattr(ino).await })
@@ -1816,6 +1875,7 @@ impl FileSystemContext for AgentFSWinFsp {
 
             match result {
                 Ok(()) => {
+                    self.clear_metadata_caches();
                     let fs = self.fs.clone();
                     if let Ok(Some(stats)) =
                         self.block_on(async move { fs.lock().getattr(ino).await })
@@ -1988,8 +2048,8 @@ impl FileSystemContext for AgentFSWinFsp {
             path,
             stats.ino
         );
-        self.clear_path_ino_cache();
-        self.remember_path_ino(&path, stats.ino);
+        self.clear_metadata_caches();
+        self.remember_path_stats(&path, &stats);
 
         let mut open_files = self.open_files.lock();
         if let Some(open_file) = open_files.get_mut(&context.fh) {

--- a/cli/src/winfsp.rs
+++ b/cli/src/winfsp.rs
@@ -232,7 +232,7 @@ struct OpenFile {
     /// Path to the file (for deletion on close)
     path: String,
     /// Cached directory entries for a directory handle.
-    dir_entries: Mutex<Option<Vec<(String, Stats)>>>,
+    dir_entries: Mutex<Option<Arc<Vec<(String, Stats)>>>>,
 }
 
 /// WinFsp filesystem adapter wrapping an AgentFS FileSystem.
@@ -240,6 +240,7 @@ pub struct AgentFSWinFsp {
     fs: Arc<Mutex<dyn FileSystem + Send>>,
     handle: Handle,
     open_files: Mutex<HashMap<u64, OpenFile>>,
+    path_ino_cache: Mutex<HashMap<String, i64>>,
     next_fh: AtomicU64,
 }
 
@@ -250,6 +251,7 @@ impl AgentFSWinFsp {
             fs,
             handle,
             open_files: Mutex::new(HashMap::new()),
+            path_ino_cache: Mutex::new(HashMap::new()),
             next_fh: AtomicU64::new(1),
         }
     }
@@ -267,6 +269,50 @@ impl AgentFSWinFsp {
 
     fn win_path_to_unix(path: &U16CStr) -> String {
         path.to_string_lossy().replace('\\', "/")
+    }
+
+    fn normalize_cache_path(path: &str) -> String {
+        let normalized = path.replace('\\', "/");
+        let trimmed = normalized.trim_end_matches('/');
+        if trimmed.is_empty() {
+            "/".to_string()
+        } else if trimmed.starts_with('/') {
+            trimmed.to_string()
+        } else {
+            format!("/{trimmed}")
+        }
+    }
+
+    fn join_child_path(parent: &str, name: &str) -> String {
+        let parent = Self::normalize_cache_path(parent);
+        if parent == "/" {
+            format!("/{name}")
+        } else {
+            format!("{parent}/{name}")
+        }
+    }
+
+    fn remember_path_ino(&self, path: &str, ino: i64) {
+        self.path_ino_cache
+            .lock()
+            .insert(Self::normalize_cache_path(path), ino);
+    }
+
+    fn forget_path_ino(&self, path: &str) {
+        self.path_ino_cache
+            .lock()
+            .remove(&Self::normalize_cache_path(path));
+    }
+
+    fn clear_path_ino_cache(&self) {
+        self.path_ino_cache.lock().clear();
+    }
+
+    fn lookup_cached_path_ino(&self, path: &str) -> Option<i64> {
+        self.path_ino_cache
+            .lock()
+            .get(&Self::normalize_cache_path(path))
+            .copied()
     }
 
     /// Parse a path into (parent_ino, name) for operations that need a parent directory.
@@ -316,6 +362,14 @@ impl AgentFSWinFsp {
 
     /// Look up a path and return its stats. Walks the entire path.
     fn path_lookup(&self, path: &str) -> Result<Option<Stats>> {
+        if let Some(ino) = self.lookup_cached_path_ino(path) {
+            let fs = self.fs.clone();
+            match self.block_on(async move { fs.lock().getattr(ino).await })? {
+                Some(stats) => return Ok(Some(stats)),
+                None => self.forget_path_ino(path),
+            }
+        }
+
         let path = path.trim_start_matches('/');
         if path.is_empty() {
             let fs = self.fs.clone();
@@ -324,7 +378,11 @@ impl AgentFSWinFsp {
 
         let (parent_ino, name) = self.parse_path(path)?;
         let fs = self.fs.clone();
-        Ok(self.block_on(async move { fs.lock().lookup(parent_ino, &name).await })?)
+        let stats = self.block_on(async move { fs.lock().lookup(parent_ino, &name).await })?;
+        if let Some(stats) = stats.as_ref() {
+            self.remember_path_ino(path, stats.ino);
+        }
+        Ok(stats)
     }
 
     fn refresh_open_stats(&self, path: &str, fallback: &Stats) -> Stats {
@@ -492,11 +550,16 @@ impl AgentFSWinFsp {
                     Ok(None) => dir_stats.clone(),
                     Err(e) => return Err(FspError::NTSTATUS(error_to_ntstatus(&e))),
                 };
+                self.remember_path_ino(dir_path, dir_stats.ino);
 
                 let mut all_entries: Vec<(String, Stats)> = Vec::with_capacity(entries.len() + 2);
                 all_entries.push((".".to_string(), dir_stats));
                 all_entries.push(("..".to_string(), parent_stats));
                 for entry in entries {
+                    self.remember_path_ino(
+                        &Self::join_child_path(dir_path, &entry.name),
+                        entry.stats.ino,
+                    );
                     all_entries.push((entry.name, entry.stats));
                 }
                 Ok(all_entries)
@@ -511,7 +574,7 @@ impl AgentFSWinFsp {
         fh: u64,
         dir_ino: i64,
         dir_path: &str,
-    ) -> winfsp::Result<Vec<(String, Stats)>> {
+    ) -> winfsp::Result<Arc<Vec<(String, Stats)>>> {
         if let Some(cached) = {
             let open_files = self.open_files.lock();
             open_files
@@ -521,7 +584,7 @@ impl AgentFSWinFsp {
             return Ok(cached);
         }
 
-        let entries = self.list_directory_entries(dir_ino, dir_path)?;
+        let entries = Arc::new(self.list_directory_entries(dir_ino, dir_path)?);
         {
             let open_files = self.open_files.lock();
             if let Some(open_file) = open_files.get(&fh) {
@@ -572,7 +635,10 @@ impl AgentFSWinFsp {
         let name_owned = name.to_string();
         let stats = self.block_on(async move { fs.lock().lookup(dir_ino, &name_owned).await });
         match stats {
-            Ok(Some(stats)) => Ok(Some((name.to_string(), stats))),
+            Ok(Some(stats)) => {
+                self.remember_path_ino(&Self::join_child_path(dir_path, name), stats.ino);
+                Ok(Some((name.to_string(), stats)))
+            }
             Ok(None) => Ok(None),
             Err(e) => Err(FspError::NTSTATUS(error_to_ntstatus(&e))),
         }
@@ -594,6 +660,7 @@ impl AgentFSWinFsp {
                 fs_guard.unlink(parent_ino, &name).await
             }
         })?;
+        self.clear_path_ino_cache();
         Ok(())
     }
 
@@ -953,6 +1020,7 @@ impl FileSystemContext for AgentFSWinFsp {
 
         match existing {
             Ok(Some(stats)) => {
+                self.remember_path_ino(&path, stats.ino);
                 // File already exists - open it directly
                 // WinFsp will call overwrite() if truncation is needed
                 tracing::trace!(
@@ -1075,6 +1143,8 @@ impl FileSystemContext for AgentFSWinFsp {
 
                 match result {
                     Ok(stats) => {
+                        self.clear_path_ino_cache();
+                        self.remember_path_ino(&path, stats.ino);
                         fill_file_info(&stats, file_info.as_mut());
 
                         let fh = self.alloc_fh();
@@ -1392,7 +1462,10 @@ impl FileSystemContext for AgentFSWinFsp {
         });
 
         match result {
-            Ok(()) => Ok(()),
+            Ok(()) => {
+                self.clear_path_ino_cache();
+                Ok(())
+            }
             Err(e) => Err(FspError::NTSTATUS(error_to_ntstatus(&e))),
         }
     }
@@ -1429,46 +1502,33 @@ impl FileSystemContext for AgentFSWinFsp {
 
         let all_entries = self.cached_directory_entries(context.fh, dir_ino, &dir_path)?;
         let original_entry_count = all_entries.len();
-        let filtered_entries: Vec<(String, Stats)> = all_entries
-            .into_iter()
-            .filter(|(name, _stats)| {
-                Self::should_include_dir_entry(
-                    Self::sanitize_dir_entry_name(name),
-                    pattern_str.as_deref(),
-                )
-            })
-            .collect();
         tracing::trace!(
-            "WinFsp::read_directory: fh={} entry_count={} filtered_count={} entries={:?}",
+            "WinFsp::read_directory: fh={} entry_count={}",
             context.fh,
-            original_entry_count,
-            filtered_entries.len(),
-            filtered_entries
-                .iter()
-                .map(|(name, _)| name.clone())
-                .collect::<Vec<_>>()
+            original_entry_count
         );
 
-        // Determine starting index based on marker.
-        // The marker is the filename (U16CStr) of the last entry returned
-        // in the previous call. We need to find it and skip past it.
-        let start_idx = if let Some(marker_name) = marker.inner_as_cstr() {
-            let marker_str = marker_name.to_string_lossy();
-            let marker_str = Self::sanitize_dir_entry_name(&marker_str);
-            let mut idx = 0usize;
-            for (i, (name, _stats)) in filtered_entries.iter().enumerate() {
-                if Self::sanitize_dir_entry_name(name) == marker_str {
-                    idx = i + 1;
-                    break;
-                }
-            }
-            idx
-        } else {
-            0
-        };
+        let marker_name = marker
+            .inner_as_cstr()
+            .map(|marker_name| marker_name.to_string_lossy());
+        let marker_name = marker_name
+            .as_deref()
+            .map(Self::sanitize_dir_entry_name)
+            .filter(|name| !name.is_empty());
+        let mut marker_seen = marker_name.is_none();
         let mut cursor = 0u32;
 
-        for (name, stats) in filtered_entries.iter().skip(start_idx) {
+        for (name, stats) in all_entries.iter() {
+            let name = Self::sanitize_dir_entry_name(name);
+            if !Self::should_include_dir_entry(name, pattern_str.as_deref()) {
+                continue;
+            }
+            if !marker_seen {
+                if Some(name) == marker_name {
+                    marker_seen = true;
+                }
+                continue;
+            }
             let mut dir_info: DirInfo<255> = DirInfo::default();
 
             // Directory entries must not include a trailing NUL in their
@@ -1514,12 +1574,15 @@ impl FileSystemContext for AgentFSWinFsp {
         let normalized_query = Self::normalize_directory_pattern(&query_name);
         let entry = if normalized_query.contains(['*', '?', DOS_STAR, DOS_QM, DOS_DOT]) {
             let entries = self.cached_directory_entries(context.fh, dir_ino, &dir_path)?;
-            entries.into_iter().find(|(name, _stats)| {
-                Self::should_include_dir_entry(
-                    Self::sanitize_dir_entry_name(name),
-                    Some(normalized_query),
-                )
-            })
+            entries
+                .iter()
+                .find(|(name, _stats)| {
+                    Self::should_include_dir_entry(
+                        Self::sanitize_dir_entry_name(name),
+                        Some(normalized_query),
+                    )
+                })
+                .map(|(name, stats)| (name.clone(), stats.clone()))
         } else {
             self.lookup_directory_entry(dir_ino, &dir_path, normalized_query)?
         };
@@ -1925,6 +1988,8 @@ impl FileSystemContext for AgentFSWinFsp {
             path,
             stats.ino
         );
+        self.clear_path_ino_cache();
+        self.remember_path_ino(&path, stats.ino);
 
         let mut open_files = self.open_files.lock();
         if let Some(open_file) = open_files.get_mut(&context.fh) {

--- a/cli/tests/appfs-connector/test-ct2-028-timeout-return-stale.sh
+++ b/cli/tests/appfs-connector/test-ct2-028-timeout-return-stale.sh
@@ -74,7 +74,7 @@ cat "$SNAPSHOT_FILE" >"$stale_output" || fail "timeout-return_stale with healthy
 hash_after="$(sha256sum "$TMP_ROOT/aiim/chats/chat-001/messages.res.jsonl" | awk '{print $1}')"
 [ "$hash_before" = "$hash_after" ] || fail "healthy stale fallback should keep cached bytes unchanged"
 cmp -s "$SNAPSHOT_FILE" "$stale_output" || fail "healthy stale fallback should return cached bytes"
-grep -F -q "[cache] timeout_return_stale resource=/chats/chat-001/messages.res.jsonl trigger=open" "$MOUNT_LOG" || fail "missing timeout_return_stale log anchor"
+grep -F -q "[cache] timeout_return_stale resource=/chats/chat-001/messages.res.jsonl trigger=read" "$MOUNT_LOG" || fail "missing timeout_return_stale log anchor"
 pass "timeout-return_stale with healthy cache returns degraded success and keeps stale bytes"
 
 stop_mount_process "${MOUNT_PID:-}" "${MOUNTPOINT:-}"
@@ -95,7 +95,7 @@ if cat "$SNAPSHOT_FILE" >/dev/null 2>"$TMP_ROOT/ct2-028-bad.stderr"; then
 fi
 bad_hash_after="$(sha256sum "$TMP_ROOT/aiim/chats/chat-001/messages.res.jsonl" | awk '{print $1}')"
 [ "$bad_hash_before" = "$bad_hash_after" ] || fail "malformed stale timeout should not mutate stale cache bytes"
-grep -F -q "[cache] expand failed resource=/chats/chat-001/messages.res.jsonl phase=timeout on_timeout=return_stale stale_reason=stale_cache_unhealthy trigger=open" "$MOUNT_LOG" || fail "missing malformed stale timeout log"
+grep -F -q "[cache] expand failed resource=/chats/chat-001/messages.res.jsonl phase=timeout on_timeout=return_stale stale_reason=stale_cache_unhealthy trigger=read" "$MOUNT_LOG" || fail "missing malformed stale timeout log"
 pass "malformed stale cache is rejected and ordinary read fails without mutating bytes"
 
 say "CT2-028 done"

--- a/docs/plans/2026-04-28-huoyan-shallow-revision-fastpath.md
+++ b/docs/plans/2026-04-28-huoyan-shallow-revision-fastpath.md
@@ -1,0 +1,292 @@
+# Huoyan Case Structure Revision Fast Path
+
+Date: 2026-04-28
+Status: Implemented
+
+## Summary
+
+Huoyan `case:*` scope startup is still slow on restart even after DB bulk materialization, because `get_app_structure()` currently rebuilds the full case tree before it can decide whether `known_revision` is unchanged.
+
+The current goal is to add a **cheap shallow revision fast path** for Huoyan case scopes:
+
+- unchanged restart should only inspect the **evidence layer** and the **top app layer**
+- full recursive node traversal should only happen when that shallow revision changes
+- AppFS should keep the existing behavior of full tree build on first load and on actual structure changes
+
+This plan is intended to reduce “second startup” latency from ~10s+ to near the cost of:
+
+- `list_evidences(case_id)`
+- `list_nodes(analysis_cid, pid=ROOT_NODE_ID)`
+
+without changing the existing AppFS structure protocol.
+
+## Current Behavior
+
+Huoyan case scope revision is currently derived from a full recursive tree walk:
+
+1. `list_evidences(case_id)`
+2. BFS over `list_nodes(analysis_cid, pid=...)` for the entire tree
+3. build full AppFS structure paths
+4. hash the full `revision_payload`
+5. compare against `known_revision`
+
+This means `known_revision` only avoids DB rewrite when unchanged. It does **not** avoid expensive connector-side tree construction.
+
+Current revision semantics are “structure/path version”, not “content version”:
+
+- included today:
+  - evidence `eid`
+  - evidence `name`
+  - each node `nid`
+  - final mapped `path`
+  - whether node is `leaf`
+- not included today:
+  - `*.res.jsonl` content
+  - record payload changes
+  - leaf row count changes unless reflected through structure
+
+## Requirements
+
+### Functional
+
+- A repeated `compose up` against an unchanged Huoyan case should avoid full recursive tree rebuild.
+- First load of a case must still build the full tree and produce a snapshot.
+- If the case structure actually changes, AppFS must still rebuild the full tree and update the DB.
+
+### Non-Functional
+
+- No AppFS protocol change required.
+- Existing managed runtime / DB bulk materialization flow remains unchanged.
+- Change should be isolated to the Huoyan bridge logic.
+
+## Recommendation
+
+Use a **hybrid revision** strategy:
+
+1. Compute a **shallow probe revision** from the first two layers only
+2. If the caller passes `known_revision` and the probe component matches, return `unchanged` immediately
+3. Otherwise, build the full tree and compute the full structure payload as today
+4. Return a revision string that contains both the probe hash and the full hash
+
+This keeps unchanged restart cheap, while preserving a richer full-tree fingerprint for debugging and rollout safety.
+
+## Why Not “Shallow Only” As The Entire Revision?
+
+A pure shallow revision is viable only if we are certain that every app refresh changes second-layer app node metadata. That may be true in practice, but it is a product assumption rather than a protocol guarantee.
+
+A hybrid revision has two advantages:
+
+- unchanged restart can still short-circuit on the cheap probe
+- when a change does occur, we still record a full-tree fingerprint in the returned revision string
+
+This gives us a safer migration path and better diagnostics if a false-unchanged suspicion appears later.
+
+## Proposed Revision Format
+
+For case scopes, return a revision like:
+
+```text
+huoyan-case:4-p:1a2b3c4d5e6f-f:7a8b9c0d1e2f
+```
+
+Where:
+
+- `p` = shallow probe hash
+- `f` = full-tree structure hash
+
+On startup:
+
+- if `known_revision` contains a probe component and `probe == known_probe`, return `unchanged`
+- if the format is old / probe missing / parsing fails, fall back to full-tree rebuild once
+
+This makes rollout backward compatible:
+
+- old revision strings still work
+- first restart after deployment may still be slow once
+- subsequent restarts can use the probe fast path
+
+## Shallow Probe Definition
+
+For case scopes, compute probe payload from:
+
+### Evidence layer
+
+From `list_evidences(case_id)`:
+
+- `eid`
+- sanitized/visible evidence name
+
+### Top app layer
+
+From `list_nodes(analysis_cid, pid=ROOT_NODE_ID)`:
+
+- `eid`
+- `nid`
+- visible node name
+- `NodeType`
+- `SubNodeType`
+- `HasChildNode`
+- stable count-style fields if available (`RecordCount` / `Count`)
+
+Recommended payload shape:
+
+```json
+{
+  "case_id": 4,
+  "evidences": [
+    {"eid": 101, "name": "手机-1"},
+    {"eid": 102, "name": "手机-2"}
+  ],
+  "apps": [
+    {
+      "eid": 101,
+      "nid": 658000891,
+      "name": "微信",
+      "node_type": "...",
+      "sub_node_type": "...",
+      "has_child": true,
+      "record_count": 123
+    }
+  ]
+}
+```
+
+Hash with the same `_compact_json(...) + sha1[:12]` pattern currently used.
+
+## Operating Assumption
+
+This fast path assumes Huoyan uses incremental parsing for app trees and does not silently reparse an existing second-layer app node without changing the shallow app inventory. Under that assumption, a probe built from:
+
+- app node `Nid`
+- app node visible `Name`
+- `NodeType`
+- `SubNodeType`
+- `HasChildNode`
+- `RecordCount` / `Count` when present
+
+is sufficient for restart-time `unchanged` detection.
+
+## Implementation Sketch
+
+### 1. Add probe helpers
+
+In `huoyan_backend.py`:
+
+- `_build_case_probe(case_id) -> dict`
+- `_known_case_probe_digest(revision: str) -> str | None`
+- `_case_revision(scope, probe_digest, payload) -> str`
+
+### 2. Update `get_app_structure()`
+
+For case scopes:
+
+1. compute shallow probe revision only
+2. compare against `known_revision`
+3. if equal: return `unchanged`
+4. otherwise: build full scope, compute full hash, return snapshot
+
+### 3. Update `refresh_app_structure()`
+
+Use the same logic for non-`enter_scope` refresh:
+
+- cheap probe first
+- only full rebuild on mismatch
+
+For `enter_scope`, full build is still required when changing to a different case scope, because the caller needs the target snapshot if the target scope differs.
+
+### 4. Keep home scope behavior unchanged
+
+Home scope revision is already cheap and does not need this optimization.
+
+## Failure Modes
+
+### False unchanged
+
+Risk:
+
+- app internal structure changes
+- second-layer metadata does not change
+- probe matches
+- AppFS skips full refresh incorrectly
+
+Mitigations:
+
+- validate actual Huoyan metadata behavior first
+- include as many stable second-layer change signals as possible
+- optionally add a configurable periodic forced full rebuild
+
+### Backward compatibility
+
+Risk:
+
+- existing `known_revision` strings do not contain a probe component
+
+Mitigation:
+
+- treat unknown revision format as “no probe available”
+- do one full rebuild
+- emit new hybrid revision format afterward
+
+## Suggested Rollout Controls
+
+Add a bridge env flag:
+
+```text
+APPFS_HUOYAN_REVISION_MODE=full|probe2|hybrid
+```
+
+Recommended rollout:
+
+- default to `hybrid`
+- allow fallback to `full` during debugging
+
+Optional diagnostic env:
+
+```text
+APPFS_HUOYAN_LOG_REVISION_TIMING=1
+```
+
+to log:
+
+- probe build duration
+- full scope build duration
+- whether fast path hit or missed
+
+## Test Plan
+
+### Unit tests
+
+- probe revision is deterministic
+- probe parser reads probe component from hybrid revision
+- duplicate/sanitized evidence/app names still produce stable probe payload
+- old revision format falls back to full build
+
+### Integration tests
+
+- first `get_app_structure(case)` returns snapshot
+- second `get_app_structure(case)` with unchanged hybrid revision returns `unchanged` without recursive traversal
+- top-layer app metadata change causes snapshot rebuild
+
+### Manual validation
+
+On a large Huoyan case:
+
+1. first `compose up` still performs full build
+2. second `compose up` on unchanged case should skip recursive tree build
+3. reparsing one app in Huoyan should cause probe mismatch and full rebuild
+
+## Recommendation
+
+This optimization is **reasonable and worth doing** if Huoyan’s second-layer app nodes reliably reflect reparsed app updates.
+
+The best implementation is:
+
+- **not** “skip structure checks entirely”
+- **not** “replace revision with top-layer-only hash blindly”
+- but a **hybrid probe/full revision design**
+
+That gives us:
+
+- cheap unchanged restart
+- low implementation blast radius
+- safer rollout than a pure shallow hash

--- a/examples/appfs/bridges/http-python/appfs_http_bridge/huoyan_backend.py
+++ b/examples/appfs/bridges/http-python/appfs_http_bridge/huoyan_backend.py
@@ -306,6 +306,14 @@ class _BuiltScope:
 
 
 @dataclass
+class _CaseProbe:
+    analysis_cid: int
+    evidences: dict[int, dict[str, Any]]
+    root_nodes: list[dict[str, Any]]
+    probe_digest: str
+
+
+@dataclass
 class HuoyanBackend:
     client: HuoyanApiClientProtocol | None = None
     app_id: str = field(default_factory=lambda: os.getenv("APPFS_HUOYAN_APP_ID", "huoyan"))
@@ -432,6 +440,12 @@ class HuoyanBackend:
         session_id = str(context.get("session_id", ""))
         scope = self.session_scopes.get(session_id, self._initial_scope())
         self._assert_attached_scope(scope)
+        known_revision = request.get("known_revision")
+        if scope != DEFAULT_HOME_SCOPE:
+            fast = self._maybe_case_structure_unchanged(scope, known_revision)
+            if fast is not None:
+                self.session_scopes[session_id] = scope
+                return fast
         built = self._build_scope(scope, force_refresh=True)
         self.session_scopes[session_id] = scope
         return self._structure_response(request, built.snapshot)
@@ -458,6 +472,12 @@ class HuoyanBackend:
                 )
 
         self._transition_scope(previous_scope, scope, reason)
+        known_revision = request.get("known_revision")
+        if scope != DEFAULT_HOME_SCOPE:
+            fast = self._maybe_case_structure_unchanged(scope, known_revision)
+            if fast is not None:
+                self.session_scopes[session_id] = scope
+                return fast
         built = self._build_scope(scope, force_refresh=True)
         self.session_scopes[session_id] = scope
         return self._structure_response(request, built.snapshot)
@@ -729,18 +749,14 @@ class HuoyanBackend:
         }
         return _BuiltScope(snapshot=snapshot, info_specs=info_specs)
 
-    def _build_case_scope(self, case_id: int) -> _BuiltScope:
-        analysis_cid = self._analysis_cid(case_id)
-        raw_evidences = self.client.list_evidences(case_id=case_id).get("evidences", [])
-        evidences: dict[int, dict[str, Any]] = {}
-        if isinstance(raw_evidences, list):
-            for evidence in raw_evidences:
-                if isinstance(evidence, dict):
-                    evidences[int(evidence.get("Id", 0))] = evidence
+    def _build_case_scope(self, case_id: int, probe: _CaseProbe | None = None) -> _BuiltScope:
+        probe = probe or self._build_case_probe(case_id)
+        analysis_cid = probe.analysis_cid
+        evidences = dict(probe.evidences)
 
-        nodes_by_pid: dict[int, list[dict[str, Any]]] = {}
-        queue = [ROOT_NODE_ID]
-        visited: set[int] = set()
+        nodes_by_pid: dict[int, list[dict[str, Any]]] = {ROOT_NODE_ID: list(probe.root_nodes)}
+        queue = [int(child.get("Nid", 0)) for child in probe.root_nodes if self._has_children(child)]
+        visited: set[int] = {ROOT_NODE_ID}
         while queue:
             pid = queue.pop(0)
             if pid in visited:
@@ -756,7 +772,7 @@ class HuoyanBackend:
                 if self._has_children(child):
                     queue.append(int(child.get("Nid", 0)))
 
-        for child in nodes_by_pid.get(ROOT_NODE_ID, []):
+        for child in probe.root_nodes:
             eid = int(child.get("Eid", 0))
             if eid > 0 and eid not in evidences:
                 evidences[eid] = {
@@ -807,7 +823,7 @@ class HuoyanBackend:
                     revision_payload=revision_payload,
                 )
 
-        revision = self._revision_from_payload(self._case_scope(case_id), revision_payload)
+        revision = self._case_revision(self._case_scope(case_id), probe.probe_digest, revision_payload)
         snapshot = {
             "app_id": self.app_id,
             "revision": revision,
@@ -816,6 +832,96 @@ class HuoyanBackend:
             "nodes": structure_nodes,
         }
         return _BuiltScope(snapshot=snapshot, leaf_specs=leaf_specs)
+
+    def _build_case_probe(self, case_id: int) -> _CaseProbe:
+        analysis_cid = self._analysis_cid(case_id)
+        raw_evidences = self.client.list_evidences(case_id=case_id).get("evidences", [])
+        evidences: dict[int, dict[str, Any]] = {}
+        if isinstance(raw_evidences, list):
+            for evidence in raw_evidences:
+                if isinstance(evidence, dict):
+                    evidences[int(evidence.get("Id", 0))] = evidence
+
+        root_response = self.client.list_nodes(analysis_cid=analysis_cid, pid=ROOT_NODE_ID)
+        root_children = root_response.get("nodes", [])
+        if not isinstance(root_children, list):
+            root_children = []
+        root_nodes = [child for child in root_children if isinstance(child, dict)]
+
+        for child in root_nodes:
+            eid = int(child.get("Eid", 0))
+            if eid > 0 and eid not in evidences:
+                evidences[eid] = {
+                    "Id": eid,
+                    "Name": f"检材-{eid}",
+                }
+
+        payload = self._build_case_probe_payload(evidences, root_nodes)
+        return _CaseProbe(
+            analysis_cid=analysis_cid,
+            evidences=evidences,
+            root_nodes=root_nodes,
+            probe_digest=self._revision_digest(payload),
+        )
+
+    def _build_case_probe_payload(
+        self, evidences: dict[int, dict[str, Any]], root_nodes: list[dict[str, Any]]
+    ) -> list[dict[str, Any]]:
+        top_level_seen: dict[str, int] = {}
+        evidence_groups: dict[int, list[dict[str, Any]]] = {}
+        for child in root_nodes:
+            evidence_groups.setdefault(int(child.get("Eid", 0)), []).append(child)
+
+        payload: list[dict[str, Any]] = []
+        for eid, top_nodes in sorted(evidence_groups.items(), key=lambda item: item[0]):
+            evidence_name = str(evidences.get(eid, {}).get("Name") or f"检材-{eid}")
+            evidence_dir = _dedupe_name(
+                _safe_segment(evidence_name, f"检材-{eid}"),
+                top_level_seen,
+                f"eid_{eid}",
+            )
+            payload.append({"eid": eid, "name": evidence_name, "path": evidence_dir})
+            seen: dict[str, int] = {}
+            for child in top_nodes:
+                raw_name = str(child.get("Name", ""))
+                if raw_name in self.blocked_names:
+                    continue
+                nid = int(child.get("Nid", 0))
+                segment = _dedupe_name(_safe_segment(raw_name, f"节点-{nid}"), seen, f"nid_{nid}")
+                payload.append(
+                    {
+                        "eid": eid,
+                        "path": f"{evidence_dir}/{segment}",
+                        "nid": nid,
+                        "name": raw_name,
+                        "node_type": str(child.get("NodeType", "")),
+                        "sub_node_type": str(child.get("SubNodeType", "")),
+                        "has_child": self._has_children(child),
+                        "record_count": child.get("RecordCount", child.get("Count")),
+                    }
+                )
+        return payload
+
+    def _maybe_case_structure_unchanged(
+        self, scope: str, known_revision: Any
+    ) -> dict[str, Any] | None:
+        if not isinstance(known_revision, str) or known_revision.strip() == "":
+            return None
+        known_probe = self._known_case_probe_digest(scope, known_revision)
+        if known_probe is None:
+            return None
+        case_id = self._parse_case_scope(scope)
+        probe = self._build_case_probe(case_id)
+        if probe.probe_digest != known_probe:
+            return None
+        return {
+            "result": {
+                "kind": "unchanged",
+                "app_id": self.app_id,
+                "revision": known_revision,
+                "active_scope": scope,
+            }
+        }
 
     def _append_case_node(
         self,
@@ -932,8 +1038,27 @@ class HuoyanBackend:
         ]
 
     def _revision_from_payload(self, scope: str, payload: Any) -> str:
-        digest = hashlib.sha1(_compact_json(payload).encode("utf-8")).hexdigest()[:12]
+        digest = self._revision_digest(payload)
         return f"huoyan-{scope}-{digest}"
+
+    def _revision_digest(self, payload: Any) -> str:
+        return hashlib.sha1(_compact_json(payload).encode("utf-8")).hexdigest()[:12]
+
+    def _case_revision(self, scope: str, probe_digest: str, full_payload: Any) -> str:
+        full_digest = self._revision_digest(full_payload)
+        return f"huoyan-{scope}-p:{probe_digest}-f:{full_digest}"
+
+    def _known_case_probe_digest(self, scope: str, revision: str) -> str | None:
+        prefix = f"huoyan-{scope}-p:"
+        if not revision.startswith(prefix):
+            return None
+        suffix = revision[len(prefix) :]
+        probe_digest, sep, _ = suffix.partition("-f:")
+        if sep == "" or len(probe_digest) != 12:
+            return None
+        if any(ch not in "0123456789abcdef" for ch in probe_digest):
+            return None
+        return probe_digest
 
     def _resolve_snapshot_spec(self, resource_path: str, context: dict[str, Any]) -> _LeafSpec | dict[str, Any]:
         if resource_path.startswith("/"):

--- a/examples/appfs/bridges/http-python/appfs_http_bridge/huoyan_backend.py
+++ b/examples/appfs/bridges/http-python/appfs_http_bridge/huoyan_backend.py
@@ -115,7 +115,11 @@ def _dedupe_name(name: str, seen: dict[str, int], suffix_seed: str) -> str:
     seen[name] = count + 1
     if count == 0:
         return name
-    return f"{name}__{suffix_seed}"
+    disambiguator = f"__{suffix_seed}"
+    if name.endswith(SNAPSHOT_SUFFIX):
+        stem = name[: -len(SNAPSHOT_SUFFIX)]
+        return _shorten_segment(stem, suffix=f"{disambiguator}{SNAPSHOT_SUFFIX}")
+    return _shorten_segment(name, suffix=disambiguator)
 
 
 def _network_error_message(url: str, err: BaseException) -> str:

--- a/examples/appfs/bridges/http-python/appfs_http_bridge/huoyan_backend.py
+++ b/examples/appfs/bridges/http-python/appfs_http_bridge/huoyan_backend.py
@@ -18,6 +18,7 @@ DEFAULT_CASES_LIMIT = 100
 DEFAULT_HOME_SCOPE = "home"
 SAFE_PATH_SEGMENT_MAX_BYTES = 96
 SNAPSHOT_SUFFIX = ".res.jsonl"
+HUOYAN_STRUCTURE_SCHEMA_VERSION = 1
 
 
 def _now_iso() -> str:
@@ -788,7 +789,9 @@ class HuoyanBackend:
             evidence_groups.setdefault(int(child.get("Eid", 0)), []).append(child)
 
         ownership_prefixes = ["_app"]
-        revision_payload: list[dict[str, Any]] = []
+        revision_payload: list[dict[str, Any]] = [
+            {"schema_version": HUOYAN_STRUCTURE_SCHEMA_VERSION}
+        ]
 
         for eid, top_nodes in sorted(evidence_groups.items(), key=lambda item: item[0]):
             evidence_name = str(evidences.get(eid, {}).get("Name") or f"检材-{eid}")
@@ -872,7 +875,9 @@ class HuoyanBackend:
         for child in root_nodes:
             evidence_groups.setdefault(int(child.get("Eid", 0)), []).append(child)
 
-        payload: list[dict[str, Any]] = []
+        payload: list[dict[str, Any]] = [
+            {"schema_version": HUOYAN_STRUCTURE_SCHEMA_VERSION}
+        ]
         for eid, top_nodes in sorted(evidence_groups.items(), key=lambda item: item[0]):
             evidence_name = str(evidences.get(eid, {}).get("Name") or f"检材-{eid}")
             evidence_dir = _dedupe_name(
@@ -1046,10 +1051,13 @@ class HuoyanBackend:
 
     def _case_revision(self, scope: str, probe_digest: str, full_payload: Any) -> str:
         full_digest = self._revision_digest(full_payload)
-        return f"huoyan-{scope}-p:{probe_digest}-f:{full_digest}"
+        return (
+            f"huoyan-{scope}-sv:{HUOYAN_STRUCTURE_SCHEMA_VERSION}"
+            f"-p:{probe_digest}-f:{full_digest}"
+        )
 
     def _known_case_probe_digest(self, scope: str, revision: str) -> str | None:
-        prefix = f"huoyan-{scope}-p:"
+        prefix = f"huoyan-{scope}-sv:{HUOYAN_STRUCTURE_SCHEMA_VERSION}-p:"
         if not revision.startswith(prefix):
             return None
         suffix = revision[len(prefix) :]

--- a/examples/appfs/bridges/http-python/appfs_http_bridge/huoyan_backend.py
+++ b/examples/appfs/bridges/http-python/appfs_http_bridge/huoyan_backend.py
@@ -16,6 +16,8 @@ from typing import Any, Protocol
 ROOT_NODE_ID = 1
 DEFAULT_CASES_LIMIT = 100
 DEFAULT_HOME_SCOPE = "home"
+SAFE_PATH_SEGMENT_MAX_BYTES = 96
+SNAPSHOT_SUFFIX = ".res.jsonl"
 
 
 def _now_iso() -> str:
@@ -53,7 +55,35 @@ def _env_float(name: str, default: float) -> float:
         return default
 
 
-def _safe_segment(name: str, fallback: str) -> str:
+def _truncate_utf8_prefix(text: str, max_bytes: int) -> str:
+    used = 0
+    out: list[str] = []
+    for ch in text:
+        size = len(ch.encode("utf-8"))
+        if used + size > max_bytes:
+            break
+        out.append(ch)
+        used += size
+    return "".join(out).strip().rstrip(".")
+
+
+def _short_hash(value: str) -> str:
+    return hashlib.sha1(value.encode("utf-8")).hexdigest()[:12]
+
+
+def _shorten_segment(name: str, *, suffix: str = "") -> str:
+    full = f"{name}{suffix}"
+    if len(full.encode("utf-8")) <= SAFE_PATH_SEGMENT_MAX_BYTES:
+        return full
+
+    digest = _short_hash(full)
+    tail = f"__{digest}{suffix}"
+    prefix_budget = max(1, SAFE_PATH_SEGMENT_MAX_BYTES - len(tail.encode("utf-8")))
+    prefix = _truncate_utf8_prefix(name, prefix_budget) or "item"
+    return f"{prefix}{tail}"
+
+
+def _sanitize_segment(name: str, fallback: str) -> str:
     raw = (name or "").strip()
     if raw == "":
         raw = fallback
@@ -63,15 +93,21 @@ def _safe_segment(name: str, fallback: str) -> str:
             out_chars.append("_")
         elif ord(ch) < 32:
             out_chars.append("_")
+        elif ord(ch) > 0xFFFF:
+            out_chars.append(f"U{ord(ch):08X}")
         else:
             out_chars.append(ch)
     out = "".join(out_chars).strip().rstrip(".")
     return out or fallback
 
 
+def _safe_segment(name: str, fallback: str) -> str:
+    return _shorten_segment(_sanitize_segment(name, fallback))
+
+
 def _safe_leaf_name(name: str, fallback: str) -> str:
-    base = _safe_segment(name.replace("/", "_"), fallback)
-    return f"{base}.res.jsonl"
+    base = _sanitize_segment(name.replace("/", "_"), fallback)
+    return _shorten_segment(base, suffix=SNAPSHOT_SUFFIX)
 
 
 def _dedupe_name(name: str, seen: dict[str, int], suffix_seed: str) -> str:

--- a/examples/appfs/bridges/http-python/tests/test_huoyan_backend.py
+++ b/examples/appfs/bridges/http-python/tests/test_huoyan_backend.py
@@ -12,6 +12,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from appfs_http_bridge.huoyan_backend import (
     HuoyanBackend,
+    _dedupe_name,
     _json_request,
     _safe_leaf_name,
     _safe_segment,
@@ -197,6 +198,16 @@ class HuoyanBackendTests(unittest.TestCase):
         first = _safe_leaf_name(prefix + "1", "节点-1")
         second = _safe_leaf_name(prefix + "2", "节点-2")
         self.assertNotEqual(first, second)
+
+    def test_dedupe_leaf_keeps_res_jsonl_suffix(self) -> None:
+        seen: dict[str, int] = {}
+        base = _safe_leaf_name("石浩（taobaoaisi）", "节点-1")
+        first = _dedupe_name(base, seen, "nid_1")
+        second = _dedupe_name(base, seen, "nid_658000891")
+        self.assertEqual(first, base)
+        self.assertTrue(second.endswith(".res.jsonl"))
+        self.assertIn("__nid_658000891.res.jsonl", second)
+        self.assertLessEqual(len(second.encode("utf-8")), 96)
 
     def test_home_structure_contains_case_directory_and_info_snapshot(self) -> None:
         body = self.backend.get_app_structure({"app_id": "huoyan"}, self.context)

--- a/examples/appfs/bridges/http-python/tests/test_huoyan_backend.py
+++ b/examples/appfs/bridges/http-python/tests/test_huoyan_backend.py
@@ -269,7 +269,7 @@ class HuoyanBackendTests(unittest.TestCase):
         )
         initial = backend.get_app_structure({"app_id": "huoyan"}, self.context)
         revision = initial["result"]["snapshot"]["revision"]
-        self.assertRegex(revision, r"^huoyan-case:7-p:[0-9a-f]{12}-f:[0-9a-f]{12}$")
+        self.assertRegex(revision, r"^huoyan-case:7-sv:1-p:[0-9a-f]{12}-f:[0-9a-f]{12}$")
 
         self.client.list_nodes_calls.clear()
         unchanged = backend.get_app_structure(

--- a/examples/appfs/bridges/http-python/tests/test_huoyan_backend.py
+++ b/examples/appfs/bridges/http-python/tests/test_huoyan_backend.py
@@ -24,6 +24,42 @@ class _FakeHuoyanClient:
         self.case_locations = case_locations
         self.opened_paths: list[str] = []
         self.exited_case_ids: list[int] = []
+        self.list_nodes_calls: list[int] = []
+        self.root_nodes: list[dict[str, Any]] = [
+            {
+                "Nid": 4000000001,
+                "Pid": 1,
+                "Eid": 1,
+                "Name": "微信",
+                "NodeType": "weixin",
+                "SubNodeType": "treenode",
+                "HasChildNode": 1,
+            }
+        ]
+        self.child_nodes: dict[int, list[dict[str, Any]]] = {
+            4000000001: [
+                {
+                    "Nid": 4000000002,
+                    "Pid": 4000000001,
+                    "Eid": 1,
+                    "Name": "mzs(wxid_ykx86h8vvs7v12)",
+                    "NodeType": "user",
+                    "SubNodeType": "treenode",
+                    "HasChildNode": 1,
+                }
+            ],
+            4000000002: [
+                {
+                    "Nid": 4000000302,
+                    "Pid": 4000000002,
+                    "Eid": 1,
+                    "Name": "好友消息/张三",
+                    "NodeType": "buddymsgobject",
+                    "SubNodeType": "immsginfo",
+                    "HasChildNode": 0,
+                }
+            ],
+        }
 
     def list_cases(
         self, *, limit: int, offset: int, desc: bool, column: str, keyword: str
@@ -75,49 +111,10 @@ class _FakeHuoyanClient:
 
     def list_nodes(self, *, analysis_cid: int, pid: int) -> dict[str, Any]:
         _ = analysis_cid
+        self.list_nodes_calls.append(pid)
         if pid == 1:
-            return {
-                "nodes": [
-                    {
-                        "Nid": 4000000001,
-                        "Pid": 1,
-                        "Eid": 1,
-                        "Name": "微信",
-                        "NodeType": "weixin",
-                        "SubNodeType": "treenode",
-                        "HasChildNode": 1,
-                    }
-                ]
-            }
-        if pid == 4000000001:
-            return {
-                "nodes": [
-                    {
-                        "Nid": 4000000002,
-                        "Pid": 4000000001,
-                        "Eid": 1,
-                        "Name": "mzs(wxid_ykx86h8vvs7v12)",
-                        "NodeType": "user",
-                        "SubNodeType": "treenode",
-                        "HasChildNode": 1,
-                    }
-                ]
-            }
-        if pid == 4000000002:
-            return {
-                "nodes": [
-                    {
-                        "Nid": 4000000302,
-                        "Pid": 4000000002,
-                        "Eid": 1,
-                        "Name": "好友消息/张三",
-                        "NodeType": "buddymsgobject",
-                        "SubNodeType": "immsginfo",
-                        "HasChildNode": 0,
-                    }
-                ]
-            }
-        return {"nodes": []}
+            return {"nodes": self.root_nodes}
+        return {"nodes": self.child_nodes.get(pid, [])}
 
     def fetch_leaf_rows(self, *, params: dict[str, Any]) -> dict[str, Any]:
         self.last_fetch_params = params
@@ -262,6 +259,64 @@ class HuoyanBackendTests(unittest.TestCase):
         self.assertEqual(self.client.last_fetch_params["cid"], 1)
         self.assertEqual(self.client.last_fetch_params["pid"], 4000000302)
         self.assertEqual(self.client.last_fetch_params["datatype"], "immsginfo")
+
+    def test_attached_case_second_boot_uses_shallow_probe_fast_path(self) -> None:
+        backend = HuoyanBackend(
+            client=self.client,
+            open_wait_sec=0,
+            bootstrap_mode="attached_case",
+            default_case_id=7,
+        )
+        initial = backend.get_app_structure({"app_id": "huoyan"}, self.context)
+        revision = initial["result"]["snapshot"]["revision"]
+        self.assertRegex(revision, r"^huoyan-case:7-p:[0-9a-f]{12}-f:[0-9a-f]{12}$")
+
+        self.client.list_nodes_calls.clear()
+        unchanged = backend.get_app_structure(
+            {"app_id": "huoyan", "known_revision": revision},
+            self.context,
+        )
+        self.assertEqual(unchanged["result"]["kind"], "unchanged")
+        self.assertEqual(unchanged["result"]["revision"], revision)
+        self.assertEqual(self.client.list_nodes_calls, [1])
+
+    def test_attached_case_shallow_probe_change_forces_full_rebuild(self) -> None:
+        backend = HuoyanBackend(
+            client=self.client,
+            open_wait_sec=0,
+            bootstrap_mode="attached_case",
+            default_case_id=7,
+        )
+        initial = backend.get_app_structure({"app_id": "huoyan"}, self.context)
+        revision = initial["result"]["snapshot"]["revision"]
+
+        self.client.root_nodes[0]["Name"] = "企业微信"
+        self.client.list_nodes_calls.clear()
+        refreshed = backend.get_app_structure(
+            {"app_id": "huoyan", "known_revision": revision},
+            self.context,
+        )
+        self.assertEqual(refreshed["result"]["kind"], "snapshot")
+        self.assertIn(4000000001, self.client.list_nodes_calls)
+        self.assertIn(4000000002, self.client.list_nodes_calls)
+
+    def test_attached_case_old_revision_format_falls_back_to_full_build(self) -> None:
+        backend = HuoyanBackend(
+            client=self.client,
+            open_wait_sec=0,
+            bootstrap_mode="attached_case",
+            default_case_id=7,
+        )
+        backend.get_app_structure({"app_id": "huoyan"}, self.context)
+        self.client.list_nodes_calls.clear()
+        refreshed = backend.get_app_structure(
+            {"app_id": "huoyan", "known_revision": "huoyan-case:7-deadbeefcafe"},
+            self.context,
+        )
+        self.assertEqual(refreshed["result"]["kind"], "snapshot")
+        self.assertIn(1, self.client.list_nodes_calls)
+        self.assertIn(4000000001, self.client.list_nodes_calls)
+        self.assertIn(4000000002, self.client.list_nodes_calls)
 
     def test_attached_case_bootstrap_starts_inside_case_without_open(self) -> None:
         backend = HuoyanBackend(

--- a/examples/appfs/bridges/http-python/tests/test_huoyan_backend.py
+++ b/examples/appfs/bridges/http-python/tests/test_huoyan_backend.py
@@ -10,7 +10,12 @@ from unittest import mock
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from appfs_http_bridge.huoyan_backend import HuoyanBackend, _json_request
+from appfs_http_bridge.huoyan_backend import (
+    HuoyanBackend,
+    _json_request,
+    _safe_leaf_name,
+    _safe_segment,
+)
 
 
 class _FakeHuoyanClient:
@@ -161,6 +166,37 @@ class HuoyanBackendTests(unittest.TestCase):
 
     def tearDown(self) -> None:
         self.tempdir.cleanup()
+
+    def test_safe_names_preserve_short_values(self) -> None:
+        self.assertEqual(_safe_segment("微信", "节点-1"), "微信")
+        self.assertEqual(_safe_leaf_name("好友消息/张三", "节点-1"), "好友消息_张三.res.jsonl")
+
+    def test_safe_names_encode_non_bmp_emoji_as_unicode_codepoint(self) -> None:
+        self.assertEqual(
+            _safe_leaf_name("🏦银行转移（19414801983@chatroom）", "节点-1"),
+            "U0001F3E6银行转移（19414801983@chatroom）.res.jsonl",
+        )
+
+    def test_safe_names_shorten_long_utf8_components_with_hash(self) -> None:
+        raw = (
+            "AAAAA租房管家六安市区单间独卫"
+            "(v3_020b3826fd030100000000007bfd31c6b4938d000000501ea9a3dba12f95f6b60a0536a1adb6e5be76923a804307b075b0d836f0346a37779b7e6e699959002aded90e980a238b5cf26bdb2c3905da256adc7ef8415510fa0b9fc26380003ebce051@stranger)"
+        )
+        leaf = _safe_leaf_name(raw, "节点-1")
+        segment = _safe_segment(raw, "节点-1")
+
+        self.assertLessEqual(len(leaf.encode("utf-8")), 96)
+        self.assertLessEqual(len(segment.encode("utf-8")), 96)
+        self.assertTrue(leaf.endswith(".res.jsonl"))
+        self.assertRegex(leaf, r"__[0-9a-f]{12}\.res\.jsonl$")
+        self.assertRegex(segment, r"__[0-9a-f]{12}$")
+        self.assertNotEqual(leaf, raw + ".res.jsonl")
+
+    def test_safe_names_hash_avoids_long_name_collisions(self) -> None:
+        prefix = "AAAAA租房管家六安市区单间独卫" + "x" * 200
+        first = _safe_leaf_name(prefix + "1", "节点-1")
+        second = _safe_leaf_name(prefix + "2", "节点-2")
+        self.assertNotEqual(first, second)
 
     def test_home_structure_contains_case_directory_and_info_snapshot(self) -> None:
         body = self.backend.get_app_structure({"app_id": "huoyan"}, self.context)

--- a/sdk/rust/src/bulk_materialize.rs
+++ b/sdk/rust/src/bulk_materialize.rs
@@ -1,0 +1,93 @@
+use crate::filesystem::{DEFAULT_DIR_MODE, DEFAULT_FILE_MODE};
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct BulkMaterializePlan {
+    pub entries: Vec<BulkMaterializeEntry>,
+}
+
+impl BulkMaterializePlan {
+    pub fn new() -> Self {
+        Self {
+            entries: Vec::new(),
+        }
+    }
+
+    pub fn push(&mut self, entry: BulkMaterializeEntry) {
+        self.entries.push(entry);
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum BulkMaterializeEntry {
+    EnsureDir {
+        path: String,
+        uid: u32,
+        gid: u32,
+        mode: u32,
+    },
+    EnsureEmptyFile {
+        path: String,
+        uid: u32,
+        gid: u32,
+        mode: u32,
+    },
+    WriteFile {
+        path: String,
+        uid: u32,
+        gid: u32,
+        mode: u32,
+        bytes: Vec<u8>,
+    },
+}
+
+impl BulkMaterializeEntry {
+    pub fn ensure_dir(path: impl Into<String>) -> Self {
+        Self::EnsureDir {
+            path: path.into(),
+            uid: 0,
+            gid: 0,
+            mode: DEFAULT_DIR_MODE,
+        }
+    }
+
+    pub fn ensure_empty_file(path: impl Into<String>) -> Self {
+        Self::EnsureEmptyFile {
+            path: path.into(),
+            uid: 0,
+            gid: 0,
+            mode: DEFAULT_FILE_MODE,
+        }
+    }
+
+    pub fn write_file(path: impl Into<String>, bytes: Vec<u8>) -> Self {
+        Self::WriteFile {
+            path: path.into(),
+            uid: 0,
+            gid: 0,
+            mode: DEFAULT_FILE_MODE,
+            bytes,
+        }
+    }
+
+    pub fn path(&self) -> &str {
+        match self {
+            Self::EnsureDir { path, .. }
+            | Self::EnsureEmptyFile { path, .. }
+            | Self::WriteFile { path, .. } => path,
+        }
+    }
+
+    pub(crate) fn depth(&self) -> usize {
+        self.path()
+            .split('/')
+            .filter(|segment| !segment.is_empty())
+            .count()
+    }
+
+    pub(crate) fn sort_rank(&self) -> u8 {
+        match self {
+            Self::EnsureDir { .. } => 0,
+            Self::EnsureEmptyFile { .. } | Self::WriteFile { .. } => 1,
+        }
+    }
+}

--- a/sdk/rust/src/filesystem/agentfs.rs
+++ b/sdk/rust/src/filesystem/agentfs.rs
@@ -2366,12 +2366,15 @@ impl AgentFS {
                 continue;
             }
 
-            let mut stmt = conn.prepare_cached("SELECT d.name, i.ino, i.mode, i.size, i.mtime
+            let mut stmt = conn
+                .prepare_cached(
+                    "SELECT d.name, i.ino, i.mode, i.size, i.mtime
                 FROM fs_dentry d
                 JOIN fs_inode i ON d.ino = i.ino
                 WHERE d.parent_ino = ?
-                ORDER BY ((i.mode & 61440) != 16384), d.name"
-            ).await?;
+                ORDER BY ((i.mode & 61440) != 16384), d.name",
+                )
+                .await?;
             let mut rows = stmt.query((parent_ino,)).await?;
             let mut returned_for_parent = 0usize;
 
@@ -2466,12 +2469,15 @@ impl AgentFS {
                 continue;
             }
 
-            let mut stmt = conn.prepare_cached("SELECT d.name, i.ino, i.mode, i.size, i.mtime
+            let mut stmt = conn
+                .prepare_cached(
+                    "SELECT d.name, i.ino, i.mode, i.size, i.mtime
                 FROM fs_dentry d
                 JOIN fs_inode i ON d.ino = i.ino
                 WHERE d.parent_ino = ?
-                ORDER BY ((i.mode & 61440) != 16384), d.name"
-            ).await?;
+                ORDER BY ((i.mode & 61440) != 16384), d.name",
+                )
+                .await?;
             let mut rows = stmt.query((parent_ino,)).await?;
 
             while let Some(row) = rows.next().await? {
@@ -5868,7 +5874,11 @@ mod tests {
             })
             .await?;
 
-        let paths: Vec<&str> = result.entries.iter().map(|entry| entry.path.as_str()).collect();
+        let paths: Vec<&str> = result
+            .entries
+            .iter()
+            .map(|entry| entry.path.as_str())
+            .collect();
         assert_eq!(result.root, "huoyan");
         assert_eq!(
             result.revision.as_deref(),

--- a/sdk/rust/src/filesystem/agentfs.rs
+++ b/sdk/rust/src/filesystem/agentfs.rs
@@ -2,7 +2,8 @@ use crate::error::{Error, Result};
 use crate::{BulkMaterializeEntry, BulkMaterializePlan};
 use async_trait::async_trait;
 use lru::LruCache;
-use std::collections::{BTreeMap, HashMap};
+use serde::{Deserialize, Serialize};
+use std::collections::{BTreeMap, HashMap, VecDeque};
 use std::num::NonZeroUsize;
 use std::path::Path;
 use std::sync::{
@@ -23,6 +24,72 @@ use crate::schema::AGENTFS_SCHEMA_VERSION;
 const ROOT_INO: i64 = 1;
 const DEFAULT_CHUNK_SIZE: usize = 4096;
 const DENTRY_CACHE_MAX_SIZE: usize = 10000;
+
+/// Entry type returned by AgentFS DB-side structure queries.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentFsQueryEntryKind {
+    File,
+    Directory,
+    Symlink,
+    Other,
+}
+
+/// A single path entry returned by AgentFS DB-side structure queries.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AgentFsQueryEntry {
+    pub path: String,
+    pub name: String,
+    pub kind: AgentFsQueryEntryKind,
+    pub depth: usize,
+    pub ino: i64,
+    pub size: i64,
+    pub mtime: i64,
+}
+
+/// Request for a bounded directory tree query against the AgentFS DB.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AgentFsTreeQuery {
+    pub root: String,
+    pub max_depth: usize,
+    pub max_entries_per_dir: usize,
+    pub include_files: bool,
+    pub exclude_internal: bool,
+}
+
+/// Result for a bounded directory tree query against the AgentFS DB.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AgentFsTreeQueryResult {
+    pub root: String,
+    pub revision: Option<String>,
+    pub entries: Vec<AgentFsQueryEntry>,
+    pub truncated: bool,
+    pub scanned_entries: usize,
+}
+
+/// Request for a bounded glob query against the AgentFS DB.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AgentFsGlobQuery {
+    pub root: String,
+    pub pattern: String,
+    pub max_depth: usize,
+    pub max_results: usize,
+    pub max_scanned_entries: usize,
+    pub include_dirs: bool,
+    pub case_sensitive: bool,
+    pub exclude_internal: bool,
+}
+
+/// Result for a bounded glob query against the AgentFS DB.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AgentFsGlobQueryResult {
+    pub root: String,
+    pub pattern: String,
+    pub revision: Option<String>,
+    pub results: Vec<AgentFsQueryEntry>,
+    pub truncated: bool,
+    pub scanned_entries: usize,
+}
 
 /// LRU cache for directory entry lookups.
 ///
@@ -2261,6 +2328,241 @@ impl AgentFS {
         Ok(Some(entries))
     }
 
+    /// Query a bounded directory tree directly from the AgentFS database.
+    ///
+    /// This avoids mount-layer round trips and is intended for large AppFS
+    /// trees where walking through FUSE/WinFsp would be too slow.
+    pub async fn query_tree(&self, request: AgentFsTreeQuery) -> Result<AgentFsTreeQueryResult> {
+        let root_path = self.normalize_query_path(&request.root);
+        let root_display = display_path(&root_path);
+        let revision = self.app_structure_revision_for_root(&root_path).await?;
+        let max_depth = request.max_depth;
+        let max_entries_per_dir = if request.max_entries_per_dir == 0 {
+            usize::MAX
+        } else {
+            request.max_entries_per_dir
+        };
+
+        let conn = self.pool.get_connection().await?;
+        let root_ino = self
+            .resolve_path_with_conn(&conn, &root_path)
+            .await?
+            .ok_or(FsError::NotFound)?;
+        let root_stats = self
+            .getattr_with_conn(&conn, root_ino)
+            .await?
+            .ok_or(FsError::NotFound)?;
+        if !root_stats.is_directory() {
+            return Err(FsError::NotADirectory.into());
+        }
+
+        let mut entries = Vec::new();
+        let mut queue = VecDeque::from([(root_ino, root_display.clone(), 0usize)]);
+        let mut truncated = false;
+        let mut scanned_entries = 0usize;
+
+        while let Some((parent_ino, parent_display, parent_depth)) = queue.pop_front() {
+            if parent_depth >= max_depth {
+                continue;
+            }
+
+            let mut stmt = conn.prepare_cached("SELECT d.name, i.ino, i.mode, i.size, i.mtime
+                FROM fs_dentry d
+                JOIN fs_inode i ON d.ino = i.ino
+                WHERE d.parent_ino = ?
+                ORDER BY ((i.mode & 61440) != 16384), d.name"
+            ).await?;
+            let mut rows = stmt.query((parent_ino,)).await?;
+            let mut returned_for_parent = 0usize;
+
+            while let Some(row) = rows.next().await? {
+                let name = row_text(&row, 0);
+                if name.is_empty() {
+                    continue;
+                }
+                if request.exclude_internal && is_internal_component(&name) {
+                    continue;
+                }
+                if returned_for_parent >= max_entries_per_dir {
+                    truncated = true;
+                    break;
+                }
+
+                scanned_entries += 1;
+                let ino = row_i64(&row, 1);
+                let mode = row_i64(&row, 2) as u32;
+                let size = row_i64(&row, 3);
+                let mtime = row_i64(&row, 4);
+                let kind = entry_kind_from_mode(mode);
+                let path = join_display_path(&parent_display, &name);
+                let depth = parent_depth + 1;
+                if !request.include_files && kind != AgentFsQueryEntryKind::Directory {
+                    // Children are ordered directories first, so no later row can
+                    // contribute to a directory-only tree outline.
+                    break;
+                }
+
+                if request.include_files || kind == AgentFsQueryEntryKind::Directory {
+                    entries.push(AgentFsQueryEntry {
+                        path: path.clone(),
+                        name: name.clone(),
+                        kind,
+                        depth,
+                        ino,
+                        size,
+                        mtime,
+                    });
+                    returned_for_parent += 1;
+                }
+
+                if kind == AgentFsQueryEntryKind::Directory {
+                    queue.push_back((ino, path, depth));
+                }
+            }
+        }
+
+        Ok(AgentFsTreeQueryResult {
+            root: root_display,
+            revision,
+            entries,
+            truncated,
+            scanned_entries,
+        })
+    }
+
+    /// Query paths matching a glob directly from the AgentFS database.
+    ///
+    /// The glob is evaluated relative to `root`. Patterns prefixed with the
+    /// root path are accepted and normalized, e.g. `huoyan/**/*.res.jsonl`.
+    pub async fn query_glob(&self, request: AgentFsGlobQuery) -> Result<AgentFsGlobQueryResult> {
+        let root_path = self.normalize_query_path(&request.root);
+        let root_display = display_path(&root_path);
+        let revision = self.app_structure_revision_for_root(&root_path).await?;
+        let pattern = normalize_glob_pattern(&request.pattern, &root_display);
+        let max_depth = request.max_depth.max(1);
+        let max_results = request.max_results.max(1);
+        let max_scanned_entries = request.max_scanned_entries.max(max_results);
+
+        let conn = self.pool.get_connection().await?;
+        let root_ino = self
+            .resolve_path_with_conn(&conn, &root_path)
+            .await?
+            .ok_or(FsError::NotFound)?;
+        let root_stats = self
+            .getattr_with_conn(&conn, root_ino)
+            .await?
+            .ok_or(FsError::NotFound)?;
+        if !root_stats.is_directory() {
+            return Err(FsError::NotADirectory.into());
+        }
+
+        let mut results = Vec::new();
+        let mut queue = VecDeque::from([(root_ino, root_display.clone(), 0usize)]);
+        let mut scanned_entries = 0usize;
+        let mut truncated = false;
+
+        while let Some((parent_ino, parent_display, parent_depth)) = queue.pop_front() {
+            if parent_depth >= max_depth {
+                continue;
+            }
+
+            let mut stmt = conn.prepare_cached("SELECT d.name, i.ino, i.mode, i.size, i.mtime
+                FROM fs_dentry d
+                JOIN fs_inode i ON d.ino = i.ino
+                WHERE d.parent_ino = ?
+                ORDER BY ((i.mode & 61440) != 16384), d.name"
+            ).await?;
+            let mut rows = stmt.query((parent_ino,)).await?;
+
+            while let Some(row) = rows.next().await? {
+                if scanned_entries >= max_scanned_entries {
+                    truncated = true;
+                    break;
+                }
+                scanned_entries += 1;
+
+                let name = row_text(&row, 0);
+                if name.is_empty() {
+                    continue;
+                }
+                if request.exclude_internal && is_internal_component(&name) {
+                    continue;
+                }
+
+                let ino = row_i64(&row, 1);
+                let mode = row_i64(&row, 2) as u32;
+                let size = row_i64(&row, 3);
+                let mtime = row_i64(&row, 4);
+                let kind = entry_kind_from_mode(mode);
+                let display = join_display_path(&parent_display, &name);
+                let relative = relative_to_root_display(&display, &root_display);
+                let depth = parent_depth + 1;
+
+                if kind == AgentFsQueryEntryKind::Directory && depth < max_depth {
+                    queue.push_back((ino, display.clone(), depth));
+                }
+
+                if kind == AgentFsQueryEntryKind::Directory && !request.include_dirs {
+                    continue;
+                }
+                if request.exclude_internal && has_internal_component(relative) {
+                    continue;
+                }
+                if !glob_pattern_matches(&pattern, relative, request.case_sensitive) {
+                    continue;
+                }
+
+                results.push(AgentFsQueryEntry {
+                    path: display,
+                    name,
+                    kind,
+                    depth,
+                    ino,
+                    size,
+                    mtime,
+                });
+                if results.len() >= max_results {
+                    truncated = true;
+                    break;
+                }
+            }
+
+            if truncated {
+                break;
+            }
+        }
+
+        Ok(AgentFsGlobQueryResult {
+            root: root_display,
+            pattern,
+            revision,
+            results,
+            truncated,
+            scanned_entries,
+        })
+    }
+
+    fn normalize_query_path(&self, path: &str) -> String {
+        self.normalize_path(&path.replace('\\', "/"))
+    }
+
+    async fn app_structure_revision_for_root(&self, root_path: &str) -> Result<Option<String>> {
+        let Some(app_id) = self.split_path(root_path).into_iter().next() else {
+            return Ok(None);
+        };
+        let state_path = format!("/{app_id}/_meta/app-structure-sync.state.res.json");
+        let Some(bytes) = self.read_file(&state_path).await? else {
+            return Ok(None);
+        };
+        let Ok(value) = serde_json::from_slice::<serde_json::Value>(&bytes) else {
+            return Ok(None);
+        };
+        Ok(value
+            .get("revision")
+            .and_then(|revision| revision.as_str())
+            .map(ToString::to_string))
+    }
+
     /// Create a symbolic link with the specified ownership
     pub async fn symlink(&self, target: &str, linkpath: &str, uid: u32, gid: u32) -> Result<()> {
         let conn = self.pool.get_connection().await?;
@@ -4141,6 +4443,136 @@ impl FileSystem for AgentFS {
     }
 }
 
+fn row_text(row: &turso::Row, index: usize) -> String {
+    row.get_value(index)
+        .ok()
+        .and_then(|value| {
+            if let Value::Text(text) = value {
+                Some(text.clone())
+            } else {
+                None
+            }
+        })
+        .unwrap_or_default()
+}
+
+fn row_i64(row: &turso::Row, index: usize) -> i64 {
+    row.get_value(index)
+        .ok()
+        .and_then(|value| value.as_integer().copied())
+        .unwrap_or(0)
+}
+
+fn entry_kind_from_mode(mode: u32) -> AgentFsQueryEntryKind {
+    match mode & S_IFMT {
+        S_IFREG => AgentFsQueryEntryKind::File,
+        S_IFDIR => AgentFsQueryEntryKind::Directory,
+        S_IFLNK => AgentFsQueryEntryKind::Symlink,
+        _ => AgentFsQueryEntryKind::Other,
+    }
+}
+
+fn display_path(path: &str) -> String {
+    path.trim_start_matches('/').to_string()
+}
+
+fn join_display_path(parent: &str, name: &str) -> String {
+    if parent.is_empty() {
+        name.to_string()
+    } else {
+        format!("{parent}/{name}")
+    }
+}
+
+fn relative_to_root_display<'a>(path: &'a str, root: &str) -> &'a str {
+    if root.is_empty() {
+        return path;
+    }
+    path.strip_prefix(root)
+        .and_then(|suffix| suffix.strip_prefix('/').or(Some(suffix)))
+        .unwrap_or(path)
+}
+
+fn is_internal_component(name: &str) -> bool {
+    matches!(
+        name,
+        "_app" | "_appfs" | "_meta" | "_stream" | ".well-known"
+    )
+}
+
+fn has_internal_component(path: &str) -> bool {
+    path.split('/')
+        .filter(|part| !part.is_empty())
+        .any(is_internal_component)
+}
+
+fn normalize_glob_pattern(pattern: &str, root_display: &str) -> String {
+    let mut normalized = pattern.replace('\\', "/");
+    normalized = normalized.trim().trim_start_matches("./").to_string();
+    normalized = normalized.trim_start_matches('/').to_string();
+    if !root_display.is_empty() {
+        if normalized == root_display {
+            return "**".to_string();
+        }
+        let root_prefix = format!("{root_display}/");
+        if let Some(stripped) = normalized.strip_prefix(&root_prefix) {
+            normalized = stripped.to_string();
+        }
+    }
+    if normalized.is_empty() {
+        "**".to_string()
+    } else {
+        normalized
+    }
+}
+
+fn glob_pattern_matches(pattern: &str, path: &str, case_sensitive: bool) -> bool {
+    let (pattern, path) = if case_sensitive {
+        (pattern.to_string(), path.to_string())
+    } else {
+        (pattern.to_lowercase(), path.to_lowercase())
+    };
+    let pattern_parts: Vec<&str> = pattern.split('/').filter(|part| !part.is_empty()).collect();
+    let path_parts: Vec<&str> = path.split('/').filter(|part| !part.is_empty()).collect();
+    glob_segments_match(&pattern_parts, &path_parts)
+}
+
+fn glob_segments_match(pattern: &[&str], path: &[&str]) -> bool {
+    if pattern.is_empty() {
+        return path.is_empty();
+    }
+    if pattern[0] == "**" {
+        return glob_segments_match(&pattern[1..], path)
+            || (!path.is_empty() && glob_segments_match(pattern, &path[1..]));
+    }
+    if path.is_empty() {
+        return false;
+    }
+    wildcard_segment_match(pattern[0], path[0]) && glob_segments_match(&pattern[1..], &path[1..])
+}
+
+fn wildcard_segment_match(pattern: &str, text: &str) -> bool {
+    let pattern_chars: Vec<char> = pattern.chars().collect();
+    let text_chars: Vec<char> = text.chars().collect();
+    let mut dp = vec![vec![false; text_chars.len() + 1]; pattern_chars.len() + 1];
+    dp[0][0] = true;
+    for i in 1..=pattern_chars.len() {
+        if pattern_chars[i - 1] == '*' {
+            dp[i][0] = dp[i - 1][0];
+        }
+    }
+    for i in 1..=pattern_chars.len() {
+        for j in 1..=text_chars.len() {
+            dp[i][j] = match pattern_chars[i - 1] {
+                '*' => dp[i - 1][j] || dp[i][j - 1],
+                '?' => dp[i - 1][j - 1],
+                ch => ch == text_chars[j - 1] && dp[i - 1][j - 1],
+            };
+        }
+    }
+    dp[pattern_chars.len()][text_chars.len()]
+}
+
 fn split_parent_path(components: &[String]) -> (String, String) {
     let name = components
         .last()
@@ -5405,6 +5837,85 @@ mod tests {
 
         assert!(reader.stat("/root/old").await?.is_none());
         assert!(reader.stat("/root/new").await?.is_some());
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_query_tree_returns_bounded_db_tree() -> Result<()> {
+        let (fs, _dir) = create_test_fs().await?;
+        let mut plan = BulkMaterializePlan::new();
+        plan.push(BulkMaterializeEntry::ensure_dir("/huoyan"));
+        plan.push(BulkMaterializeEntry::ensure_dir("/huoyan/_meta"));
+        plan.push(BulkMaterializeEntry::ensure_dir("/huoyan/检材1"));
+        plan.push(BulkMaterializeEntry::ensure_dir("/huoyan/检材1/App分析"));
+        plan.push(BulkMaterializeEntry::ensure_empty_file(
+            "/huoyan/检材1/App分析/APK列表.res.jsonl",
+        ));
+        plan.push(BulkMaterializeEntry::write_file(
+            "/huoyan/_meta/app-structure-sync.state.res.json",
+            br#"{"revision":"huoyan-case:1-sv:1-p:aaaaaaaaaaaa-f:bbbbbbbbbbbb"}"#.to_vec(),
+        ));
+        fs.bulk_materialize_tree(&plan).await?;
+
+        let result = fs
+            .query_tree(AgentFsTreeQuery {
+                root: "huoyan".to_string(),
+                max_depth: 3,
+                max_entries_per_dir: 100,
+                include_files: true,
+                exclude_internal: true,
+            })
+            .await?;
+
+        let paths: Vec<&str> = result.entries.iter().map(|entry| entry.path.as_str()).collect();
+        assert_eq!(result.root, "huoyan");
+        assert_eq!(
+            result.revision.as_deref(),
+            Some("huoyan-case:1-sv:1-p:aaaaaaaaaaaa-f:bbbbbbbbbbbb")
+        );
+        assert!(paths.contains(&"huoyan/检材1"));
+        assert!(paths.contains(&"huoyan/检材1/App分析"));
+        assert!(paths.contains(&"huoyan/检材1/App分析/APK列表.res.jsonl"));
+        assert!(!paths.contains(&"huoyan/_meta"));
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_query_glob_matches_relative_and_root_prefixed_patterns() -> Result<()> {
+        let (fs, _dir) = create_test_fs().await?;
+        let mut plan = BulkMaterializePlan::new();
+        plan.push(BulkMaterializeEntry::ensure_dir("/huoyan"));
+        plan.push(BulkMaterializeEntry::ensure_dir("/huoyan/检材1"));
+        plan.push(BulkMaterializeEntry::ensure_dir("/huoyan/检材1/App分析"));
+        plan.push(BulkMaterializeEntry::ensure_empty_file(
+            "/huoyan/检材1/App分析/APK列表.res.jsonl",
+        ));
+        plan.push(BulkMaterializeEntry::ensure_empty_file(
+            "/huoyan/检材1/App分析/readme.txt",
+        ));
+        fs.bulk_materialize_tree(&plan).await?;
+
+        let result = fs
+            .query_glob(AgentFsGlobQuery {
+                root: "/huoyan".to_string(),
+                pattern: "huoyan/**/*.RES.JSONL".to_string(),
+                max_depth: 8,
+                max_results: 10,
+                max_scanned_entries: 100,
+                include_dirs: false,
+                case_sensitive: false,
+                exclude_internal: true,
+            })
+            .await?;
+
+        assert_eq!(result.results.len(), 1);
+        assert_eq!(
+            result.results[0].path,
+            "huoyan/检材1/App分析/APK列表.res.jsonl"
+        );
+        assert_eq!(result.results[0].kind, AgentFsQueryEntryKind::File);
 
         Ok(())
     }

--- a/sdk/rust/src/filesystem/agentfs.rs
+++ b/sdk/rust/src/filesystem/agentfs.rs
@@ -5,7 +5,10 @@ use lru::LruCache;
 use std::collections::{BTreeMap, HashMap};
 use std::num::NonZeroUsize;
 use std::path::Path;
-use std::sync::{Arc, Mutex};
+use std::sync::{
+    atomic::{AtomicU64, Ordering},
+    Arc, LazyLock, Mutex, Weak,
+};
 use std::time::{SystemTime, UNIX_EPOCH};
 use turso::transaction::{Transaction, TransactionBehavior};
 use turso::{Builder, Connection, Value};
@@ -64,6 +67,28 @@ impl DentryCache {
             .unwrap()
             .pop(&(parent_ino, name.to_string()));
     }
+
+    fn clear(&self) {
+        self.entries.lock().unwrap().clear();
+    }
+}
+
+#[derive(Default)]
+struct SharedDentryEpoch {
+    value: AtomicU64,
+}
+
+static SHARED_DENTRY_EPOCHS: LazyLock<Mutex<HashMap<String, Weak<SharedDentryEpoch>>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+
+fn shared_dentry_epoch(cache_key: &str) -> Arc<SharedDentryEpoch> {
+    let mut guard = SHARED_DENTRY_EPOCHS.lock().unwrap();
+    if let Some(epoch) = guard.get(cache_key).and_then(Weak::upgrade) {
+        return epoch;
+    }
+    let epoch = Arc::new(SharedDentryEpoch::default());
+    guard.insert(cache_key.to_string(), Arc::downgrade(&epoch));
+    epoch
 }
 
 /// A filesystem backed by SQLite
@@ -73,6 +98,8 @@ pub struct AgentFS {
     chunk_size: usize,
     /// Cache for directory entry lookups (shared across clones)
     dentry_cache: Arc<DentryCache>,
+    shared_dentry_epoch: Option<Arc<SharedDentryEpoch>>,
+    seen_dentry_epoch: Arc<AtomicU64>,
 }
 
 /// An open file handle for AgentFS.
@@ -431,11 +458,19 @@ impl AgentFS {
     /// Create a new filesystem
     pub async fn new(db_path: &str) -> Result<Self> {
         let db = Builder::new_local(db_path).build().await?;
-        Self::from_pool(ConnectionPool::new(db)).await
+        Self::from_pool_with_cache_key(ConnectionPool::new(db), Some(db_path.to_string())).await
     }
 
     /// Create a filesystem from a connection pool
     pub async fn from_pool(pool: ConnectionPool) -> Result<Self> {
+        Self::from_pool_with_cache_key(pool, None).await
+    }
+
+    /// Create a filesystem from a connection pool with an optional shared cache key.
+    pub async fn from_pool_with_cache_key(
+        pool: ConnectionPool,
+        cache_key: Option<String>,
+    ) -> Result<Self> {
         let conn = pool.get_connection().await?;
 
         // Initialize schema first
@@ -451,12 +486,40 @@ impl AgentFS {
         // Get chunk_size from config (or use default)
         let chunk_size = Self::read_chunk_size(&conn).await?;
 
+        let shared_dentry_epoch = cache_key.as_deref().map(shared_dentry_epoch);
+        let initial_epoch = shared_dentry_epoch
+            .as_ref()
+            .map(|epoch| epoch.value.load(Ordering::SeqCst))
+            .unwrap_or(0);
+
         let fs = Self {
             pool,
             chunk_size,
             dentry_cache: Arc::new(DentryCache::new(DENTRY_CACHE_MAX_SIZE)),
+            shared_dentry_epoch,
+            seen_dentry_epoch: Arc::new(AtomicU64::new(initial_epoch)),
         };
         Ok(fs)
+    }
+
+    fn refresh_dentry_cache_if_stale(&self) {
+        let Some(shared) = &self.shared_dentry_epoch else {
+            return;
+        };
+        let current = shared.value.load(Ordering::SeqCst);
+        let seen = self.seen_dentry_epoch.load(Ordering::SeqCst);
+        if current != seen {
+            self.dentry_cache.clear();
+            self.seen_dentry_epoch.store(current, Ordering::SeqCst);
+        }
+    }
+
+    fn invalidate_shared_dentry_caches(&self) {
+        self.dentry_cache.clear();
+        if let Some(shared) = &self.shared_dentry_epoch {
+            let next = shared.value.fetch_add(1, Ordering::SeqCst) + 1;
+            self.seen_dentry_epoch.store(next, Ordering::SeqCst);
+        }
     }
 
     /// Get the configured chunk size
@@ -841,6 +904,7 @@ impl AgentFS {
 
     /// Resolve a path to an inode number using a provided connection
     async fn resolve_path_with_conn(&self, conn: &Connection, path: &str) -> Result<Option<i64>> {
+        self.refresh_dentry_cache_if_stale();
         let components = self.split_path(path);
         if components.is_empty() {
             return Ok(Some(ROOT_INO));
@@ -1407,6 +1471,7 @@ impl AgentFS {
                 for (parent_ino, name, ino) in dentry_cache_inserts {
                     self.dentry_cache.insert(parent_ino, &name, ino);
                 }
+                self.invalidate_shared_dentry_caches();
                 Ok(())
             }
             Err(err) => {
@@ -2477,6 +2542,7 @@ impl AgentFS {
 
         // Invalidate cache for this entry
         self.dentry_cache.remove(parent_ino, name);
+        self.invalidate_shared_dentry_caches();
 
         // Decrement link count
         let mut stmt = conn
@@ -5317,6 +5383,28 @@ mod tests {
                 .unwrap(),
             br#"{"id":"m-1"}"#.to_vec()
         );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_shared_dentry_cache_invalidation_after_bulk_materialize() -> Result<()> {
+        let dir = tempfile::tempdir()?;
+        let db_path = dir.path().join("shared-cache.db");
+        let writer = AgentFS::new(db_path.to_str().unwrap()).await?;
+        let reader = AgentFS::new(db_path.to_str().unwrap()).await?;
+
+        writer.mkdir("/root", 0, 0).await?;
+        writer.mkdir("/root/old", 0, 0).await?;
+        assert!(reader.stat("/root/old").await?.is_some());
+
+        writer.remove("/root/old").await?;
+        let mut plan = BulkMaterializePlan::new();
+        plan.push(BulkMaterializeEntry::ensure_dir("/root/new"));
+        writer.bulk_materialize_tree(&plan).await?;
+
+        assert!(reader.stat("/root/old").await?.is_none());
+        assert!(reader.stat("/root/new").await?.is_some());
 
         Ok(())
     }

--- a/sdk/rust/src/filesystem/agentfs.rs
+++ b/sdk/rust/src/filesystem/agentfs.rs
@@ -1,6 +1,8 @@
 use crate::error::{Error, Result};
+use crate::{BulkMaterializeEntry, BulkMaterializePlan};
 use async_trait::async_trait;
 use lru::LruCache;
+use std::collections::{BTreeMap, HashMap};
 use std::num::NonZeroUsize;
 use std::path::Path;
 use std::sync::{Arc, Mutex};
@@ -10,7 +12,7 @@ use turso::{Builder, Connection, Value};
 
 use super::{
     BoxedFile, DirEntry, File, FileSystem, FilesystemStats, FsError, Stats, TimeChange,
-    DEFAULT_DIR_MODE, DEFAULT_FILE_MODE, MAX_NAME_LEN, S_IFLNK, S_IFMT, S_IFREG,
+    DEFAULT_DIR_MODE, DEFAULT_FILE_MODE, MAX_NAME_LEN, S_IFDIR, S_IFLNK, S_IFMT, S_IFREG,
 };
 use crate::connection_pool::ConnectionPool;
 use crate::schema::AGENTFS_SCHEMA_VERSION;
@@ -81,6 +83,12 @@ pub struct AgentFSFile {
     pool: ConnectionPool,
     ino: i64,
     chunk_size: usize,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct BulkPathState {
+    ino: i64,
+    mode: u32,
 }
 
 #[async_trait]
@@ -1304,6 +1312,316 @@ impl AgentFS {
         });
 
         Ok((stats, file))
+    }
+
+    /// Bulk materialize directories and files directly into the AgentFS database.
+    ///
+    /// This bypasses mount-layer round-trips and is intended for large startup
+    /// tree bootstraps.
+    pub async fn bulk_materialize_tree(&self, plan: &BulkMaterializePlan) -> Result<()> {
+        if plan.entries.is_empty() {
+            return Ok(());
+        }
+
+        let conn = self.pool.get_connection().await?;
+        let txn = Transaction::new_unchecked(&conn, TransactionBehavior::Immediate).await?;
+        let mut path_cache = HashMap::from([(
+            "/".to_string(),
+            BulkPathState {
+                ino: ROOT_INO,
+                mode: DEFAULT_DIR_MODE,
+            },
+        )]);
+        let mut parent_updates = BTreeMap::<i64, i64>::new();
+        let mut dentry_cache_inserts = Vec::<(i64, String, i64)>::new();
+
+        let mut sorted_entries = plan.entries.clone();
+        sorted_entries.sort_by(|left, right| {
+            left.depth()
+                .cmp(&right.depth())
+                .then(left.sort_rank().cmp(&right.sort_rank()))
+                .then(left.path().cmp(right.path()))
+        });
+
+        let result: Result<()> = async {
+            for entry in &sorted_entries {
+                let normalized_path = self.normalize_path(entry.path());
+                if normalized_path == "/" {
+                    return Err(FsError::RootOperation.into());
+                }
+
+                let components = self.split_path(&normalized_path);
+                if components.is_empty() {
+                    return Err(FsError::RootOperation.into());
+                }
+                for component in &components {
+                    if component.len() > MAX_NAME_LEN {
+                        return Err(FsError::NameTooLong.into());
+                    }
+                }
+
+                let (parent_path, name) = split_parent_path(&components);
+                let parent = self
+                    .resolve_cached_bulk_path(&conn, &parent_path, &mut path_cache)
+                    .await?
+                    .ok_or(FsError::NotFound)?;
+                if (parent.mode & S_IFMT) != S_IFDIR {
+                    return Err(FsError::NotADirectory.into());
+                }
+
+                if let Some(existing) = self
+                    .resolve_cached_bulk_path(&conn, &normalized_path, &mut path_cache)
+                    .await?
+                {
+                    self.validate_existing_bulk_entry(entry, existing.mode)?;
+                    if let BulkMaterializeEntry::WriteFile { bytes, .. } = entry {
+                        self.write_bulk_file_contents(&conn, existing.ino, bytes)
+                            .await?;
+                    }
+                    continue;
+                }
+
+                let created = self
+                    .create_bulk_entry(
+                        &conn,
+                        entry,
+                        &normalized_path,
+                        &name,
+                        parent.ino,
+                        &mut parent_updates,
+                    )
+                    .await?;
+                path_cache.insert(normalized_path, created);
+                dentry_cache_inserts.push((parent.ino, name, created.ino));
+            }
+
+            self.apply_bulk_parent_updates(&conn, &parent_updates)
+                .await?;
+            Ok(())
+        }
+        .await;
+
+        match result {
+            Ok(()) => {
+                txn.commit().await?;
+                for (parent_ino, name, ino) in dentry_cache_inserts {
+                    self.dentry_cache.insert(parent_ino, &name, ino);
+                }
+                Ok(())
+            }
+            Err(err) => {
+                let _ = txn.rollback().await;
+                Err(err)
+            }
+        }
+    }
+
+    async fn resolve_cached_bulk_path(
+        &self,
+        conn: &Connection,
+        path: &str,
+        cache: &mut HashMap<String, BulkPathState>,
+    ) -> Result<Option<BulkPathState>> {
+        let normalized = self.normalize_path(path);
+        if let Some(state) = cache.get(&normalized).copied() {
+            return Ok(Some(state));
+        }
+        let Some(ino) = self.resolve_path_with_conn(conn, &normalized).await? else {
+            return Ok(None);
+        };
+        let stats = self.getattr_with_conn(conn, ino).await?.ok_or_else(|| {
+            Error::Internal(format!(
+                "inode {ino} resolved from {normalized} disappeared"
+            ))
+        })?;
+        let state = BulkPathState {
+            ino,
+            mode: stats.mode,
+        };
+        cache.insert(normalized, state);
+        Ok(Some(state))
+    }
+
+    fn validate_existing_bulk_entry(
+        &self,
+        entry: &BulkMaterializeEntry,
+        existing_mode: u32,
+    ) -> Result<()> {
+        let existing_kind = existing_mode & S_IFMT;
+        match entry {
+            BulkMaterializeEntry::EnsureDir { .. } if existing_kind != S_IFDIR => {
+                Err(FsError::NotADirectory.into())
+            }
+            BulkMaterializeEntry::EnsureEmptyFile { .. }
+            | BulkMaterializeEntry::WriteFile { .. }
+                if existing_kind != S_IFREG =>
+            {
+                Err(FsError::IsADirectory.into())
+            }
+            _ => Ok(()),
+        }
+    }
+
+    async fn create_bulk_entry(
+        &self,
+        conn: &Connection,
+        entry: &BulkMaterializeEntry,
+        normalized_path: &str,
+        name: &str,
+        parent_ino: i64,
+        parent_updates: &mut BTreeMap<i64, i64>,
+    ) -> Result<BulkPathState> {
+        let (mode, uid, gid, size, nlink) = match entry {
+            BulkMaterializeEntry::EnsureDir { uid, gid, mode, .. } => {
+                ((S_IFDIR | (mode & 0o7777)) as i64, *uid, *gid, 0i64, 2i64)
+            }
+            BulkMaterializeEntry::EnsureEmptyFile { uid, gid, mode, .. } => {
+                ((S_IFREG | (mode & 0o7777)) as i64, *uid, *gid, 0i64, 1i64)
+            }
+            BulkMaterializeEntry::WriteFile {
+                uid,
+                gid,
+                mode,
+                bytes,
+                ..
+            } => (
+                (S_IFREG | (mode & 0o7777)) as i64,
+                *uid,
+                *gid,
+                bytes.len() as i64,
+                1i64,
+            ),
+        };
+
+        let dur = SystemTime::now().duration_since(UNIX_EPOCH)?;
+        let now_secs = dur.as_secs() as i64;
+        let now_nsec = dur.subsec_nanos() as i64;
+
+        let mut inode_stmt = conn
+            .prepare_cached(
+                "INSERT INTO fs_inode (mode, nlink, uid, gid, size, atime, mtime, ctime, atime_nsec, mtime_nsec, ctime_nsec)
+                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) RETURNING ino",
+            )
+            .await?;
+        let row = inode_stmt
+            .query_row((
+                mode, nlink, uid, gid, size, now_secs, now_secs, now_secs, now_nsec, now_nsec,
+                now_nsec,
+            ))
+            .await?;
+        let ino = row
+            .get_value(0)
+            .ok()
+            .and_then(|v| v.as_integer().copied())
+            .ok_or_else(|| {
+                Error::Internal(format!(
+                    "failed to get inode for bulk materialized path {normalized_path}"
+                ))
+            })?;
+
+        let mut dentry_stmt = conn
+            .prepare_cached("INSERT INTO fs_dentry (name, parent_ino, ino) VALUES (?, ?, ?)")
+            .await?;
+        dentry_stmt.execute((name, parent_ino, ino)).await?;
+
+        if let BulkMaterializeEntry::WriteFile { bytes, .. } = entry {
+            self.insert_bulk_file_chunks(conn, ino, bytes).await?;
+        }
+
+        let nlink_increment = match entry {
+            BulkMaterializeEntry::EnsureDir { .. } => 1,
+            _ => 0,
+        };
+        parent_updates
+            .entry(parent_ino)
+            .and_modify(|count| *count += nlink_increment)
+            .or_insert(nlink_increment);
+
+        Ok(BulkPathState {
+            ino,
+            mode: mode as u32,
+        })
+    }
+
+    async fn write_bulk_file_contents(
+        &self,
+        conn: &Connection,
+        ino: i64,
+        bytes: &[u8],
+    ) -> Result<()> {
+        conn.execute("DELETE FROM fs_data WHERE ino = ?", (ino,))
+            .await?;
+        self.insert_bulk_file_chunks(conn, ino, bytes).await?;
+
+        let dur = SystemTime::now().duration_since(UNIX_EPOCH)?;
+        let now_secs = dur.as_secs() as i64;
+        let now_nsec = dur.subsec_nanos() as i64;
+        let mut stmt = conn
+            .prepare_cached(
+                "UPDATE fs_inode SET size = ?, mtime = ?, ctime = ?, mtime_nsec = ?, ctime_nsec = ? WHERE ino = ?",
+            )
+            .await?;
+        stmt.execute((
+            bytes.len() as i64,
+            now_secs,
+            now_secs,
+            now_nsec,
+            now_nsec,
+            ino,
+        ))
+        .await?;
+        Ok(())
+    }
+
+    async fn insert_bulk_file_chunks(
+        &self,
+        conn: &Connection,
+        ino: i64,
+        bytes: &[u8],
+    ) -> Result<()> {
+        if bytes.is_empty() {
+            return Ok(());
+        }
+        let mut stmt = conn
+            .prepare_cached("INSERT INTO fs_data (ino, chunk_index, data) VALUES (?, ?, ?)")
+            .await?;
+        for (chunk_index, chunk) in bytes.chunks(self.chunk_size).enumerate() {
+            stmt.execute((ino, chunk_index as i64, chunk)).await?;
+        }
+        Ok(())
+    }
+
+    async fn apply_bulk_parent_updates(
+        &self,
+        conn: &Connection,
+        parent_updates: &BTreeMap<i64, i64>,
+    ) -> Result<()> {
+        if parent_updates.is_empty() {
+            return Ok(());
+        }
+
+        let dur = SystemTime::now().duration_since(UNIX_EPOCH)?;
+        let now_secs = dur.as_secs() as i64;
+        let now_nsec = dur.subsec_nanos() as i64;
+        let mut stmt = conn
+            .prepare_cached(
+                "UPDATE fs_inode
+                 SET nlink = nlink + ?, mtime = ?, ctime = ?, mtime_nsec = ?, ctime_nsec = ?
+                 WHERE ino = ?",
+            )
+            .await?;
+        for (parent_ino, nlink_increment) in parent_updates {
+            stmt.execute((
+                *nlink_increment,
+                now_secs,
+                now_secs,
+                now_nsec,
+                now_nsec,
+                *parent_ino,
+            ))
+            .await?;
+        }
+        Ok(())
     }
 
     /// Read data from a file
@@ -3757,9 +4075,23 @@ impl FileSystem for AgentFS {
     }
 }
 
+fn split_parent_path(components: &[String]) -> (String, String) {
+    let name = components
+        .last()
+        .cloned()
+        .expect("split_parent_path requires at least one component");
+    let parent_path = if components.len() == 1 {
+        "/".to_string()
+    } else {
+        format!("/{}", components[..components.len() - 1].join("/"))
+    };
+    (parent_path, name)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::{BulkMaterializeEntry, BulkMaterializePlan};
     use tempfile::tempdir;
 
     async fn create_test_fs() -> Result<(AgentFS, tempfile::TempDir)> {
@@ -4912,6 +5244,79 @@ mod tests {
 
         let stats = fs.lstat("/link.txt").await?.unwrap();
         assert!(stats.is_symlink(), "Should still be a symlink");
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_bulk_materialize_tree_creates_directories_and_files() -> Result<()> {
+        let (fs, _dir) = create_test_fs().await?;
+        let mut plan = BulkMaterializePlan::new();
+        plan.push(BulkMaterializeEntry::ensure_dir("/aiim"));
+        plan.push(BulkMaterializeEntry::ensure_dir("/aiim/_meta"));
+        plan.push(BulkMaterializeEntry::ensure_dir("/aiim/chats"));
+        plan.push(BulkMaterializeEntry::ensure_dir("/aiim/chats/chat-001"));
+        plan.push(BulkMaterializeEntry::ensure_empty_file(
+            "/aiim/chats/chat-001/messages.res.jsonl",
+        ));
+        plan.push(BulkMaterializeEntry::write_file(
+            "/aiim/_meta/manifest.res.json",
+            br#"{"app_id":"aiim"}"#.to_vec(),
+        ));
+
+        fs.bulk_materialize_tree(&plan).await?;
+
+        assert!(fs.stat("/aiim").await?.unwrap().is_directory());
+        assert!(fs
+            .stat("/aiim/chats/chat-001/messages.res.jsonl")
+            .await?
+            .unwrap()
+            .is_file());
+        assert_eq!(
+            fs.read_file("/aiim/_meta/manifest.res.json")
+                .await?
+                .unwrap(),
+            br#"{"app_id":"aiim"}"#.to_vec()
+        );
+        assert_eq!(
+            fs.read_file("/aiim/chats/chat-001/messages.res.jsonl")
+                .await?
+                .unwrap(),
+            Vec::<u8>::new()
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_bulk_materialize_tree_preserves_existing_placeholder_content() -> Result<()> {
+        let (fs, _dir) = create_test_fs().await?;
+        fs.mkdir("/aiim", 0, 0).await?;
+        fs.mkdir("/aiim/chats", 0, 0).await?;
+        fs.mkdir("/aiim/chats/chat-001", 0, 0).await?;
+        let (_, file) = fs
+            .create_file(
+                "/aiim/chats/chat-001/messages.res.jsonl",
+                DEFAULT_FILE_MODE,
+                0,
+                0,
+            )
+            .await?;
+        file.pwrite(0, br#"{"id":"m-1"}"#).await?;
+
+        let mut plan = BulkMaterializePlan::new();
+        plan.push(BulkMaterializeEntry::ensure_empty_file(
+            "/aiim/chats/chat-001/messages.res.jsonl",
+        ));
+
+        fs.bulk_materialize_tree(&plan).await?;
+
+        assert_eq!(
+            fs.read_file("/aiim/chats/chat-001/messages.res.jsonl")
+                .await?
+                .unwrap(),
+            br#"{"id":"m-1"}"#.to_vec()
+        );
 
         Ok(())
     }

--- a/sdk/rust/src/filesystem/mod.rs
+++ b/sdk/rust/src/filesystem/mod.rs
@@ -14,8 +14,8 @@ use thiserror::Error;
 
 // Re-export implementations
 pub use agentfs::{
-    AgentFS, AgentFsGlobQuery, AgentFsGlobQueryResult, AgentFsQueryEntry,
-    AgentFsQueryEntryKind, AgentFsTreeQuery, AgentFsTreeQueryResult,
+    AgentFS, AgentFsGlobQuery, AgentFsGlobQueryResult, AgentFsQueryEntry, AgentFsQueryEntryKind,
+    AgentFsTreeQuery, AgentFsTreeQueryResult,
 };
 #[cfg(target_os = "macos")]
 pub use hostfs_darwin::HostFS;

--- a/sdk/rust/src/filesystem/mod.rs
+++ b/sdk/rust/src/filesystem/mod.rs
@@ -13,7 +13,10 @@ use std::sync::Arc;
 use thiserror::Error;
 
 // Re-export implementations
-pub use agentfs::AgentFS;
+pub use agentfs::{
+    AgentFS, AgentFsGlobQuery, AgentFsGlobQueryResult, AgentFsQueryEntry,
+    AgentFsQueryEntryKind, AgentFsTreeQuery, AgentFsTreeQueryResult,
+};
 #[cfg(target_os = "macos")]
 pub use hostfs_darwin::HostFS;
 #[cfg(target_os = "linux")]

--- a/sdk/rust/src/lib.rs
+++ b/sdk/rust/src/lib.rs
@@ -46,9 +46,10 @@ pub use bulk_materialize::{BulkMaterializeEntry, BulkMaterializePlan};
 #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
 pub use filesystem::HostFS;
 pub use filesystem::{
-    BoxedFile, DirEntry, File, FileSystem, FilesystemStats, FsError, OverlayFS, Stats, TimeChange,
-    DEFAULT_DIR_MODE, DEFAULT_FILE_MODE, S_IFBLK, S_IFCHR, S_IFDIR, S_IFIFO, S_IFLNK, S_IFMT,
-    S_IFREG, S_IFSOCK,
+    AgentFsGlobQuery, AgentFsGlobQueryResult, AgentFsQueryEntry, AgentFsQueryEntryKind,
+    AgentFsTreeQuery, AgentFsTreeQueryResult, BoxedFile, DirEntry, File, FileSystem,
+    FilesystemStats, FsError, OverlayFS, Stats, TimeChange, DEFAULT_DIR_MODE, DEFAULT_FILE_MODE,
+    S_IFBLK, S_IFCHR, S_IFDIR, S_IFIFO, S_IFLNK, S_IFMT, S_IFREG, S_IFSOCK,
 };
 pub use kvstore::KvStore;
 pub use schema::{SchemaVersion, AGENTFS_SCHEMA_VERSION};
@@ -456,6 +457,16 @@ impl AgentFS {
     /// bootstraps such as AppFS structure synchronization.
     pub async fn bulk_materialize_tree(&self, plan: &BulkMaterializePlan) -> Result<()> {
         self.fs.bulk_materialize_tree(plan).await
+    }
+
+    /// Query a bounded directory tree directly from the AgentFS DB.
+    pub async fn query_tree(&self, request: AgentFsTreeQuery) -> Result<AgentFsTreeQueryResult> {
+        self.fs.query_tree(request).await
+    }
+
+    /// Query paths matching a glob directly from the AgentFS DB.
+    pub async fn query_glob(&self, request: AgentFsGlobQuery) -> Result<AgentFsGlobQueryResult> {
+        self.fs.query_glob(request).await
     }
 
     /// Check if sync is enabled for this database

--- a/sdk/rust/src/lib.rs
+++ b/sdk/rust/src/lib.rs
@@ -391,7 +391,7 @@ impl AgentFS {
             OverlayFS::init_schema(&conn, &base_path_str).await?;
         }
 
-        Self::open_with_pool(pool, sync_db).await
+        Self::open_with_pool_and_cache_key(pool, sync_db, Some(db_path)).await
     }
 
     /// Open an AgentFS instance from a connection pool
@@ -399,8 +399,16 @@ impl AgentFS {
         pool: connection_pool::ConnectionPool,
         sync_db: Option<turso::sync::Database>,
     ) -> Result<Self> {
+        Self::open_with_pool_and_cache_key(pool, sync_db, None).await
+    }
+
+    async fn open_with_pool_and_cache_key(
+        pool: connection_pool::ConnectionPool,
+        sync_db: Option<turso::sync::Database>,
+        cache_key: Option<String>,
+    ) -> Result<Self> {
         let kv = KvStore::from_pool(pool.clone()).await?;
-        let fs = filesystem::AgentFS::from_pool(pool.clone()).await?;
+        let fs = filesystem::AgentFS::from_pool_with_cache_key(pool.clone(), cache_key).await?;
         let tools = ToolCalls::from_pool(pool.clone()).await?;
 
         Ok(Self {

--- a/sdk/rust/src/lib.rs
+++ b/sdk/rust/src/lib.rs
@@ -2,6 +2,7 @@ pub mod appfs_adapter;
 pub mod appfs_adapter_testkit;
 pub mod appfs_connector;
 pub mod appfs_demo_adapter;
+pub mod bulk_materialize;
 pub mod connection_pool;
 pub mod error;
 pub mod filesystem;
@@ -41,6 +42,7 @@ pub use appfs_connector::{
     APPFS_CONNECTOR_SDK_VERSION,
 };
 pub use appfs_demo_adapter::{DemoAppAdapterV1, DemoAppConnector};
+pub use bulk_materialize::{BulkMaterializeEntry, BulkMaterializePlan};
 #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
 pub use filesystem::HostFS;
 pub use filesystem::{
@@ -438,6 +440,14 @@ impl AgentFS {
     /// Get the connection pool
     pub fn get_pool(&self) -> connection_pool::ConnectionPool {
         self.pool.clone()
+    }
+
+    /// Bulk materialize a tree of directories and files directly into the AgentFS DB.
+    ///
+    /// This bypasses mount-backend round-trips and is intended for large startup
+    /// bootstraps such as AppFS structure synchronization.
+    pub async fn bulk_materialize_tree(&self, plan: &BulkMaterializePlan) -> Result<()> {
+        self.fs.bulk_materialize_tree(plan).await
     }
 
     /// Check if sync is enabled for this database


### PR DESCRIPTION
## Summary

This is a staged PR for the AppFS large-tree performance and Windows mount compatibility work.

It includes:

- DB-backed bulk materialization for AppFS structures, so large connector trees can be written directly into the AgentFS runtime DB instead of creating thousands of placeholders through WinFsp.
- DB-direct managed scope refresh, including pruning old scoped structure entries and materializing the new scope consistently with startup.
- Managed runtime bootstrap/scaffolding fixes so `_stream`, `_meta`, registry, and runtime state files are available after mount.
- Huoyan bridge path sanitization and shallow structure revision fast path to avoid rebuilding the full case tree when the shallow app/evidence tree has not changed.
- DB-backed `appfs tree` and `appfs glob` queries for fast large-tree navigation without shell globbing over the mounted filesystem.
- WinFsp/AppFS listing fixes to avoid read-through from directory listing probes, including Git Bash `ls` snapshot probe suppression.

## Why

Large Huoyan cases can contain tens of thousands of directories and `.res.jsonl` placeholders. Creating those through a mounted WinFsp filesystem is too slow and can also amplify cache/read-through behavior from shell tools. This PR moves structure materialization to the DB path and narrows read-through to actual content reads.

## Validation

- `cargo fmt --all --manifest-path cli/Cargo.toml -- --check`
- `cargo fmt --all --manifest-path sdk/rust/Cargo.toml -- --check`
- `cargo test --quiet --manifest-path cli/Cargo.toml --package agentfs`
- Targeted tests for snapshot open/fstat behavior, WinFsp directory cache behavior, and snapshot probe classification
- Manual Windows validation: Git Bash `ls` no longer triggers snapshot read-through on cold `.res.jsonl` placeholders

## Notes

This PR is intentionally staged for pilot validation before final cleanup. The AppFS mounted ordinary read contract is preserved for normal file reads; only tiny Windows cold-placeholder prefix probes are suppressed by default.
