### PR TITLE
Backfill AppFS principal Tinode foundation

### DIFF
--- a/appfs-compose.aiim-tinode.local.yaml
+++ b/appfs-compose.aiim-tinode.local.yaml
@@ -1,0 +1,57 @@
+version: 1
+name: aiim-tinode-compose-smoke
+
+runtime:
+  db: C:/Users/esp3j/rep/appfs-platform/appfs/cli/.agentfs/compose-aiim-tinode.db
+  mountpoint: C:/mnt/appfs-compose-aiim-tinode
+  backend: winfsp
+  init: if_missing
+  reset: true
+  poll_ms: 0
+
+connectors:
+  aiim-http:
+    mode: command
+    transport: http
+    endpoint: http://127.0.0.1:8080
+    healthcheck:
+      kind: connector
+      interval_ms: 500
+      timeout_ms: 2000
+      max_attempts: 40
+    command:
+      cwd: C:/Users/esp3j/rep/appfs-platform/appfs/examples/appfs/bridges/http-python
+      program: python
+      args: ["-u", "bridge_server.py"]
+      env:
+        APPFS_HTTP_BRIDGE_BACKEND: aiim
+  tinode-in-process:
+    mode: in_process
+    transport: in_process
+
+apps:
+  aiim:
+    connector: aiim-http
+    visibility: public
+    transport:
+      http_timeout_ms: 5000
+      grpc_timeout_ms: 5000
+      bridge_max_retries: 2
+      bridge_initial_backoff_ms: 100
+      bridge_max_backoff_ms: 1000
+      bridge_circuit_breaker_failures: 5
+      bridge_circuit_breaker_cooldown_ms: 3000
+  tinode:
+    connector: tinode-in-process
+    visibility: private
+    path_template: private/{principal_id}/tinode
+    profile_template: tinode:{principal_id}
+    credential_policy: auto-create
+    transport:
+      http_timeout_ms: 5000
+      grpc_timeout_ms: 5000
+      bridge_max_retries: 2
+      bridge_initial_backoff_ms: 100
+      bridge_max_backoff_ms: 1000
+      bridge_circuit_breaker_failures: 5
+      bridge_circuit_breaker_cooldown_ms: 3000

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -139,6 +139,7 @@ version = "0.7.0-beta.1"
 dependencies = [
  "aegis",
  "async-trait",
+ "base64",
  "libc",
  "lru",
  "serde",
@@ -146,6 +147,7 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "tracing",
+ "tungstenite",
  "turso",
 ]
 
@@ -401,6 +403,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
@@ -741,6 +752,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -769,6 +786,16 @@ dependencies = [
  "quote",
  "syn",
  "unicode-xid",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
 ]
 
 [[package]]
@@ -2957,6 +2984,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sha1_smol"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3495,6 +3533,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "tungstenite"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18e5b8366ee7a95b16d32197d0b2604b43a0be89dc5fac9f8e96ccafbaedda8a"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.8.5",
+ "sha1",
+ "thiserror 1.0.69",
+ "utf-8",
+]
+
+[[package]]
 name = "turso"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3821,6 +3877,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "utf8_iter"

--- a/cli/src/cmd/appfs.rs
+++ b/cli/src/cmd/appfs.rs
@@ -1211,7 +1211,10 @@ pub async fn handle_appfs_compose_up_command(compose_path: Option<PathBuf>) -> R
         &resolved_apps,
     )
     .await?;
-    for resolved_app in resolved_apps.values() {
+    for resolved_app in resolved_apps
+        .values()
+        .filter(|app| app.visibility == compose::schema::AppfsComposeAppVisibility::Public)
+    {
         let session_id = normalize_appfs_session_id(resolved_app.session_id.clone());
         let bridge_config =
             build_appfs_bridge_config(bridge_args_from_resolved_compose_app(resolved_app));
@@ -1219,12 +1222,15 @@ pub async fn handle_appfs_compose_up_command(compose_path: Option<PathBuf>) -> R
             &agent,
             &resolved_app.app_id,
             &session_id,
+            None,
+            None,
             &bridge_config,
         )
         .await?;
     }
-    let startup_app_ids = resolved_apps
-        .values()
+    let startup_app_ids = registry_doc
+        .apps
+        .iter()
         .map(|app| app.app_id.clone())
         .collect::<Vec<_>>();
     let startup_plan = build_managed_runtime_bootstrap_plan(&agent, &startup_app_ids).await?;
@@ -1266,11 +1272,13 @@ fn bridge_args_from_resolved_compose_app(
     AppfsBridgeCliArgs {
         adapter_http_endpoint: match app.transport_kind {
             compose::schema::AppfsComposeTransportKind::Http => Some(app.endpoint.clone()),
-            compose::schema::AppfsComposeTransportKind::Grpc => None,
+            compose::schema::AppfsComposeTransportKind::Grpc
+            | compose::schema::AppfsComposeTransportKind::InProcess => None,
         },
         adapter_http_timeout_ms: app.transport.http_timeout_ms,
         adapter_grpc_endpoint: match app.transport_kind {
-            compose::schema::AppfsComposeTransportKind::Http => None,
+            compose::schema::AppfsComposeTransportKind::Http
+            | compose::schema::AppfsComposeTransportKind::InProcess => None,
             compose::schema::AppfsComposeTransportKind::Grpc => Some(app.endpoint.clone()),
         },
         adapter_grpc_timeout_ms: app.transport.grpc_timeout_ms,
@@ -1514,6 +1522,8 @@ struct ActionCursorDoc {
 struct AppfsAdapter {
     app_id: String,
     session_id: String,
+    principal_id: Option<String>,
+    profile_id: Option<String>,
     app_dir: PathBuf,
     direct_db_path: Option<String>,
     action_specs: Vec<ActionSpec>,
@@ -1561,6 +1571,42 @@ mod supervisor_tests {
             adapter_bridge_circuit_breaker_failures: 5,
             adapter_bridge_circuit_breaker_cooldown_ms: 3_000,
         }
+    }
+
+    fn configure_tinode_env_for_tests() {
+        std::env::set_var("APPFS_TINODE_ENDPOINT", "http://127.0.0.1:6060");
+        std::env::set_var("APPFS_TINODE_LOGIN_PREFIX", "appfs_test");
+        std::env::set_var("APPFS_TINODE_CREDENTIAL_POLICY", "auto-create");
+    }
+
+    fn write_tinode_private_policy(root: &std::path::Path) {
+        registry::write_app_policy_registry(
+            root,
+            &registry::AppfsAppPolicyRegistryDoc {
+                version: registry::APPFS_REGISTRY_VERSION,
+                apps: vec![registry::AppfsAppPolicyRecord {
+                    app_id: "tinode".to_string(),
+                    visibility: registry::AppfsAppPolicyVisibility::Private,
+                    connector: "tinode-in-process".to_string(),
+                    transport: registry::AppfsRegistryTransportDoc {
+                        kind: registry::AppfsRegistryTransportKind::InProcess,
+                        endpoint: None,
+                        http_timeout_ms: 5000,
+                        grpc_timeout_ms: 5000,
+                        bridge_max_retries: 2,
+                        bridge_initial_backoff_ms: 100,
+                        bridge_max_backoff_ms: 1000,
+                        bridge_circuit_breaker_failures: 5,
+                        bridge_circuit_breaker_cooldown_ms: 3000,
+                    },
+                    path: None,
+                    path_template: Some("private/{principal_id}/tinode".to_string()),
+                    profile_template: Some("tinode:{principal_id}".to_string()),
+                    credential_policy: Some("auto-create".to_string()),
+                }],
+            },
+        )
+        .expect("write tinode private policy");
     }
 
     #[test]
@@ -2048,7 +2094,13 @@ mod supervisor_tests {
         let existing = registry::AppfsAppsRegistryDoc {
             version: registry::APPFS_REGISTRY_VERSION,
             apps: vec![registry::AppfsRegisteredAppDoc {
+                instance_id: "aiim".to_string(),
                 app_id: "aiim".to_string(),
+                visibility: registry::AppfsRegisteredAppVisibility::Public,
+                parent_app_id: None,
+                principal_id: None,
+                profile_id: None,
+                path: "aiim".to_string(),
                 transport: registry::AppfsRegistryTransportDoc {
                     kind: registry::AppfsRegistryTransportKind::InProcess,
                     endpoint: None,
@@ -2121,6 +2173,252 @@ mod supervisor_tests {
             events[0].get("type").and_then(|value| value.as_str()),
             Some("action.completed")
         );
+    }
+
+    #[test]
+    fn runtime_supervisor_can_create_update_and_delete_principal() {
+        let temp = TempDir::new().expect("tempdir");
+        let mut supervisor =
+            AppfsRuntimeSupervisor::new(temp.path().to_path_buf(), Vec::new(), false, None)
+                .expect("supervisor");
+        supervisor.prepare_action_sinks().expect("prepare sinks");
+
+        let create_action = temp.path().join("_appfs/principals/create_principal.act");
+        assert!(create_action.exists());
+        append_text(
+            &create_action,
+            "{\"principal_id\":\"default\",\"display_name\":\"Default agent\",\"description\":\"The default project agent.\",\"kind\":\"agent\",\"client_token\":\"principal-create-001\"}\n",
+        );
+        supervisor.poll_once().expect("poll create principal");
+
+        let registry = registry::read_principal_registry(temp.path())
+            .expect("read principal registry")
+            .expect("principal registry exists");
+        assert_eq!(registry.default_principal_id, "default");
+        assert_eq!(registry.principals.len(), 1);
+        assert_eq!(registry.principals[0].principal_id, "default");
+        assert_eq!(registry.principals[0].display_name, "Default agent");
+        let view_path = temp.path().join("_appfs/principals/default.res.json");
+        assert!(view_path.exists());
+        let view: registry::PrincipalRecord =
+            serde_json::from_slice(&fs::read(&view_path).expect("read principal view"))
+                .expect("parse principal view");
+        assert_eq!(view, registry.principals[0]);
+
+        let events = control_events(&temp, "principal-create-001");
+        assert_eq!(events.len(), 1);
+        assert_eq!(
+            events[0]
+                .get("content")
+                .and_then(|value| value.get("principal_event"))
+                .and_then(|value| value.as_str()),
+            Some("principal.created")
+        );
+
+        append_text(
+            &create_action,
+            "{\"principal_id\":\"default\",\"display_name\":\"Default agent\",\"client_token\":\"principal-create-002\"}\n",
+        );
+        supervisor
+            .poll_once()
+            .expect("poll duplicate create principal");
+        let registry = registry::read_principal_registry(temp.path())
+            .expect("read principal registry")
+            .expect("principal registry exists");
+        assert_eq!(registry.principals.len(), 1);
+        let events = control_events(&temp, "principal-create-002");
+        assert_eq!(
+            events[0]
+                .get("content")
+                .and_then(|value| value.get("principal_event"))
+                .and_then(|value| value.as_str()),
+            Some("principal.exists")
+        );
+
+        append_text(
+            &temp
+                .path()
+                .join("_appfs/principals/update_principal.act"),
+            "{\"principal_id\":\"default\",\"display_name\":\"Default project agent\",\"client_token\":\"principal-update-001\"}\n",
+        );
+        supervisor.poll_once().expect("poll update principal");
+        let registry = registry::read_principal_registry(temp.path())
+            .expect("read principal registry")
+            .expect("principal registry exists");
+        assert_eq!(registry.principals[0].display_name, "Default project agent");
+
+        append_text(
+            &temp.path().join("_appfs/principals/delete_principal.act"),
+            "{\"principal_id\":\"default\",\"client_token\":\"principal-delete-001\"}\n",
+        );
+        supervisor.poll_once().expect("poll delete principal");
+        let registry = registry::read_principal_registry(temp.path())
+            .expect("read principal registry")
+            .expect("principal registry exists");
+        assert!(registry.principals.is_empty());
+        assert!(!view_path.exists());
+        let events = control_events(&temp, "principal-delete-001");
+        assert_eq!(
+            events[0]
+                .get("content")
+                .and_then(|value| value.get("principal_event"))
+                .and_then(|value| value.as_str()),
+            Some("principal.deleted")
+        );
+    }
+
+    #[test]
+    fn runtime_supervisor_materializes_private_tinode_skeleton_for_created_principal() {
+        let temp = TempDir::new().expect("tempdir");
+        configure_tinode_env_for_tests();
+        write_tinode_private_policy(temp.path());
+
+        let mut supervisor =
+            AppfsRuntimeSupervisor::new(temp.path().to_path_buf(), Vec::new(), false, None)
+                .expect("supervisor");
+        supervisor.prepare_action_sinks().expect("prepare sinks");
+        append_text(
+            &temp
+                .path()
+                .join("_appfs/principals/create_principal.act"),
+            "{\"principal_id\":\"default\",\"display_name\":\"Default agent\",\"kind\":\"agent\",\"client_token\":\"principal-private-001\"}\n",
+        );
+
+        supervisor.poll_once().expect("poll create principal");
+
+        assert!(supervisor.runtimes.contains_key("tinode--default"));
+        let tinode_root = temp.path().join("private/default/tinode");
+        assert!(tinode_root.exists());
+        assert!(tinode_root.join("_meta/manifest.res.json").exists());
+        assert!(tinode_root.join("_stream/events.evt.jsonl").exists());
+        for expected in [
+            "_app/actions.res.json",
+            "_app/control.res.json",
+            "_app/self.res.json",
+            "_app/skill.res.json",
+            "_app/ensure_credentials.act",
+            "_app/refresh_structure.act",
+            "_app/refresh_inbox.act",
+            "contacts/index.res.jsonl",
+            "contacts/send_message.act",
+            "contacts/resolve.act",
+            "contacts/search_results.res.jsonl",
+            "groups/index.res.jsonl",
+            "groups/create_group.act",
+            "inbox/recent.res.jsonl",
+            "inbox/unread.res.jsonl",
+            "inbox/mark_read.act",
+            "topics/index.res.jsonl",
+        ] {
+            assert!(tinode_root.join(expected).exists(), "missing {expected}");
+        }
+        let self_doc: JsonValue =
+            serde_json::from_slice(&fs::read(tinode_root.join("_app/self.res.json")).unwrap())
+                .expect("parse tinode self");
+        assert_eq!(self_doc["credential_status"], "missing");
+        assert_eq!(self_doc["principal_id"], "default");
+        assert_eq!(self_doc["profile_id"], "tinode:default");
+        let self_rendered = self_doc.to_string();
+        for forbidden in ["token", "refresh_token", "password", "secret", "cookie"] {
+            assert!(!self_rendered.contains(forbidden));
+        }
+
+        let stored = registry::read_app_registry(temp.path())
+            .expect("read app registry")
+            .expect("app registry exists");
+        assert_eq!(stored.apps.len(), 1);
+        assert_eq!(stored.apps[0].instance_id, "tinode--default");
+        assert_eq!(stored.apps[0].app_id, "tinode");
+        assert_eq!(
+            stored.apps[0].visibility,
+            registry::AppfsRegisteredAppVisibility::PrivateInstance
+        );
+        assert_eq!(stored.apps[0].principal_id.as_deref(), Some("default"));
+        assert_eq!(stored.apps[0].profile_id.as_deref(), Some("tinode:default"));
+        assert_eq!(stored.apps[0].path, "private/default/tinode");
+
+        let events = control_events(&temp, "principal-private-001");
+        assert_eq!(events.len(), 1);
+        assert_eq!(
+            events[0]
+                .get("content")
+                .and_then(|value| value.get("principal_event"))
+                .and_then(|value| value.as_str()),
+            Some("principal.exists")
+        );
+        assert_eq!(
+            events[0]
+                .get("content")
+                .and_then(|value| value.get("app_instances"))
+                .and_then(|value| value.as_array())
+                .map(|instances| instances.len()),
+            Some(0)
+        );
+
+        append_text(
+            &temp.path().join("_appfs/principals/delete_principal.act"),
+            "{\"principal_id\":\"default\",\"client_token\":\"principal-private-delete-001\"}\n",
+        );
+        supervisor.poll_once().expect("poll delete principal");
+        let events = control_events(&temp, "principal-private-delete-001");
+        assert_eq!(events.len(), 1);
+        let content = events[0].get("content").expect("delete content");
+        assert_eq!(
+            content
+                .get("credentials_cleanup")
+                .and_then(|value| value.as_str()),
+            Some("requested")
+        );
+        let cleanup = content
+            .get("credential_cleanup_requests")
+            .and_then(|value| value.as_array())
+            .expect("cleanup requests");
+        assert_eq!(cleanup.len(), 1);
+        assert_eq!(
+            cleanup[0]
+                .get("instance_id")
+                .and_then(|value| value.as_str()),
+            Some("tinode--default")
+        );
+        assert_eq!(
+            cleanup[0]
+                .get("profile_id")
+                .and_then(|value| value.as_str()),
+            Some("tinode:default")
+        );
+    }
+
+    #[test]
+    fn runtime_supervisor_backfills_private_apps_for_existing_principals() {
+        let temp = TempDir::new().expect("tempdir");
+        configure_tinode_env_for_tests();
+
+        let mut supervisor =
+            AppfsRuntimeSupervisor::new(temp.path().to_path_buf(), Vec::new(), false, None)
+                .expect("supervisor");
+        supervisor.prepare_action_sinks().expect("prepare sinks");
+        append_text(
+            &temp
+                .path()
+                .join("_appfs/principals/create_principal.act"),
+            "{\"principal_id\":\"default\",\"display_name\":\"Default agent\",\"kind\":\"agent\",\"client_token\":\"principal-before-policy-001\"}\n",
+        );
+        supervisor.poll_once().expect("poll create principal");
+        assert!(!supervisor.runtimes.contains_key("tinode--default"));
+
+        write_tinode_private_policy(temp.path());
+        supervisor.poll_once().expect("poll backfill private app");
+
+        assert!(supervisor.runtimes.contains_key("tinode--default"));
+        let tinode_root = temp.path().join("private/default/tinode");
+        assert!(tinode_root.join("_app/skill.res.json").exists());
+        let stored = registry::read_app_registry(temp.path())
+            .expect("read app registry")
+            .expect("app registry exists");
+        assert!(stored.apps.iter().any(|app| {
+            app.instance_id == "tinode--default"
+                && app.profile_id.as_deref() == Some("tinode:default")
+        }));
     }
 
     #[test]

--- a/cli/src/cmd/appfs/action_dispatcher.rs
+++ b/cli/src/cmd/appfs/action_dispatcher.rs
@@ -38,6 +38,11 @@ pub(super) struct StructureRefreshRequest {
 }
 
 #[derive(Debug, Clone)]
+pub(super) struct EnsureCredentialsRequest {
+    pub(super) expected_profile_id: Option<String>,
+}
+
+#[derive(Debug, Clone)]
 pub(super) struct RegisterAppRequest {
     pub(super) app_id: String,
     pub(super) session_id: Option<String>,
@@ -50,12 +55,34 @@ pub(super) struct UnregisterAppRequest {
 }
 
 #[derive(Debug, Clone)]
+pub(super) struct CreatePrincipalRequest {
+    pub(super) principal_id: String,
+    pub(super) display_name: String,
+    pub(super) description: Option<String>,
+    pub(super) kind: String,
+}
+
+#[derive(Debug, Clone)]
+pub(super) struct UpdatePrincipalRequest {
+    pub(super) principal_id: String,
+    pub(super) display_name: Option<String>,
+    pub(super) description: Option<String>,
+    pub(super) kind: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub(super) struct DeletePrincipalRequest {
+    pub(super) principal_id: String,
+}
+
+#[derive(Debug, Clone)]
 pub(super) enum DispatchRoute {
     PagingFetchNext(PagingRequest),
     PagingClose(PagingRequest),
     SnapshotRefresh(SnapshotRefreshRequest),
     EnterScope(EnterScopeRequest),
     StructureRefresh(StructureRefreshRequest),
+    EnsureCredentials(EnsureCredentialsRequest),
     BusinessSubmit,
 }
 
@@ -66,6 +93,7 @@ pub(super) enum DispatchRouteParseError {
     SnapshotRefresh,
     EnterScope,
     StructureRefresh,
+    EnsureCredentials,
 }
 
 pub(super) fn normalize_actionline_payload(
@@ -106,6 +134,11 @@ pub(super) fn route_action(
         return parse_structure_refresh_request(payload)
             .map(DispatchRoute::StructureRefresh)
             .map_err(|_| DispatchRouteParseError::StructureRefresh);
+    }
+    if normalized_path == "/_app/ensure_credentials.act" {
+        return parse_ensure_credentials_request(payload)
+            .map(DispatchRoute::EnsureCredentials)
+            .map_err(|_| DispatchRouteParseError::EnsureCredentials);
     }
 
     Ok(DispatchRoute::BusinessSubmit)
@@ -259,6 +292,15 @@ pub(super) fn parse_structure_refresh_request(
     Ok(StructureRefreshRequest { target_scope })
 }
 
+pub(super) fn parse_ensure_credentials_request(
+    payload: &str,
+) -> std::result::Result<EnsureCredentialsRequest, &'static str> {
+    let object = parse_json_object(payload)?;
+    Ok(EnsureCredentialsRequest {
+        expected_profile_id: optional_string(&object, "expected_profile_id")?,
+    })
+}
+
 pub(super) fn parse_register_app_request(
     payload: &str,
 ) -> std::result::Result<RegisterAppRequest, &'static str> {
@@ -313,4 +355,102 @@ pub(super) fn parse_list_apps_request(payload: &str) -> std::result::Result<(), 
     } else {
         Err(ERR_INVALID_ARGUMENT)
     }
+}
+
+pub(super) fn parse_create_principal_request(
+    payload: &str,
+) -> std::result::Result<CreatePrincipalRequest, &'static str> {
+    let object = parse_json_object(payload)?;
+    let principal_id = required_principal_id(&object, "principal_id")?;
+    let display_name = required_string(&object, "display_name")?;
+    let description = optional_string(&object, "description")?;
+    let kind = optional_string(&object, "kind")?.unwrap_or_else(|| "agent".to_string());
+    Ok(CreatePrincipalRequest {
+        principal_id,
+        display_name,
+        description,
+        kind,
+    })
+}
+
+pub(super) fn parse_update_principal_request(
+    payload: &str,
+) -> std::result::Result<UpdatePrincipalRequest, &'static str> {
+    let object = parse_json_object(payload)?;
+    let principal_id = required_principal_id(&object, "principal_id")?;
+    Ok(UpdatePrincipalRequest {
+        principal_id,
+        display_name: optional_string(&object, "display_name")?,
+        description: optional_string(&object, "description")?,
+        kind: optional_string(&object, "kind")?,
+    })
+}
+
+pub(super) fn parse_delete_principal_request(
+    payload: &str,
+) -> std::result::Result<DeletePrincipalRequest, &'static str> {
+    let object = parse_json_object(payload)?;
+    let principal_id = required_principal_id(&object, "principal_id")?;
+    Ok(DeletePrincipalRequest { principal_id })
+}
+
+fn parse_json_object(
+    payload: &str,
+) -> std::result::Result<serde_json::Map<String, JsonValue>, &'static str> {
+    let json = serde_json::from_str::<JsonValue>(payload).map_err(|_| ERR_INVALID_ARGUMENT)?;
+    json.as_object().cloned().ok_or(ERR_INVALID_ARGUMENT)
+}
+
+fn required_string(
+    object: &serde_json::Map<String, JsonValue>,
+    field_name: &str,
+) -> std::result::Result<String, &'static str> {
+    object
+        .get(field_name)
+        .and_then(|value| value.as_str())
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+        .ok_or(ERR_INVALID_ARGUMENT)
+}
+
+fn optional_string(
+    object: &serde_json::Map<String, JsonValue>,
+    field_name: &str,
+) -> std::result::Result<Option<String>, &'static str> {
+    object
+        .get(field_name)
+        .map(|value| {
+            value
+                .as_str()
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .map(ToOwned::to_owned)
+                .ok_or(ERR_INVALID_ARGUMENT)
+        })
+        .transpose()
+}
+
+fn required_principal_id(
+    object: &serde_json::Map<String, JsonValue>,
+    field_name: &str,
+) -> std::result::Result<String, &'static str> {
+    let principal_id = required_string(object, field_name)?;
+    if is_safe_principal_id(&principal_id) {
+        Ok(principal_id)
+    } else {
+        Err(ERR_INVALID_ARGUMENT)
+    }
+}
+
+fn is_safe_principal_id(value: &str) -> bool {
+    if value == "." || value == ".." || value.len() > 120 {
+        return false;
+    }
+    if value.contains(['/', '\\', '\0', ':']) {
+        return false;
+    }
+    value
+        .chars()
+        .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '_' | '-'))
 }

--- a/cli/src/cmd/appfs/compose/connector_supervisor.rs
+++ b/cli/src/cmd/appfs/compose/connector_supervisor.rs
@@ -1,6 +1,7 @@
 use super::schema::{
-    AppfsComposeAppTransport, AppfsComposeConnector, AppfsComposeConnectorHealthcheck,
-    AppfsComposeConnectorMode, AppfsComposeDoc, AppfsComposeTransportKind,
+    AppfsComposeAppTransport, AppfsComposeAppVisibility, AppfsComposeConnector,
+    AppfsComposeConnectorHealthcheck, AppfsComposeConnectorMode, AppfsComposeDoc,
+    AppfsComposeTransportKind,
 };
 use crate::cmd::appfs::core::build_app_connector;
 use crate::cmd::appfs::{build_appfs_bridge_config, AppfsBridgeCliArgs};
@@ -35,6 +36,11 @@ pub(crate) struct ResolvedComposeApp {
     pub(crate) endpoint: String,
     pub(crate) session_id: Option<String>,
     pub(crate) transport: AppfsComposeAppTransport,
+    pub(crate) visibility: AppfsComposeAppVisibility,
+    pub(crate) path: Option<String>,
+    pub(crate) path_template: Option<String>,
+    pub(crate) profile_template: Option<String>,
+    pub(crate) credential_policy: Option<String>,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -128,6 +134,7 @@ impl ComposeConnectorSupervisor {
                     });
                 }
             }
+            AppfsComposeConnectorMode::InProcess => {}
         }
 
         Ok(ResolvedComposeApp {
@@ -137,6 +144,11 @@ impl ComposeConnectorSupervisor {
             endpoint: connector.endpoint.clone(),
             session_id: app.session_id.clone(),
             transport: app.transport.clone(),
+            visibility: app.visibility,
+            path: app.path.clone(),
+            path_template: app.path_template.clone(),
+            profile_template: app.profile_template.clone(),
+            credential_policy: app.credential_policy.clone(),
         })
     }
 }
@@ -214,6 +226,8 @@ fn probe_connector_once(
         request_id: format!("compose-health-{}", Uuid::new_v4().simple()),
         client_token: None,
         trace_id: None,
+        principal_id: None,
+        profile_id: None,
     };
     let health = connector_client
         .health(&ctx)
@@ -241,11 +255,11 @@ fn build_health_bridge_config(
     build_appfs_bridge_config(AppfsBridgeCliArgs {
         adapter_http_endpoint: match connector.transport {
             AppfsComposeTransportKind::Http => Some(connector.endpoint.clone()),
-            AppfsComposeTransportKind::Grpc => None,
+            AppfsComposeTransportKind::Grpc | AppfsComposeTransportKind::InProcess => None,
         },
         adapter_http_timeout_ms: timeout_ms.max(1),
         adapter_grpc_endpoint: match connector.transport {
-            AppfsComposeTransportKind::Http => None,
+            AppfsComposeTransportKind::Http | AppfsComposeTransportKind::InProcess => None,
             AppfsComposeTransportKind::Grpc => Some(connector.endpoint.clone()),
         },
         adapter_grpc_timeout_ms: timeout_ms.max(1),
@@ -371,6 +385,11 @@ apps:
                 endpoint: server.endpoint(),
                 session_id: None,
                 transport: Default::default(),
+                visibility: crate::cmd::appfs::compose::schema::AppfsComposeAppVisibility::Public,
+                path: None,
+                path_template: None,
+                profile_template: None,
+                credential_policy: None,
             }
         );
     }

--- a/cli/src/cmd/appfs/compose/reconcile.rs
+++ b/cli/src/cmd/appfs/compose/reconcile.rs
@@ -14,7 +14,7 @@ pub(crate) fn build_registry_doc_from_resolved_apps(
         .map(|doc| {
             doc.apps
                 .iter()
-                .map(|app| (app.app_id.clone(), app.registered_at.clone()))
+                .map(|app| (app.instance_id.clone(), app.registered_at.clone()))
                 .collect::<HashMap<_, _>>()
         })
         .unwrap_or_default();
@@ -24,10 +24,18 @@ pub(crate) fn build_registry_doc_from_resolved_apps(
         version: registry::APPFS_REGISTRY_VERSION,
         apps: resolved_apps
             .values()
+            .filter(|app| app.visibility == super::schema::AppfsComposeAppVisibility::Public)
             .map(|app| {
                 let session_id = normalize_appfs_session_id(app.session_id.clone());
+                let path = app.path.clone().unwrap_or_else(|| app.app_id.clone());
                 registry::AppfsRegisteredAppDoc {
+                    instance_id: app.app_id.clone(),
                     app_id: app.app_id.clone(),
+                    visibility: registry::AppfsRegisteredAppVisibility::Public,
+                    parent_app_id: None,
+                    principal_id: None,
+                    profile_id: None,
+                    path,
                     transport: registry_transport_from_resolved_app(app),
                     session_id,
                     registered_at: existing_registered_at
@@ -35,6 +43,42 @@ pub(crate) fn build_registry_doc_from_resolved_apps(
                         .cloned()
                         .unwrap_or_else(|| now.clone()),
                     active_scope: None,
+                }
+            })
+            .collect(),
+    }
+}
+
+pub(crate) fn build_app_policy_registry_doc_from_resolved_apps(
+    resolved_apps: &BTreeMap<String, ResolvedComposeApp>,
+) -> registry::AppfsAppPolicyRegistryDoc {
+    registry::AppfsAppPolicyRegistryDoc {
+        version: registry::APPFS_REGISTRY_VERSION,
+        apps: resolved_apps
+            .values()
+            .map(|app| {
+                let visibility = match app.visibility {
+                    super::schema::AppfsComposeAppVisibility::Public => {
+                        registry::AppfsAppPolicyVisibility::Public
+                    }
+                    super::schema::AppfsComposeAppVisibility::Private => {
+                        registry::AppfsAppPolicyVisibility::Private
+                    }
+                };
+                registry::AppfsAppPolicyRecord {
+                    app_id: app.app_id.clone(),
+                    visibility,
+                    connector: app.connector_name.clone(),
+                    transport: registry_transport_from_resolved_app(app),
+                    path: match app.visibility {
+                        super::schema::AppfsComposeAppVisibility::Public => {
+                            Some(app.path.clone().unwrap_or_else(|| app.app_id.clone()))
+                        }
+                        super::schema::AppfsComposeAppVisibility::Private => None,
+                    },
+                    path_template: app.path_template.clone(),
+                    profile_template: app.profile_template.clone(),
+                    credential_policy: app.credential_policy.clone(),
                 }
             })
             .collect(),
@@ -50,6 +94,8 @@ pub(crate) fn bootstrap_registry_from_resolved_apps(
     if existing.as_ref() != Some(&doc) {
         registry::write_app_registry(root, &doc)?;
     }
+    let policy_doc = build_app_policy_registry_doc_from_resolved_apps(resolved_apps);
+    registry::write_app_policy_registry(root, &policy_doc)?;
     Ok(doc)
 }
 
@@ -71,6 +117,14 @@ pub(crate) async fn bootstrap_registry_from_resolved_apps_in_agentfs(
         ));
         agent.bulk_materialize_tree(&plan).await?;
     }
+    let policy_doc = build_app_policy_registry_doc_from_resolved_apps(resolved_apps);
+    let mut plan = BulkMaterializePlan::new();
+    plan.push(BulkMaterializeEntry::ensure_dir("/_appfs"));
+    plan.push(BulkMaterializeEntry::write_file(
+        "/_appfs/app-policies.registry.json",
+        serde_json::to_vec_pretty(&policy_doc)?,
+    ));
+    agent.bulk_materialize_tree(&plan).await?;
     Ok(doc)
 }
 
@@ -84,10 +138,17 @@ fn registry_transport_from_resolved_app(
         super::schema::AppfsComposeTransportKind::Grpc => {
             registry::AppfsRegistryTransportKind::Grpc
         }
+        super::schema::AppfsComposeTransportKind::InProcess => {
+            registry::AppfsRegistryTransportKind::InProcess
+        }
     };
     registry::AppfsRegistryTransportDoc {
         kind,
-        endpoint: Some(app.endpoint.clone()),
+        endpoint: match app.transport_kind {
+            super::schema::AppfsComposeTransportKind::Http
+            | super::schema::AppfsComposeTransportKind::Grpc => Some(app.endpoint.clone()),
+            super::schema::AppfsComposeTransportKind::InProcess => None,
+        },
         http_timeout_ms: app.transport.http_timeout_ms,
         grpc_timeout_ms: app.transport.grpc_timeout_ms,
         bridge_max_retries: app.transport.bridge_max_retries,
@@ -100,9 +161,14 @@ fn registry_transport_from_resolved_app(
 
 #[cfg(test)]
 mod tests {
-    use super::{bootstrap_registry_from_resolved_apps, build_registry_doc_from_resolved_apps};
+    use super::{
+        bootstrap_registry_from_resolved_apps, build_app_policy_registry_doc_from_resolved_apps,
+        build_registry_doc_from_resolved_apps,
+    };
     use crate::cmd::appfs::compose::connector_supervisor::ResolvedComposeApp;
-    use crate::cmd::appfs::compose::schema::{AppfsComposeAppTransport, AppfsComposeTransportKind};
+    use crate::cmd::appfs::compose::schema::{
+        AppfsComposeAppTransport, AppfsComposeAppVisibility, AppfsComposeTransportKind,
+    };
     use crate::cmd::appfs::{registry, resolve_runtime_cli_args};
     use std::collections::BTreeMap;
     use tempfile::TempDir;
@@ -113,6 +179,11 @@ mod tests {
         transport_kind: AppfsComposeTransportKind,
         endpoint: &str,
         session_id: Option<&str>,
+        visibility: AppfsComposeAppVisibility,
+        path: Option<&str>,
+        path_template: Option<&str>,
+        profile_template: Option<&str>,
+        credential_policy: Option<&str>,
     ) -> ResolvedComposeApp {
         ResolvedComposeApp {
             app_id: app_id.to_string(),
@@ -121,6 +192,11 @@ mod tests {
             endpoint: endpoint.to_string(),
             session_id: session_id.map(str::to_string),
             transport: AppfsComposeAppTransport::default(),
+            visibility,
+            path: path.map(str::to_string),
+            path_template: path_template.map(str::to_string),
+            profile_template: profile_template.map(str::to_string),
+            credential_policy: credential_policy.map(str::to_string),
         }
     }
 
@@ -135,6 +211,11 @@ mod tests {
                 AppfsComposeTransportKind::Http,
                 "http://127.0.0.1:8080",
                 Some("sess-aiim"),
+                AppfsComposeAppVisibility::Public,
+                Some("public/aiim"),
+                None,
+                None,
+                None,
             ),
         );
 
@@ -142,7 +223,13 @@ mod tests {
             version: registry::APPFS_REGISTRY_VERSION,
             apps: vec![
                 registry::AppfsRegisteredAppDoc {
+                    instance_id: "aiim".to_string(),
                     app_id: "aiim".to_string(),
+                    visibility: registry::AppfsRegisteredAppVisibility::Public,
+                    parent_app_id: None,
+                    principal_id: None,
+                    profile_id: None,
+                    path: "public/aiim".to_string(),
                     transport: registry::AppfsRegistryTransportDoc {
                         kind: registry::AppfsRegistryTransportKind::Http,
                         endpoint: Some("http://127.0.0.1:8080".to_string()),
@@ -159,7 +246,13 @@ mod tests {
                     active_scope: Some("chat-001".to_string()),
                 },
                 registry::AppfsRegisteredAppDoc {
+                    instance_id: "stale".to_string(),
                     app_id: "stale".to_string(),
+                    visibility: registry::AppfsRegisteredAppVisibility::Public,
+                    parent_app_id: None,
+                    principal_id: None,
+                    profile_id: None,
+                    path: "public/stale".to_string(),
                     transport: registry::AppfsRegistryTransportDoc {
                         kind: registry::AppfsRegistryTransportKind::Grpc,
                         endpoint: Some("http://127.0.0.1:50051".to_string()),
@@ -181,7 +274,9 @@ mod tests {
         let doc = build_registry_doc_from_resolved_apps(&resolved_apps, Some(&existing));
 
         assert_eq!(doc.apps.len(), 1);
+        assert_eq!(doc.apps[0].instance_id, "aiim");
         assert_eq!(doc.apps[0].app_id, "aiim");
+        assert_eq!(doc.apps[0].path, "public/aiim");
         assert_eq!(doc.apps[0].session_id, "sess-aiim");
         assert_eq!(doc.apps[0].registered_at, "2026-04-01T00:00:00Z");
         assert_eq!(doc.apps[0].active_scope, None);
@@ -199,6 +294,11 @@ mod tests {
                 AppfsComposeTransportKind::Http,
                 "http://127.0.0.1:8080",
                 None,
+                AppfsComposeAppVisibility::Public,
+                Some("public/aiim"),
+                None,
+                None,
+                None,
             ),
         );
         resolved_apps.insert(
@@ -209,6 +309,11 @@ mod tests {
                 AppfsComposeTransportKind::Grpc,
                 "http://127.0.0.1:50051",
                 Some("sess-huoyan"),
+                AppfsComposeAppVisibility::Public,
+                Some("public/huoyan"),
+                None,
+                None,
+                None,
             ),
         );
 
@@ -244,5 +349,70 @@ mod tests {
                 .as_deref(),
             Some("http://127.0.0.1:50051")
         );
+    }
+
+    #[test]
+    fn app_policy_registry_keeps_private_apps_as_policies() {
+        let mut resolved_apps = BTreeMap::new();
+        resolved_apps.insert(
+            "aiim".to_string(),
+            resolved_app(
+                "aiim",
+                "aiim-http",
+                AppfsComposeTransportKind::Http,
+                "http://127.0.0.1:8080",
+                None,
+                AppfsComposeAppVisibility::Public,
+                Some("public/aiim"),
+                None,
+                None,
+                None,
+            ),
+        );
+        resolved_apps.insert(
+            "tinode".to_string(),
+            resolved_app(
+                "tinode",
+                "tinode-in-process",
+                AppfsComposeTransportKind::InProcess,
+                "",
+                None,
+                AppfsComposeAppVisibility::Private,
+                None,
+                Some("private/{principal_id}/tinode"),
+                Some("tinode:{principal_id}"),
+                Some("auto-create"),
+            ),
+        );
+
+        let app_registry = build_registry_doc_from_resolved_apps(&resolved_apps, None);
+        assert_eq!(app_registry.apps.len(), 1);
+        assert_eq!(app_registry.apps[0].app_id, "aiim");
+
+        let policy_registry = build_app_policy_registry_doc_from_resolved_apps(&resolved_apps);
+        assert_eq!(policy_registry.apps.len(), 2);
+        let tinode = policy_registry
+            .apps
+            .iter()
+            .find(|app| app.app_id == "tinode")
+            .expect("tinode policy");
+        assert_eq!(
+            tinode.visibility,
+            registry::AppfsAppPolicyVisibility::Private
+        );
+        assert_eq!(
+            tinode.transport.kind,
+            registry::AppfsRegistryTransportKind::InProcess
+        );
+        assert_eq!(tinode.transport.endpoint, None);
+        assert_eq!(
+            tinode.path_template.as_deref(),
+            Some("private/{principal_id}/tinode")
+        );
+        assert_eq!(
+            tinode.profile_template.as_deref(),
+            Some("tinode:{principal_id}")
+        );
+        assert_eq!(tinode.credential_policy.as_deref(), Some("auto-create"));
     }
 }

--- a/cli/src/cmd/appfs/compose/schema.rs
+++ b/cli/src/cmd/appfs/compose/schema.rs
@@ -64,12 +64,14 @@ pub(crate) enum AppfsComposeConnectorMode {
     External,
     Command,
     ExternalOrCommand,
+    InProcess,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum AppfsComposeTransportKind {
     Http,
     Grpc,
+    InProcess,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -98,6 +100,17 @@ pub(crate) struct AppfsComposeApp {
     pub(crate) connector: String,
     pub(crate) session_id: Option<String>,
     pub(crate) transport: AppfsComposeAppTransport,
+    pub(crate) visibility: AppfsComposeAppVisibility,
+    pub(crate) path: Option<String>,
+    pub(crate) path_template: Option<String>,
+    pub(crate) profile_template: Option<String>,
+    pub(crate) credential_policy: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum AppfsComposeAppVisibility {
+    Public,
+    Private,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -203,10 +216,19 @@ fn normalize_connector(
 ) -> Result<AppfsComposeConnector> {
     let mode = normalize_connector_mode(raw.mode)?;
     let transport = normalize_transport_kind(raw.transport)?;
-    let endpoint = normalize_required_string(
-        raw.endpoint,
-        &format!("connectors.{connector_name}.endpoint"),
-    )?;
+    let endpoint = match transport {
+        AppfsComposeTransportKind::Http | AppfsComposeTransportKind::Grpc => {
+            normalize_required_string(
+                raw.endpoint,
+                &format!("connectors.{connector_name}.endpoint"),
+            )?
+        }
+        AppfsComposeTransportKind::InProcess => normalize_optional_string(
+            raw.endpoint,
+            format!("connectors.{connector_name}.endpoint"),
+        )?
+        .unwrap_or_default(),
+    };
 
     let command = raw
         .command
@@ -214,6 +236,12 @@ fn normalize_connector(
         .transpose()?;
     match mode {
         AppfsComposeConnectorMode::External => {
+            if transport == AppfsComposeTransportKind::InProcess {
+                anyhow::bail!(
+                    "compose connector {} with transport=in_process must use mode=in_process",
+                    connector_name
+                );
+            }
             if command.is_some() {
                 anyhow::bail!(
                     "compose connector {} in external mode cannot define command",
@@ -222,11 +250,37 @@ fn normalize_connector(
             }
         }
         AppfsComposeConnectorMode::Command | AppfsComposeConnectorMode::ExternalOrCommand => {
+            if transport == AppfsComposeTransportKind::InProcess {
+                anyhow::bail!(
+                    "compose connector {} with transport=in_process must use mode=in_process",
+                    connector_name
+                );
+            }
             if command.is_none() {
                 anyhow::bail!(
                     "compose connector {} in {} mode requires command",
                     connector_name,
                     connector_mode_label(mode)
+                );
+            }
+        }
+        AppfsComposeConnectorMode::InProcess => {
+            if transport != AppfsComposeTransportKind::InProcess {
+                anyhow::bail!(
+                    "compose connector {} in in_process mode must use transport=in_process",
+                    connector_name
+                );
+            }
+            if command.is_some() {
+                anyhow::bail!(
+                    "compose connector {} in in_process mode cannot define command",
+                    connector_name
+                );
+            }
+            if !endpoint.trim().is_empty() {
+                anyhow::bail!(
+                    "compose connector {} in in_process mode cannot define endpoint",
+                    connector_name
                 );
             }
         }
@@ -238,6 +292,14 @@ fn normalize_connector(
 
     match transport {
         AppfsComposeTransportKind::Http | AppfsComposeTransportKind::Grpc => {}
+        AppfsComposeTransportKind::InProcess => {
+            if healthcheck.is_some() {
+                anyhow::bail!(
+                    "compose connector {} with transport=in_process cannot define healthcheck",
+                    connector_name
+                );
+            }
+        }
     }
 
     Ok(AppfsComposeConnector {
@@ -368,14 +430,27 @@ fn normalize_apps(
             .entry(connector.clone())
             .or_default()
             .push(app_id.clone());
-        apps.insert(
-            app_id,
-            AppfsComposeApp {
-                connector,
-                session_id,
-                transport: normalize_app_transport(raw_app.transport),
-            },
-        );
+        let app = AppfsComposeApp {
+            connector,
+            session_id,
+            transport: normalize_app_transport(raw_app.transport),
+            visibility: normalize_app_visibility(raw_app.visibility)?,
+            path: normalize_app_path_field(raw_app.path, &format!("apps.{app_id}.path"))?,
+            path_template: normalize_app_path_field(
+                raw_app.path_template,
+                &format!("apps.{app_id}.path_template"),
+            )?,
+            profile_template: normalize_optional_string(
+                raw_app.profile_template,
+                format!("apps.{app_id}.profile_template"),
+            )?,
+            credential_policy: normalize_optional_string(
+                raw_app.credential_policy,
+                format!("apps.{app_id}.credential_policy"),
+            )?,
+        };
+        validate_app_visibility_fields(&app, &format!("apps.{app_id}"))?;
+        apps.insert(app_id, app);
     }
     for (connector, app_ids) in connector_usage {
         if app_ids.len() > 1 {
@@ -387,6 +462,37 @@ fn normalize_apps(
         }
     }
     Ok(apps)
+}
+
+fn validate_app_visibility_fields(app: &AppfsComposeApp, field_prefix: &str) -> Result<()> {
+    match app.visibility {
+        AppfsComposeAppVisibility::Public => {
+            if app.path_template.is_some() {
+                anyhow::bail!("{field_prefix}.path_template is only valid for private apps");
+            }
+        }
+        AppfsComposeAppVisibility::Private => {
+            if app.path.is_some() {
+                anyhow::bail!("{field_prefix}.path is only valid for public apps");
+            }
+            let path_template = app.path_template.as_deref().ok_or_else(|| {
+                anyhow::anyhow!("{field_prefix}.path_template is required for private apps")
+            })?;
+            if !path_template.contains("{principal_id}") {
+                anyhow::bail!(
+                    "{field_prefix}.path_template must contain {{principal_id}} for private apps"
+                );
+            }
+            if let Some(profile_template) = app.profile_template.as_deref() {
+                if !profile_template.contains("{principal_id}") {
+                    anyhow::bail!(
+                        "{field_prefix}.profile_template must contain {{principal_id}} for private apps"
+                    );
+                }
+            }
+        }
+    }
+    Ok(())
 }
 
 fn normalize_app_transport(raw: RawAppfsComposeAppTransport) -> AppfsComposeAppTransport {
@@ -444,6 +550,23 @@ fn normalize_optional_string(
         )?)),
         None => Ok(None),
     }
+}
+
+fn normalize_app_path_field(raw: Option<String>, field_name: &str) -> Result<Option<String>> {
+    let Some(value) = normalize_optional_string(raw, field_name)? else {
+        return Ok(None);
+    };
+    let rendered = value.replace('\\', "/");
+    if rendered.starts_with('/') {
+        anyhow::bail!("{field_name} must be relative to the AppFS mount root");
+    }
+    if rendered
+        .split('/')
+        .any(|segment| segment.is_empty() || segment == "." || segment == "..")
+    {
+        anyhow::bail!("{field_name} must not contain empty, . or .. path segments");
+    }
+    Ok(Some(rendered))
 }
 
 fn normalize_map_key(raw: &str, entity_name: &str) -> Result<String> {
@@ -524,6 +647,7 @@ fn normalize_connector_mode(
         RawAppfsComposeConnectorMode::ExternalOrCommand => {
             AppfsComposeConnectorMode::ExternalOrCommand
         }
+        RawAppfsComposeConnectorMode::InProcess => AppfsComposeConnectorMode::InProcess,
     })
 }
 
@@ -532,6 +656,7 @@ fn connector_mode_label(mode: AppfsComposeConnectorMode) -> &'static str {
         AppfsComposeConnectorMode::External => "external",
         AppfsComposeConnectorMode::Command => "command",
         AppfsComposeConnectorMode::ExternalOrCommand => "external_or_command",
+        AppfsComposeConnectorMode::InProcess => "in_process",
     }
 }
 
@@ -541,6 +666,16 @@ fn normalize_transport_kind(
     Ok(match raw {
         RawAppfsComposeTransportKind::Http => AppfsComposeTransportKind::Http,
         RawAppfsComposeTransportKind::Grpc => AppfsComposeTransportKind::Grpc,
+        RawAppfsComposeTransportKind::InProcess => AppfsComposeTransportKind::InProcess,
+    })
+}
+
+fn normalize_app_visibility(
+    raw: Option<RawAppfsComposeAppVisibility>,
+) -> Result<AppfsComposeAppVisibility> {
+    Ok(match raw.unwrap_or(RawAppfsComposeAppVisibility::Public) {
+        RawAppfsComposeAppVisibility::Public => AppfsComposeAppVisibility::Public,
+        RawAppfsComposeAppVisibility::Private => AppfsComposeAppVisibility::Private,
     })
 }
 
@@ -626,6 +761,7 @@ enum RawAppfsComposeConnectorMode {
     External,
     Command,
     ExternalOrCommand,
+    InProcess,
 }
 
 #[derive(Debug, Deserialize)]
@@ -633,6 +769,7 @@ enum RawAppfsComposeConnectorMode {
 enum RawAppfsComposeTransportKind {
     Http,
     Grpc,
+    InProcess,
 }
 
 #[derive(Debug, Deserialize)]
@@ -674,6 +811,23 @@ struct RawAppfsComposeApp {
     session_id: Option<String>,
     #[serde(default)]
     transport: RawAppfsComposeAppTransport,
+    #[serde(default)]
+    visibility: Option<RawAppfsComposeAppVisibility>,
+    #[serde(default)]
+    path: Option<String>,
+    #[serde(default)]
+    path_template: Option<String>,
+    #[serde(default)]
+    profile_template: Option<String>,
+    #[serde(default)]
+    credential_policy: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum RawAppfsComposeAppVisibility {
+    Public,
+    Private,
 }
 
 #[derive(Debug, Deserialize, Default)]
@@ -702,8 +856,8 @@ const fn default_true() -> bool {
 #[cfg(test)]
 mod tests {
     use super::{
-        parse_compose_doc, AppfsComposeConnectorMode, AppfsComposeInitMode,
-        AppfsComposeTransportKind,
+        parse_compose_doc, AppfsComposeAppVisibility, AppfsComposeConnectorMode,
+        AppfsComposeInitMode, AppfsComposeTransportKind,
     };
     use std::path::PathBuf;
 
@@ -780,6 +934,95 @@ apps:
             doc.apps.get("aiim").expect("app").transport.http_timeout_ms,
             5000
         );
+        assert_eq!(
+            doc.apps.get("aiim").expect("app").visibility,
+            AppfsComposeAppVisibility::Public
+        );
+    }
+
+    #[test]
+    fn parses_public_and_private_app_visibility_fields() {
+        let doc = parse_compose_doc(
+            r#"
+version: 1
+runtime:
+  db: .agentfs/demo.db
+  mountpoint: ./mnt/appfs
+  backend: fuse
+connectors:
+  aiim-http:
+    mode: external
+    transport: http
+    endpoint: http://127.0.0.1:8080
+  tinode-http:
+    mode: in_process
+    transport: in_process
+apps:
+  aiim:
+    connector: aiim-http
+    visibility: public
+    path: public/aiim
+  tinode:
+    connector: tinode-http
+    visibility: private
+    path_template: private/{principal_id}/tinode
+    profile_template: tinode:{principal_id}
+    credential_policy: auto-create
+"#,
+            PathBuf::from("/tmp/appfs-compose.yaml"),
+        )
+        .expect("compose should parse");
+
+        let aiim = doc.apps.get("aiim").expect("aiim app");
+        assert_eq!(aiim.visibility, AppfsComposeAppVisibility::Public);
+        assert_eq!(aiim.path.as_deref(), Some("public/aiim"));
+        assert_eq!(aiim.path_template, None);
+
+        let tinode = doc.apps.get("tinode").expect("tinode app");
+        assert_eq!(tinode.visibility, AppfsComposeAppVisibility::Private);
+        assert_eq!(
+            tinode.path_template.as_deref(),
+            Some("private/{principal_id}/tinode")
+        );
+        assert_eq!(
+            tinode.profile_template.as_deref(),
+            Some("tinode:{principal_id}")
+        );
+        assert_eq!(tinode.credential_policy.as_deref(), Some("auto-create"));
+        let tinode_connector = doc.connectors.get("tinode-http").expect("tinode connector");
+        assert_eq!(tinode_connector.mode, AppfsComposeConnectorMode::InProcess);
+        assert_eq!(
+            tinode_connector.transport,
+            AppfsComposeTransportKind::InProcess
+        );
+        assert_eq!(tinode_connector.endpoint, "");
+    }
+
+    #[test]
+    fn rejects_private_apps_without_principal_path_template() {
+        let err = parse_compose_doc(
+            r#"
+version: 1
+runtime:
+  db: .agentfs/demo.db
+  mountpoint: ./mnt/appfs
+  backend: fuse
+connectors:
+  tinode-http:
+    mode: external
+    transport: http
+    endpoint: http://127.0.0.1:6061
+apps:
+  tinode:
+    connector: tinode-http
+    visibility: private
+    path_template: private/tinode
+"#,
+            PathBuf::from("/tmp/appfs-compose.yaml"),
+        )
+        .expect_err("compose should fail");
+
+        assert!(err.to_string().contains("must contain {principal_id}"));
     }
 
     #[test]

--- a/cli/src/cmd/appfs/core.rs
+++ b/cli/src/cmd/appfs/core.rs
@@ -1,9 +1,10 @@
 use agentfs_sdk::{
     connector_error_codes, ActionExecutionMode, AgentFS as SdkAgentFS, AgentFSOptions,
     AppAdapterV1, AppConnector, AppStructureSyncReason, AuthStatus, ConnectorContext,
-    ConnectorError, ConnectorInfo, ConnectorTransport, DemoAppConnector, FetchLivePageRequest,
-    FetchLivePageResponse, FetchSnapshotChunkRequest, FetchSnapshotChunkResponse, HealthStatus,
-    SnapshotMeta, SubmitActionOutcome, SubmitActionRequest, SubmitActionResponse,
+    ConnectorCredentialSummary, ConnectorError, ConnectorInboundEvent, ConnectorInfo,
+    ConnectorTransport, DemoAppConnector, FetchLivePageRequest, FetchLivePageResponse,
+    FetchSnapshotChunkRequest, FetchSnapshotChunkResponse, HealthStatus, SnapshotMeta,
+    SubmitActionOutcome, SubmitActionRequest, SubmitActionResponse, TinodeConnector,
 };
 use anyhow::{Context, Result};
 use serde_json::Value as JsonValue;
@@ -27,7 +28,7 @@ use super::shared::{
     MultilineRecoveryOutcome,
 };
 use super::tree_sync::{
-    ensure_app_structure_initialized, refresh_app_structure, refresh_app_structure_in_db,
+    ensure_app_structure_initialized_at, refresh_app_structure, refresh_app_structure_in_db,
 };
 use super::{
     ActionCursorDoc, ActionCursorState, ActionSpec, AppRuntimeStartupBootstrap, AppfsAdapter,
@@ -275,6 +276,7 @@ impl AppConnector for LegacyAdapterConnector {
 }
 
 impl AppfsAdapter {
+    #[allow(dead_code)]
     pub(super) fn new(
         root: PathBuf,
         app_id: String,
@@ -284,6 +286,7 @@ impl AppfsAdapter {
         Self::new_with_bootstrap(root, app_id, session_id, bridge_config, None)
     }
 
+    #[allow(dead_code)]
     pub(super) fn new_with_bootstrap(
         root: PathBuf,
         app_id: String,
@@ -291,10 +294,40 @@ impl AppfsAdapter {
         bridge_config: AppfsBridgeConfig,
         startup_bootstrap: Option<AppRuntimeStartupBootstrap>,
     ) -> Result<Self> {
+        Self::new_with_mount_path(
+            root,
+            app_id.clone(),
+            app_id,
+            None,
+            None,
+            session_id,
+            bridge_config,
+            startup_bootstrap,
+        )
+    }
+
+    pub(super) fn new_with_mount_path(
+        root: PathBuf,
+        app_id: String,
+        app_mount_path: String,
+        principal_id: Option<String>,
+        profile_id: Option<String>,
+        session_id: String,
+        bridge_config: AppfsBridgeConfig,
+        startup_bootstrap: Option<AppRuntimeStartupBootstrap>,
+    ) -> Result<Self> {
         if startup_bootstrap.is_none() {
-            ensure_app_structure_initialized(&root, &app_id, &session_id, &bridge_config)?;
+            ensure_app_structure_initialized_at(
+                &root,
+                &app_id,
+                &app_mount_path,
+                principal_id.clone(),
+                profile_id.clone(),
+                &session_id,
+                &bridge_config,
+            )?;
         }
-        let app_dir = root.join(&app_id);
+        let app_dir = root.join(&app_mount_path);
         let manifest_path = app_dir.join("_meta").join("manifest.res.json");
         let events_path = app_dir.join("_stream").join("events.evt.jsonl");
         let cursor_path = app_dir.join("_stream").join("cursor.res.json");
@@ -371,6 +404,8 @@ impl AppfsAdapter {
         let mut adapter = Self {
             app_id,
             session_id,
+            principal_id,
+            profile_id,
             app_dir,
             direct_db_path: startup_bootstrap
                 .as_ref()
@@ -452,8 +487,57 @@ impl AppfsAdapter {
         Ok(())
     }
 
+    fn drain_connector_inbound_events(&mut self) -> Result<()> {
+        let request_id = Self::new_request_id();
+        let request_ctx = ConnectorContext {
+            app_id: self.app_id.clone(),
+            session_id: self.session_id.clone(),
+            request_id: request_id.clone(),
+            client_token: None,
+            trace_id: None,
+            principal_id: self.principal_id.clone(),
+            profile_id: self.profile_id.clone(),
+        };
+
+        match self.connector.drain_inbound_events(&request_ctx) {
+            Ok(events) => {
+                for event in events {
+                    self.emit_connector_inbound_event(&request_id, event)?;
+                }
+            }
+            Err(ConnectorError {
+                code,
+                message,
+                retryable,
+                ..
+            }) => {
+                eprintln!(
+                    "AppFS adapter ignored inbound drain failure for app {}: code={code} message={message} retryable={retryable}",
+                    self.app_id
+                );
+            }
+        }
+        Ok(())
+    }
+
+    fn emit_connector_inbound_event(
+        &mut self,
+        request_id: &str,
+        event: ConnectorInboundEvent,
+    ) -> Result<()> {
+        self.emit_event(
+            &event.path,
+            request_id,
+            &event.event_type,
+            event.content,
+            event.error,
+            None,
+        )
+    }
+
     pub(super) fn poll_once(&mut self) -> Result<()> {
         self.drain_streaming_jobs()?;
+        self.drain_connector_inbound_events()?;
 
         let mut actions = self.collect_action_files()?;
         actions.sort();
@@ -759,6 +843,16 @@ impl AppfsAdapter {
                     client_token,
                 );
             }
+            Ok(action_dispatcher::DispatchRoute::EnsureCredentials(request)) => {
+                return self.handle_ensure_credentials(
+                    &normalized_path,
+                    &request_id,
+                    request.expected_profile_id.as_deref(),
+                    payload,
+                    spec,
+                    client_token,
+                );
+            }
             Ok(action_dispatcher::DispatchRoute::BusinessSubmit) => {}
             Err(action_dispatcher::DispatchRouteParseError::PagingFetchNext) => {
                 eprintln!(
@@ -795,6 +889,13 @@ impl AppfsAdapter {
                 );
                 return Ok(ProcessOutcome::Consumed);
             }
+            Err(action_dispatcher::DispatchRouteParseError::EnsureCredentials) => {
+                eprintln!(
+                    "AppFS adapter rejected malformed ensure_credentials payload at submit-time: {}",
+                    normalized_path
+                );
+                return Ok(ProcessOutcome::Consumed);
+            }
         }
 
         let request_ctx = ConnectorContext {
@@ -803,6 +904,8 @@ impl AppfsAdapter {
             request_id: request_id.clone(),
             client_token: client_token.clone(),
             trace_id: None,
+            principal_id: self.principal_id.clone(),
+            profile_id: self.profile_id.clone(),
         };
         let execution_mode = match spec.execution_mode {
             ExecutionMode::Inline => ActionExecutionMode::Inline,
@@ -823,6 +926,18 @@ impl AppfsAdapter {
                 outcome: SubmitActionOutcome::Completed { content },
                 ..
             }) => {
+                let (content, side_events) = split_connector_side_events(content);
+                for event in side_events {
+                    let event_path = event.path.as_deref().unwrap_or(&normalized_path);
+                    self.emit_event(
+                        event_path,
+                        &request_id,
+                        &event.event_type,
+                        event.content,
+                        event.error,
+                        client_token.clone(),
+                    )?;
+                }
                 self.emit_event(
                     &normalized_path,
                     &request_id,
@@ -864,6 +979,121 @@ impl AppfsAdapter {
                 self.emit_failed_with_retryable(
                     &normalized_path,
                     &request_id,
+                    &code,
+                    &message,
+                    retryable,
+                    client_token,
+                )?;
+                Ok(ProcessOutcome::Consumed)
+            }
+        }
+    }
+
+    fn handle_ensure_credentials(
+        &mut self,
+        normalized_path: &str,
+        request_id: &str,
+        expected_profile_id: Option<&str>,
+        payload: &str,
+        spec: &ActionSpec,
+        client_token: Option<String>,
+    ) -> Result<ProcessOutcome> {
+        let Some(profile_id) = self.profile_id.clone() else {
+            self.emit_credential_failed(
+                normalized_path,
+                request_id,
+                connector_error_codes::PROFILE_NOT_READY,
+                "ensure_credentials requires a private app profile_id in connector context",
+                false,
+                client_token,
+            )?;
+            return Ok(ProcessOutcome::Consumed);
+        };
+        if let Some(expected_profile_id) = expected_profile_id {
+            if expected_profile_id != profile_id {
+                self.emit_credential_failed(
+                    normalized_path,
+                    request_id,
+                    connector_error_codes::INVALID_ARGUMENT,
+                    &format!(
+                        "expected_profile_id {expected_profile_id} does not match effective profile_id {profile_id}"
+                    ),
+                    false,
+                    client_token,
+                )?;
+                return Ok(ProcessOutcome::Consumed);
+            }
+        }
+
+        let request_ctx = ConnectorContext {
+            app_id: self.app_id.clone(),
+            session_id: self.session_id.clone(),
+            request_id: request_id.to_string(),
+            client_token: client_token.clone(),
+            trace_id: None,
+            principal_id: self.principal_id.clone(),
+            profile_id: Some(profile_id.clone()),
+        };
+        let execution_mode = match spec.execution_mode {
+            ExecutionMode::Inline => ActionExecutionMode::Inline,
+            ExecutionMode::Streaming => ActionExecutionMode::Streaming,
+        };
+        let payload_json: JsonValue =
+            serde_json::from_str(payload).context("validated JSON payload must parse")?;
+
+        match self.connector.submit_action(
+            SubmitActionRequest {
+                path: normalized_path.to_string(),
+                payload: payload_json,
+                execution_mode,
+            },
+            &request_ctx,
+        ) {
+            Ok(SubmitActionResponse {
+                outcome: SubmitActionOutcome::Completed { content },
+                ..
+            }) => {
+                let safe_summary =
+                    ConnectorCredentialSummary::from_connector_content(&content, &profile_id);
+                self.emit_event(
+                    normalized_path,
+                    request_id,
+                    "profile.credentials.ready",
+                    Some(serde_json::to_value(safe_summary)?),
+                    None,
+                    client_token,
+                )?;
+                Ok(ProcessOutcome::Consumed)
+            }
+            Ok(SubmitActionResponse {
+                outcome: SubmitActionOutcome::Streaming { .. },
+                ..
+            }) => {
+                self.emit_credential_failed(
+                    normalized_path,
+                    request_id,
+                    connector_error_codes::INVALID_ARGUMENT,
+                    "ensure_credentials must complete inline and cannot stream credential state",
+                    false,
+                    client_token,
+                )?;
+                Ok(ProcessOutcome::Consumed)
+            }
+            Err(ConnectorError {
+                code,
+                message,
+                retryable,
+                ..
+            }) => {
+                if is_transient_connector_failure(&code, retryable) {
+                    eprintln!(
+                        "AppFS adapter transient connector failure for {normalized_path}: code={code} message={message}; will retry without advancing cursor"
+                    );
+                    return Ok(ProcessOutcome::RetryPending);
+                }
+                self.emit_credential_failed(
+                    normalized_path,
+                    request_id,
                     &code,
                     &message,
                     retryable,
@@ -942,6 +1172,14 @@ pub(super) fn build_app_connector(
             Duration::from_millis(bridge_config.adapter_http_timeout_ms.max(1)),
             bridge_config.runtime_options,
         ))
+    } else if app_id == "tinode" {
+        Box::new(TinodeConnector::from_env().map_err(|err| {
+            anyhow::anyhow!(
+                "failed to initialize Tinode connector: {}: {}",
+                err.code,
+                err.message
+            )
+        })?)
     } else {
         Box::new(DemoAppConnector::new(app_id.to_string()))
     };
@@ -957,6 +1195,50 @@ pub(super) fn build_app_connector(
         );
     }
     Ok(connector)
+}
+
+struct ConnectorSideEvent {
+    event_type: String,
+    path: Option<String>,
+    content: Option<JsonValue>,
+    error: Option<JsonValue>,
+}
+
+fn split_connector_side_events(mut content: JsonValue) -> (JsonValue, Vec<ConnectorSideEvent>) {
+    let Some(object) = content.as_object_mut() else {
+        return (content, Vec::new());
+    };
+    let Some(raw_events) = object.remove("_appfs_events") else {
+        return (content, Vec::new());
+    };
+    let Some(raw_events) = raw_events.as_array() else {
+        return (content, Vec::new());
+    };
+
+    let events = raw_events
+        .iter()
+        .filter_map(|raw| {
+            let event_type = raw
+                .get("type")
+                .and_then(JsonValue::as_str)
+                .map(str::trim)
+                .filter(|value| !value.is_empty())?
+                .to_string();
+            Some(ConnectorSideEvent {
+                event_type,
+                path: raw
+                    .get("path")
+                    .and_then(JsonValue::as_str)
+                    .map(str::trim)
+                    .filter(|value| !value.is_empty())
+                    .map(ToOwned::to_owned),
+                content: raw.get("content").cloned(),
+                error: raw.get("error").cloned(),
+            })
+        })
+        .collect();
+
+    (content, events)
 }
 
 pub(super) fn parse_manifest_contract_json(
@@ -1382,6 +1664,8 @@ impl AppfsAdapter {
         if let Some(db_path) = self.direct_db_path.clone() {
             let app_id = self.app_id.clone();
             let session_id = self.session_id.clone();
+            let principal_id = self.principal_id.clone();
+            let profile_id = self.profile_id.clone();
             let connector = &mut self.connector;
             return crate::get_runtime().block_on(async move {
                 let agent = SdkAgentFS::open(AgentFSOptions::with_path(db_path)).await?;
@@ -1389,6 +1673,8 @@ impl AppfsAdapter {
                     &agent,
                     &app_id,
                     &session_id,
+                    principal_id,
+                    profile_id,
                     &mut **connector,
                     reason,
                     target_scope,
@@ -1406,6 +1692,8 @@ impl AppfsAdapter {
             root,
             &self.app_id,
             &self.session_id,
+            self.principal_id.clone(),
+            self.profile_id.clone(),
             &mut *self.connector,
             reason,
             target_scope,
@@ -1502,6 +1790,8 @@ mod tests {
             request_id: "req-1".to_string(),
             client_token: None,
             trace_id: None,
+            principal_id: None,
+            profile_id: None,
         }
     }
 
@@ -1649,6 +1939,23 @@ mod tests {
             bridge_config(),
         )
         .expect("structured adapter");
+
+        (temp, adapter)
+    }
+
+    fn private_structured_adapter() -> (TempDir, AppfsAdapter) {
+        let temp = TempDir::new().expect("tempdir");
+        let adapter = AppfsAdapter::new_with_mount_path(
+            temp.path().to_path_buf(),
+            "demo-private".to_string(),
+            "private/default/demo-private".to_string(),
+            Some("default".to_string()),
+            Some("demo-private:default".to_string()),
+            "sess-test".to_string(),
+            bridge_config(),
+            None,
+        )
+        .expect("private structured adapter");
 
         (temp, adapter)
     }
@@ -2353,11 +2660,41 @@ mod tests {
     }
 
     #[test]
+    fn connector_side_events_are_split_and_reserved_field_is_hidden() {
+        let (content, events) = super::split_connector_side_events(json!({
+            "ok": true,
+            "_appfs_events": [
+                {"type": "message.sent", "path": "contacts/zhangsan/messages.res.jsonl", "content": {"message_id": "m1"}},
+                {"type": "action.accepted", "content": {"ok": true}},
+                {"content": {"ignored": true}}
+            ]
+        }));
+
+        assert_eq!(content["ok"], true);
+        assert!(content.get("_appfs_events").is_none());
+        assert_eq!(events.len(), 2);
+        assert_eq!(events[0].event_type, "message.sent");
+        assert_eq!(
+            events[0].path.as_deref(),
+            Some("contacts/zhangsan/messages.res.jsonl")
+        );
+        assert_eq!(
+            events[0]
+                .content
+                .as_ref()
+                .and_then(|value| value.get("message_id"))
+                .and_then(|value| value.as_str()),
+            Some("m1")
+        );
+    }
+
+    #[test]
     fn structured_bootstrap_exposes_app_control_actions() {
         let (_temp, adapter) = structured_adapter();
 
         assert!(adapter.app_dir.join("_app/enter_scope.act").exists());
         assert!(adapter.app_dir.join("_app/refresh_structure.act").exists());
+        assert!(!adapter.app_dir.join("_app/ensure_credentials.act").exists());
         assert!(adapter
             .action_specs
             .iter()
@@ -2366,10 +2703,96 @@ mod tests {
             .action_specs
             .iter()
             .any(|spec| spec.template == "_app/refresh_structure.act"));
+        assert!(!adapter
+            .action_specs
+            .iter()
+            .any(|spec| spec.template == "_app/ensure_credentials.act"));
         assert!(adapter
             .snapshot_specs
             .iter()
             .any(|spec| spec.template == "chats/chat-001/messages.res.jsonl"));
+    }
+
+    #[test]
+    fn ensure_credentials_emits_only_safe_profile_summary() {
+        let (_temp, mut adapter) = private_structured_adapter();
+        adapter.prepare_action_sinks().expect("prepare sinks");
+
+        let action_path = adapter.app_dir.join("_app/ensure_credentials.act");
+        let events_path = adapter.app_dir.join("_stream/events.evt.jsonl");
+
+        assert!(action_path.exists());
+        assert!(adapter
+            .action_specs
+            .iter()
+            .any(|spec| spec.template == "_app/ensure_credentials.act"));
+
+        append_text(
+            &action_path,
+            "{\"client_token\":\"ensure-001\",\"expected_profile_id\":\"demo-private:default\"}\n",
+        );
+        adapter.poll_once().expect("poll ensure credentials");
+
+        let events = token_events(&events_path, "ensure-001");
+        assert_eq!(events.len(), 1);
+        assert_eq!(
+            events[0].get("type").and_then(|value| value.as_str()),
+            Some("profile.credentials.ready")
+        );
+        let content = events[0].get("content").expect("credential content");
+        assert_eq!(
+            content
+                .get("credential_status")
+                .and_then(|value| value.as_str()),
+            Some("ready")
+        );
+        assert_eq!(
+            content.get("profile_id").and_then(|value| value.as_str()),
+            Some("demo-private:default")
+        );
+        assert_eq!(
+            content
+                .get("upstream_user_id")
+                .and_then(|value| value.as_str()),
+            Some("demo-user-demo-private:default")
+        );
+        assert_eq!(
+            content.get("login").and_then(|value| value.as_str()),
+            Some("demo-demo-private:default")
+        );
+        assert!(content.get("token").is_none());
+        assert!(!content.to_string().contains("demo-secret-token"));
+    }
+
+    #[test]
+    fn ensure_credentials_rejects_payload_profile_mismatch() {
+        let (_temp, mut adapter) = private_structured_adapter();
+        adapter.prepare_action_sinks().expect("prepare sinks");
+
+        let action_path = adapter.app_dir.join("_app/ensure_credentials.act");
+        let events_path = adapter.app_dir.join("_stream/events.evt.jsonl");
+
+        append_text(
+            &action_path,
+            "{\"client_token\":\"ensure-mismatch-001\",\"expected_profile_id\":\"demo-private:attacker\"}\n",
+        );
+        adapter
+            .poll_once()
+            .expect("poll ensure credentials mismatch");
+
+        let events = token_events(&events_path, "ensure-mismatch-001");
+        assert_eq!(events.len(), 1);
+        assert_eq!(
+            events[0].get("type").and_then(|value| value.as_str()),
+            Some("profile.credentials.failed")
+        );
+        assert_eq!(
+            events[0]
+                .get("error")
+                .and_then(|value| value.get("code"))
+                .and_then(|value| value.as_str()),
+            Some("INVALID_ARGUMENT")
+        );
     }
 
     #[test]

--- a/cli/src/cmd/appfs/events.rs
+++ b/cli/src/cmd/appfs/events.rs
@@ -123,6 +123,29 @@ impl AppfsAdapter {
         )
     }
 
+    pub(super) fn emit_credential_failed(
+        &mut self,
+        action_path: &str,
+        request_id: &str,
+        error_code: &str,
+        message: &str,
+        retryable: bool,
+        client_token: Option<String>,
+    ) -> Result<()> {
+        self.emit_event(
+            action_path,
+            request_id,
+            "profile.credentials.failed",
+            None,
+            Some(json!({
+                "code": error_code,
+                "message": message,
+                "retryable": retryable,
+            })),
+            client_token,
+        )
+    }
+
     #[allow(clippy::too_many_arguments)]
     pub(super) fn emit_snapshot_too_large(
         &mut self,

--- a/cli/src/cmd/appfs/grpc_bridge_adapter.rs
+++ b/cli/src/cmd/appfs/grpc_bridge_adapter.rs
@@ -908,6 +908,8 @@ fn to_connector_proto_context(ctx: &ConnectorContext) -> connector_proto::Connec
         request_id: ctx.request_id.clone(),
         client_token: ctx.client_token.clone(),
         trace_id: ctx.trace_id.clone(),
+        principal_id: ctx.principal_id.clone(),
+        profile_id: ctx.profile_id.clone(),
     }
 }
 
@@ -918,6 +920,8 @@ fn to_structure_proto_context(ctx: &ConnectorContext) -> structure_proto::Connec
         request_id: ctx.request_id.clone(),
         client_token: ctx.client_token.clone(),
         trace_id: ctx.trace_id.clone(),
+        principal_id: ctx.principal_id.clone(),
+        profile_id: ctx.profile_id.clone(),
     }
 }
 
@@ -1433,8 +1437,8 @@ where
 #[cfg(test)]
 mod tests {
     use super::{
-        parse_connector_json_text, to_proto_execution_mode, to_proto_input_mode,
-        GrpcBridgeAdapterV1, GrpcBridgeConnector,
+        parse_connector_json_text, to_connector_proto_context, to_proto_execution_mode,
+        to_proto_input_mode, to_structure_proto_context, GrpcBridgeAdapterV1, GrpcBridgeConnector,
     };
     use agentfs_sdk::{
         ActionExecutionMode, AdapterControlActionV1, AdapterControlOutcomeV1,
@@ -2075,7 +2079,21 @@ mod tests {
             request_id: "req-grpc".to_string(),
             client_token: Some("tok-grpc".to_string()),
             trace_id: Some("trace-grpc".to_string()),
+            principal_id: Some("default".to_string()),
+            profile_id: Some("tinode:default".to_string()),
         }
+    }
+
+    #[test]
+    fn grpc_connector_context_maps_principal_and_profile() {
+        let ctx = connector_test_ctx();
+        let connector_ctx = to_connector_proto_context(&ctx);
+        assert_eq!(connector_ctx.principal_id.as_deref(), Some("default"));
+        assert_eq!(connector_ctx.profile_id.as_deref(), Some("tinode:default"));
+
+        let structure_ctx = to_structure_proto_context(&ctx);
+        assert_eq!(structure_ctx.principal_id.as_deref(), Some("default"));
+        assert_eq!(structure_ctx.profile_id.as_deref(), Some("tinode:default"));
     }
 
     async fn spawn_test_grpc_connector_server() -> (SocketAddr, tokio::sync::oneshot::Sender<()>) {

--- a/cli/src/cmd/appfs/http_bridge_adapter.rs
+++ b/cli/src/cmd/appfs/http_bridge_adapter.rs
@@ -640,8 +640,8 @@ fn map_status_error_connector(status: u16, body: &str) -> ConnectorError {
 
 #[cfg(test)]
 mod tests {
-    use super::{map_status_error_connector, map_status_error_v1};
-    use agentfs_sdk::{connector_error_codes, AdapterErrorV1};
+    use super::{map_status_error_connector, map_status_error_v1, WrappedRequest};
+    use agentfs_sdk::{connector_error_codes, AdapterErrorV1, ConnectorContext};
 
     #[test]
     fn map_status_error_v1_accepts_adapter_error_shape() {
@@ -680,5 +680,25 @@ mod tests {
         let err = map_status_error_connector(503, "upstream down");
         assert_eq!(err.code, connector_error_codes::UPSTREAM_UNAVAILABLE);
         assert!(err.retryable);
+    }
+
+    #[test]
+    fn wrapped_connector_request_serializes_principal_context() {
+        let wrapped = WrappedRequest {
+            context: ConnectorContext {
+                app_id: "tinode".to_string(),
+                session_id: "sess-1".to_string(),
+                request_id: "req-1".to_string(),
+                client_token: None,
+                trace_id: None,
+                principal_id: Some("default".to_string()),
+                profile_id: Some("tinode:default".to_string()),
+            },
+            request: serde_json::json!({"path": "/contacts/send_message.act"}),
+        };
+
+        let json = serde_json::to_value(&wrapped).expect("serialize wrapped request");
+        assert_eq!(json["context"]["principal_id"], "default");
+        assert_eq!(json["context"]["profile_id"], "tinode:default");
     }
 }

--- a/cli/src/cmd/appfs/mount_runtime.rs
+++ b/cli/src/cmd/appfs/mount_runtime.rs
@@ -73,17 +73,31 @@ struct MountSnapshotReadThroughFs {
 
 struct MountSnapshotRuntime {
     app_id: String,
+    app_mount_path: String,
     session_id: String,
+    principal_id: Option<String>,
+    profile_id: Option<String>,
     snapshot_specs: Vec<SnapshotSpec>,
     snapshot_expand_journal: HashMap<String, SnapshotExpandJournalEntry>,
     connector: Box<dyn agentfs_sdk::AppConnector>,
 }
 
 #[derive(Clone)]
+struct MountSnapshotRuntimeConfig {
+    instance_id: String,
+    app_id: String,
+    app_mount_path: String,
+    session_id: Option<String>,
+    principal_id: Option<String>,
+    profile_id: Option<String>,
+    bridge: super::AppfsBridgeCliArgs,
+}
+
+#[derive(Clone)]
 struct SnapshotReadThroughContext {
     inner: DynFs,
     managed: bool,
-    runtime_configs: Arc<Mutex<HashMap<String, AppfsRuntimeCliArgs>>>,
+    runtime_configs: Arc<Mutex<HashMap<String, MountSnapshotRuntimeConfig>>>,
     registry_fingerprint: Arc<Mutex<Option<Vec<u8>>>>,
     path_cache: Arc<Mutex<HashMap<i64, String>>>,
     runtimes: Arc<Mutex<HashMap<String, MountSnapshotRuntime>>>,
@@ -109,7 +123,7 @@ struct SnapshotReadThroughFile {
 #[derive(Default)]
 struct SnapshotReadThroughFileState {
     file: Option<BoxedFile>,
-    read_prepared: bool,
+    read_buffer: Option<Vec<u8>>,
 }
 
 impl MountSnapshotRuntime {
@@ -123,7 +137,7 @@ impl MountSnapshotRuntime {
     fn journal_path(&self) -> String {
         format!(
             "{}/_stream/{}",
-            self.app_id, SNAPSHOT_EXPAND_JOURNAL_FILENAME
+            self.app_mount_path, SNAPSHOT_EXPAND_JOURNAL_FILENAME
         )
     }
 
@@ -144,7 +158,7 @@ impl MountSnapshotRuntime {
         }
         format!(
             "{}/_stream/snapshot-expand-tmp/{}.pending.jsonl",
-            self.app_id, sanitized
+            self.app_mount_path, sanitized
         )
     }
 
@@ -155,6 +169,38 @@ impl MountSnapshotRuntime {
             request_id: request_id.to_string(),
             client_token: None,
             trace_id: None,
+            principal_id: self.principal_id.clone(),
+            profile_id: self.profile_id.clone(),
+        }
+    }
+
+    fn resource_fs_rel(&self, resource_rel: &str) -> String {
+        format!("{}/{}", self.app_mount_path, resource_rel)
+    }
+}
+
+impl MountSnapshotRuntimeConfig {
+    fn from_cli(runtime: AppfsRuntimeCliArgs) -> Self {
+        Self {
+            instance_id: runtime.app_id.clone(),
+            app_mount_path: runtime.app_id.clone(),
+            app_id: runtime.app_id,
+            session_id: runtime.session_id,
+            principal_id: None,
+            profile_id: None,
+            bridge: runtime.bridge,
+        }
+    }
+
+    fn from_registry(app: &registry::AppfsRegisteredAppDoc) -> Self {
+        Self {
+            instance_id: app.instance_id.clone(),
+            app_id: app.app_id.clone(),
+            app_mount_path: normalize_mount_path(&app.path),
+            session_id: Some(app.session_id.clone()),
+            principal_id: app.principal_id.clone(),
+            profile_id: app.profile_id.clone(),
+            bridge: registry::bridge_args_from_transport_doc(&app.transport),
         }
     }
 }
@@ -220,7 +266,10 @@ impl MountSnapshotReadThroughFs {
             .runtimes
             .iter()
             .cloned()
-            .map(|runtime| (runtime.app_id.clone(), runtime))
+            .map(|runtime| {
+                let mount_config = MountSnapshotRuntimeConfig::from_cli(runtime);
+                (mount_config.instance_id.clone(), mount_config)
+            })
             .collect();
         Self {
             ctx: SnapshotReadThroughContext {
@@ -246,27 +295,28 @@ impl SnapshotReadThroughContext {
         self.path_cache.lock().await.insert(ino, rel_path);
     }
 
-    async fn expand_lock_for(&self, app_id: &str, resource_rel: &str) -> Arc<Mutex<()>> {
+    async fn expand_lock_for(&self, instance_id: &str, resource_rel: &str) -> Arc<Mutex<()>> {
         let mut locks = self.expand_locks.lock().await;
-        let key = format!("{app_id}:{resource_rel}");
+        let key = format!("{instance_id}:{resource_rel}");
         locks
             .entry(key)
             .or_insert_with(|| Arc::new(Mutex::new(())))
             .clone()
     }
 
-    async fn runtime_loaded(&self, app_id: &str) -> Result<bool> {
+    async fn runtime_loaded(&self, instance_id: &str) -> Result<bool> {
         self.refresh_registry_snapshot().await?;
-        let Some(runtime_config) = self.runtime_configs.lock().await.get(app_id).cloned() else {
+        let Some(runtime_config) = self.runtime_configs.lock().await.get(instance_id).cloned()
+        else {
             return Ok(false);
         };
 
         let mut guard = self.runtimes.lock().await;
-        if guard.contains_key(app_id) {
+        if guard.contains_key(instance_id) {
             return Ok(true);
         }
 
-        let manifest_rel = format!("{app_id}/_meta/manifest.res.json");
+        let manifest_rel = format!("{}/_meta/manifest.res.json", runtime_config.app_mount_path);
         let manifest_bytes = match self.read_file_if_exists(&manifest_rel).await? {
             Some(bytes) => bytes,
             None => return Ok(false),
@@ -277,8 +327,11 @@ impl SnapshotReadThroughContext {
             parse_manifest_contract_json(&manifest_json, &format!("/{}", manifest_rel))?;
         let session_id = super::normalize_appfs_session_id(runtime_config.session_id.clone());
         let bridge_config = super::build_appfs_bridge_config(runtime_config.bridge.clone());
-        let connector = build_app_connector(app_id, &bridge_config)?;
-        let journal_path = format!("{app_id}/_stream/{}", SNAPSHOT_EXPAND_JOURNAL_FILENAME);
+        let connector = build_app_connector(&runtime_config.app_id, &bridge_config)?;
+        let journal_path = format!(
+            "{}/_stream/{}",
+            runtime_config.app_mount_path, SNAPSHOT_EXPAND_JOURNAL_FILENAME
+        );
         let snapshot_expand_journal = match self.read_file_if_exists(&journal_path).await? {
             Some(bytes) => {
                 let doc: SnapshotExpandJournalDoc = serde_json::from_slice(&bytes)
@@ -289,16 +342,23 @@ impl SnapshotReadThroughContext {
         };
 
         let mut snapshot_expand_journal = snapshot_expand_journal;
-        self.recover_incomplete_expands(app_id, &journal_path, &mut snapshot_expand_journal)
-            .await?;
+        self.recover_incomplete_expands(
+            &runtime_config.app_mount_path,
+            &journal_path,
+            &mut snapshot_expand_journal,
+        )
+        .await?;
         let runtime = MountSnapshotRuntime {
-            app_id: app_id.to_string(),
+            app_id: runtime_config.app_id,
+            app_mount_path: runtime_config.app_mount_path,
             session_id,
+            principal_id: runtime_config.principal_id,
+            profile_id: runtime_config.profile_id,
             snapshot_specs: manifest_contract.snapshot_specs,
             snapshot_expand_journal,
             connector,
         };
-        guard.insert(app_id.to_string(), runtime);
+        guard.insert(instance_id.to_string(), runtime);
         Ok(true)
     }
 
@@ -320,10 +380,13 @@ impl SnapshotReadThroughContext {
         }
         let doc = registry::parse_app_registry_bytes(&bytes)
             .context("failed to load managed AppFS registry for mount read-through")?;
-        let runtime_args = registry::runtime_args_from_registry(&doc)?;
-        let runtime_configs = runtime_args
-            .into_iter()
-            .map(|runtime| (runtime.app_id.clone(), runtime))
+        let runtime_configs = doc
+            .apps
+            .iter()
+            .map(|app| {
+                let runtime = MountSnapshotRuntimeConfig::from_registry(app);
+                (runtime.instance_id.clone(), runtime)
+            })
             .collect::<HashMap<_, _>>();
         *self.runtime_configs.lock().await = runtime_configs;
         *self.registry_fingerprint.lock().await = Some(bytes);
@@ -336,7 +399,7 @@ impl SnapshotReadThroughContext {
 
     async fn recover_incomplete_expands(
         &self,
-        app_id: &str,
+        app_mount_path: &str,
         journal_path: &str,
         journal_resources: &mut HashMap<String, SnapshotExpandJournalEntry>,
     ) -> Result<()> {
@@ -350,7 +413,7 @@ impl SnapshotReadThroughContext {
             .collect();
         for (resource_rel, entry) in entries {
             if let Some(temp_artifact) = entry.temp_artifact.as_deref() {
-                if self.is_valid_temp_artifact(app_id, temp_artifact) {
+                if self.is_valid_temp_artifact(app_mount_path, temp_artifact) {
                     let temp_rel = temp_artifact.trim_start_matches('/');
                     let _ = self.remove_file_if_exists(temp_rel).await;
                 }
@@ -365,7 +428,7 @@ impl SnapshotReadThroughContext {
             .await
     }
 
-    fn is_valid_temp_artifact(&self, app_id: &str, temp_artifact: &str) -> bool {
+    fn is_valid_temp_artifact(&self, app_mount_path: &str, temp_artifact: &str) -> bool {
         let trimmed = temp_artifact.trim().trim_start_matches('/');
         if trimmed.is_empty() {
             return false;
@@ -383,69 +446,93 @@ impl SnapshotReadThroughContext {
             }
         }
         normalized.starts_with(
-            Path::new(app_id)
+            Path::new(app_mount_path)
                 .join("_stream")
                 .join("snapshot-expand-tmp"),
         )
+    }
+
+    async fn runtime_resource_from_fs_path(
+        &self,
+        fs_rel_path: &str,
+    ) -> Result<Option<(String, String)>> {
+        self.refresh_registry_snapshot().await?;
+        let normalized_path = normalize_mount_path(fs_rel_path);
+        let configs = self.runtime_configs.lock().await;
+        let mut best: Option<(&MountSnapshotRuntimeConfig, String)> = None;
+        for config in configs.values() {
+            let mount_path = normalize_mount_path(&config.app_mount_path);
+            let Some(resource_rel) = strip_mount_prefix(&normalized_path, &mount_path) else {
+                continue;
+            };
+            if best.as_ref().map_or(true, |(existing, _)| {
+                mount_path.len() > normalize_mount_path(&existing.app_mount_path).len()
+            }) {
+                best = Some((config, resource_rel.to_string()));
+            }
+        }
+        Ok(best.map(|(config, resource_rel)| (config.instance_id.clone(), resource_rel)))
     }
 
     async fn maybe_snapshot_resource_from_fs_path(
         &self,
         fs_rel_path: &str,
     ) -> Result<Option<(String, String)>> {
-        let Some((app_id, resource_rel)) = split_app_relative_path(fs_rel_path) else {
+        let Some((instance_id, resource_rel)) =
+            self.runtime_resource_from_fs_path(fs_rel_path).await?
+        else {
             return Ok(None);
         };
-        if !self.runtime_loaded(app_id).await? {
+        if !self.runtime_loaded(&instance_id).await? {
             return Ok(None);
         }
         let guard = self.runtimes.lock().await;
-        let Some(runtime) = guard.get(app_id) else {
+        let Some(runtime) = guard.get(&instance_id) else {
             return Ok(None);
         };
         Ok(runtime
-            .find_snapshot_spec(resource_rel)
-            .map(|_| (app_id.to_string(), resource_rel.to_string())))
+            .find_snapshot_spec(&resource_rel)
+            .map(|_| (instance_id, resource_rel)))
     }
 
-    async fn journal_contains(&self, app_id: &str, resource_rel: &str) -> Result<bool> {
-        if !self.runtime_loaded(app_id).await? {
+    async fn journal_contains(&self, instance_id: &str, resource_rel: &str) -> Result<bool> {
+        if !self.runtime_loaded(instance_id).await? {
             return Ok(false);
         }
         let guard = self.runtimes.lock().await;
         Ok(guard
-            .get(app_id)
+            .get(instance_id)
             .is_some_and(|runtime| runtime.snapshot_expand_journal.contains_key(resource_rel)))
     }
 
     async fn ensure_snapshot_materialized(
         &self,
-        app_id: &str,
+        instance_id: &str,
         resource_rel: &str,
         trigger: &str,
     ) -> Result<()> {
-        if !self.runtime_loaded(app_id).await? {
+        if !self.runtime_loaded(instance_id).await? {
             anyhow::bail!("AppFS manifest is not available yet for mount-side read-through");
         }
 
-        let expand_lock = self.expand_lock_for(app_id, resource_rel).await;
+        let expand_lock = self.expand_lock_for(instance_id, resource_rel).await;
         let _expand_guard = expand_lock.lock().await;
         let request_id = format!("read-{}", uuid::Uuid::new_v4().simple());
         let resource_path = format!("/{}", resource_rel);
-        let (snapshot_spec, temp_rel) = {
+        let (snapshot_spec, temp_rel, resource_fs_rel) = {
             let mut guard = self.runtimes.lock().await;
             let runtime = guard
-                .get_mut(app_id)
+                .get_mut(instance_id)
                 .expect("runtime_loaded() should initialize runtime");
             let snapshot_spec = runtime
                 .find_snapshot_spec(resource_rel)
                 .cloned()
                 .ok_or_else(|| anyhow::anyhow!("snapshot resource is not declared in manifest"))?;
             let temp_rel = runtime.temp_rel_path(resource_rel);
-            (snapshot_spec, temp_rel)
+            let resource_fs_rel = runtime.resource_fs_rel(resource_rel);
+            (snapshot_spec, temp_rel, resource_fs_rel)
         };
-        let resource_fs_rel = format!("{}/{}", app_id, resource_rel);
-        let has_journal = self.journal_contains(app_id, resource_rel).await?;
+        let has_journal = self.journal_contains(instance_id, resource_rel).await?;
         let force_expand_existing =
             matches!(trigger, "open" | "read") && snapshot_force_expand_on_refresh();
         let current_stats = self.lookup_path(&resource_fs_rel).await?;
@@ -462,7 +549,7 @@ impl SnapshotReadThroughContext {
         {
             let mut guard = self.runtimes.lock().await;
             let runtime = guard
-                .get_mut(app_id)
+                .get_mut(instance_id)
                 .expect("runtime_loaded() should initialize runtime");
             runtime.snapshot_expand_journal.insert(
                 resource_rel.to_string(),
@@ -476,7 +563,7 @@ impl SnapshotReadThroughContext {
                 },
             );
         }
-        self.flush_runtime_snapshot_journal(app_id).await?;
+        self.flush_runtime_snapshot_journal(instance_id).await?;
 
         eprintln!(
             "[cache] mount read-through resource={} trigger={} timeout_ms={} on_timeout={}",
@@ -512,7 +599,7 @@ impl SnapshotReadThroughContext {
                 Some("stale_cache_disabled".to_string())
             };
             let stale_ok = stale_health.is_none();
-            self.remove_snapshot_journal_entry(app_id, resource_rel)
+            self.remove_snapshot_journal_entry(instance_id, resource_rel)
                 .await?;
             if stale_ok {
                 eprintln!(
@@ -540,12 +627,12 @@ impl SnapshotReadThroughContext {
         let expanded_jsonl = {
             let mut guard = self.runtimes.lock().await;
             let runtime = guard
-                .get_mut(app_id)
+                .get_mut(instance_id)
                 .expect("runtime_loaded() should initialize runtime");
             self.fetch_snapshot_jsonl_from_upstream(runtime, resource_rel, &request_id)?
         };
         if expanded_jsonl.len() > snapshot_spec.max_materialized_bytes {
-            self.remove_snapshot_journal_entry(app_id, resource_rel)
+            self.remove_snapshot_journal_entry(instance_id, resource_rel)
                 .await?;
             eprintln!(
                 "[cache] snapshot_too_large resource={} size={} max_size={} trigger={}",
@@ -567,14 +654,14 @@ impl SnapshotReadThroughContext {
         }
 
         self.materialize_snapshot_file(
-            app_id,
+            instance_id,
             resource_rel,
             &temp_rel,
             &expanded_jsonl,
             &request_id,
         )
         .await?;
-        self.remove_snapshot_journal_entry(app_id, resource_rel)
+        self.remove_snapshot_journal_entry(instance_id, resource_rel)
             .await?;
         eprintln!(
             "[cache] expanded resource={} bytes={} trigger={}",
@@ -583,6 +670,128 @@ impl SnapshotReadThroughContext {
             trigger
         );
         Ok(())
+    }
+
+    async fn read_snapshot_bytes(
+        &self,
+        instance_id: &str,
+        resource_rel: &str,
+        trigger: &str,
+    ) -> Result<Vec<u8>> {
+        if !self.runtime_loaded(instance_id).await? {
+            anyhow::bail!("AppFS manifest is not available yet for mount-side read-through");
+        }
+
+        let expand_lock = self.expand_lock_for(instance_id, resource_rel).await;
+        let _expand_guard = expand_lock.lock().await;
+        let request_id = format!("read-{}", uuid::Uuid::new_v4().simple());
+        let resource_path = format!("/{}", resource_rel);
+        let (snapshot_spec, resource_fs_rel) = {
+            let guard = self.runtimes.lock().await;
+            let runtime = guard
+                .get(instance_id)
+                .expect("runtime_loaded() should initialize runtime");
+            let snapshot_spec = runtime
+                .find_snapshot_spec(resource_rel)
+                .cloned()
+                .ok_or_else(|| anyhow::anyhow!("snapshot resource is not declared in manifest"))?;
+            let resource_fs_rel = runtime.resource_fs_rel(resource_rel);
+            (snapshot_spec, resource_fs_rel)
+        };
+
+        eprintln!(
+            "[cache] mount read-through resource={} trigger={} timeout_ms={} on_timeout={}",
+            resource_path,
+            trigger,
+            snapshot_spec.read_through_timeout_ms,
+            snapshot_spec.on_timeout.as_str()
+        );
+
+        let simulated_delay_ms = snapshot_expand_delay_ms();
+        if simulated_delay_ms > 0 {
+            std::thread::sleep(Duration::from_millis(simulated_delay_ms));
+        }
+
+        if simulated_delay_ms > snapshot_spec.read_through_timeout_ms {
+            let mut stale_health = if matches!(
+                snapshot_spec.on_timeout,
+                SnapshotOnTimeoutPolicy::ReturnStale
+            ) {
+                Some("stale_cache_missing")
+            } else {
+                Some("stale_cache_disabled")
+            };
+            if matches!(
+                snapshot_spec.on_timeout,
+                SnapshotOnTimeoutPolicy::ReturnStale
+            ) {
+                if let Some(stale_bytes) = self.read_file_if_exists(&resource_fs_rel).await? {
+                    if stale_bytes.len() > snapshot_spec.max_materialized_bytes {
+                        stale_health = Some("stale_cache_too_large");
+                    } else {
+                        match self.validate_stale_snapshot_jsonl(&stale_bytes) {
+                            Ok(_) => {
+                                eprintln!(
+                                    "[cache] timeout_return_stale resource={} trigger={}",
+                                    resource_path, trigger
+                                );
+                                return Ok(stale_bytes);
+                            }
+                            Err(_) => {
+                                stale_health = Some("stale_cache_unhealthy");
+                            }
+                        }
+                    }
+                }
+            }
+            eprintln!(
+                "[cache] expand failed resource={} phase=timeout on_timeout={} stale_reason={} trigger={}",
+                resource_path,
+                snapshot_spec.on_timeout.as_str(),
+                stale_health.unwrap_or("stale_cache_missing"),
+                trigger
+            );
+            return Err(io_error(
+                RAW_TIMEOUT_ERROR,
+                format!("snapshot read-through timed out: {}", resource_path),
+            )
+            .into());
+        }
+
+        let expanded_jsonl = {
+            let mut guard = self.runtimes.lock().await;
+            let runtime = guard
+                .get_mut(instance_id)
+                .expect("runtime_loaded() should initialize runtime");
+            self.fetch_snapshot_jsonl_from_upstream(runtime, resource_rel, &request_id)?
+        };
+        if expanded_jsonl.len() > snapshot_spec.max_materialized_bytes {
+            eprintln!(
+                "[cache] snapshot_too_large resource={} size={} max_size={} trigger={}",
+                resource_path,
+                expanded_jsonl.len(),
+                snapshot_spec.max_materialized_bytes,
+                trigger
+            );
+            return Err(io_error(
+                RAW_IO_ERROR,
+                format!(
+                    "snapshot too large for {}: {} > {}",
+                    resource_path,
+                    expanded_jsonl.len(),
+                    snapshot_spec.max_materialized_bytes
+                ),
+            )
+            .into());
+        }
+
+        eprintln!(
+            "[cache] read-through resource={} bytes={} trigger={}",
+            resource_path,
+            expanded_jsonl.len(),
+            trigger
+        );
+        Ok(expanded_jsonl)
     }
 
     fn fetch_snapshot_jsonl_from_upstream(
@@ -634,31 +843,27 @@ impl SnapshotReadThroughContext {
             })?;
             resume = SnapshotResume::Cursor(next_cursor);
         }
-        if out.is_empty() {
-            return Err(io_error(
-                RAW_IO_ERROR,
-                format!(
-                    "connector returned empty snapshot stream for /{}",
-                    resource_rel
-                ),
-            )
-            .into());
-        }
         Ok(out)
     }
 
     async fn materialize_snapshot_file(
         &self,
-        app_id: &str,
+        instance_id: &str,
         resource_rel: &str,
         temp_rel: &str,
         content: &[u8],
         request_id: &str,
     ) -> Result<()> {
-        let target_rel = format!("{}/{}", app_id, resource_rel);
+        let target_rel = {
+            let guard = self.runtimes.lock().await;
+            let runtime = guard
+                .get(instance_id)
+                .expect("runtime_loaded() should initialize runtime");
+            runtime.resource_fs_rel(resource_rel)
+        };
         self.write_file_bytes(temp_rel, content).await?;
 
-        self.mark_snapshot_journal_publishing(app_id, resource_rel, request_id, temp_rel)
+        self.mark_snapshot_journal_publishing(instance_id, resource_rel, request_id, temp_rel)
             .await?;
 
         let publish_delay_ms = snapshot_publish_delay_ms();
@@ -666,8 +871,14 @@ impl SnapshotReadThroughContext {
             std::thread::sleep(Duration::from_millis(publish_delay_ms));
         }
 
-        self.remove_file_if_exists(&target_rel).await?;
-        self.rename_path(temp_rel, &target_rel).await
+        if self.lookup_path(&target_rel).await?.is_some() {
+            // Keep the resource path present for readers. On Windows, a remove+rename publish can
+            // race with Get-Content and surface as a transient "path not found".
+            self.write_file_bytes(&target_rel, content).await?;
+            self.remove_file_if_exists(temp_rel).await
+        } else {
+            self.rename_path(temp_rel, &target_rel).await
+        }
     }
 
     async fn save_snapshot_expand_journal(
@@ -903,7 +1114,7 @@ impl SnapshotReadThroughContext {
 
 impl SnapshotReadThroughFile {
     async fn is_read_prepared(&self) -> bool {
-        self.state.lock().await.read_prepared
+        self.state.lock().await.read_buffer.is_some()
     }
 
     async fn is_cold_empty_placeholder(&self) -> Result<bool, agentfs_sdk::error::Error> {
@@ -943,32 +1154,60 @@ impl SnapshotReadThroughFile {
         Ok(file)
     }
 
-    async fn ensure_read_prepared(&self) -> Result<(), agentfs_sdk::error::Error> {
-        {
-            let state = self.state.lock().await;
-            if state.read_prepared {
-                return Ok(());
-            }
+    async fn cached_backing_buffer_if_usable(
+        &self,
+    ) -> Result<Option<Vec<u8>>, agentfs_sdk::error::Error> {
+        if snapshot_force_expand_on_refresh() {
+            return Ok(None);
         }
-
-        {
-            let mut state = self.state.lock().await;
-            if state.read_prepared {
-                return Ok(());
-            }
-            state.file = None;
-        }
-
-        self.ctx
-            .ensure_snapshot_materialized(&self.app_id, &self.resource_rel, "read")
+        let stats = self
+            .ctx
+            .lookup_path(&self.rel_path)
             .await
             .map_err(|err| map_anyhow_to_sdk_error(err, RAW_IO_ERROR))?;
-        let file = self.open_backing_file().await?;
+        let Some(stats) = stats else {
+            return Ok(None);
+        };
+        if stats.size <= 0 {
+            return Ok(None);
+        }
+        let bytes = self
+            .ctx
+            .read_file_if_exists(&self.rel_path)
+            .await
+            .map_err(|err| map_anyhow_to_sdk_error(err, RAW_IO_ERROR))?;
+        Ok(bytes)
+    }
+
+    async fn read_buffer(&self) -> Result<Vec<u8>, agentfs_sdk::error::Error> {
+        {
+            let state = self.state.lock().await;
+            if let Some(buffer) = state.read_buffer.as_ref() {
+                return Ok(buffer.clone());
+            }
+        }
+
+        if let Some(buffer) = self.cached_backing_buffer_if_usable().await? {
+            let mut state = self.state.lock().await;
+            if let Some(existing) = state.read_buffer.as_ref() {
+                return Ok(existing.clone());
+            }
+            state.read_buffer = Some(buffer.clone());
+            return Ok(buffer);
+        }
+
+        let buffer = self
+            .ctx
+            .read_snapshot_bytes(&self.app_id, &self.resource_rel, "read")
+            .await
+            .map_err(|err| map_anyhow_to_sdk_error(err, RAW_IO_ERROR))?;
 
         let mut state = self.state.lock().await;
-        state.file = Some(file);
-        state.read_prepared = true;
-        Ok(())
+        if let Some(existing) = state.read_buffer.as_ref() {
+            return Ok(existing.clone());
+        }
+        state.read_buffer = Some(buffer.clone());
+        Ok(buffer)
     }
 }
 
@@ -993,9 +1232,8 @@ impl agentfs_sdk::File for SnapshotReadThroughFile {
             );
             return Ok(Vec::new());
         }
-        self.ensure_read_prepared().await?;
-        let file = self.open_backing_file().await?;
-        file.pread(offset, size).await
+        let buffer = self.read_buffer().await?;
+        Ok(read_slice(&buffer, offset, size))
     }
 
     async fn pwrite(&self, offset: u64, data: &[u8]) -> Result<(), agentfs_sdk::error::Error> {
@@ -1405,13 +1643,31 @@ fn join_rel_path(parent: &str, name: &str) -> String {
     }
 }
 
-fn split_app_relative_path(rel_path: &str) -> Option<(&str, &str)> {
-    let trimmed = rel_path.trim_matches('/');
-    let (app_id, rest) = trimmed.split_once('/')?;
-    if app_id.is_empty() || rest.is_empty() {
+fn normalize_mount_path(path: &str) -> String {
+    path.trim().trim_matches(['/', '\\']).replace('\\', "/")
+}
+
+fn strip_mount_prefix<'a>(rel_path: &'a str, mount_path: &str) -> Option<&'a str> {
+    if mount_path.is_empty() {
         return None;
     }
-    Some((app_id, rest))
+    if rel_path == mount_path {
+        return None;
+    }
+    rel_path
+        .strip_prefix(mount_path)
+        .and_then(|rest| rest.strip_prefix('/'))
+        .filter(|rest| !rest.is_empty())
+}
+
+fn read_slice(buffer: &[u8], offset: u64, size: u64) -> Vec<u8> {
+    let start = usize::try_from(offset).unwrap_or(usize::MAX);
+    if start >= buffer.len() {
+        return Vec::new();
+    }
+    let size = usize::try_from(size).unwrap_or(usize::MAX);
+    let end = start.saturating_add(size).min(buffer.len());
+    buffer[start..end].to_vec()
 }
 
 fn io_error(errno: i32, message: String) -> std::io::Error {
@@ -1434,8 +1690,8 @@ fn map_anyhow_to_sdk_error(err: anyhow::Error, default_errno: i32) -> agentfs_sd
 mod tests {
     use super::{
         action_wake_is_relevant_path, open_requests_read, should_skip_existing_expand,
-        should_suppress_snapshot_probe_read, ActionWakeHandle, AppfsRuntimeCliArgs,
-        MountSnapshotReadThroughConfig, MountSnapshotReadThroughFs, MountSnapshotRuntime,
+        should_suppress_snapshot_probe_read, ActionWakeHandle, MountSnapshotReadThroughConfig,
+        MountSnapshotReadThroughFs, MountSnapshotRuntime, MountSnapshotRuntimeConfig,
         SnapshotOnTimeoutPolicy, SnapshotSpec, OPEN_NO_READ_HINT, OPEN_READ_ONLY, OPEN_READ_WRITE,
         OPEN_WRITE_ONLY, ROOT_INO,
     };
@@ -1533,6 +1789,7 @@ mod tests {
     #[derive(Clone)]
     struct FakeSnapshotConnector {
         fetch_count: Arc<AtomicUsize>,
+        contexts: Arc<std::sync::Mutex<Vec<ConnectorContext>>>,
         snapshot_lines: Vec<serde_json::Value>,
     }
 
@@ -1540,6 +1797,19 @@ mod tests {
         fn new(fetch_count: Arc<AtomicUsize>, snapshot_lines: Vec<serde_json::Value>) -> Self {
             Self {
                 fetch_count,
+                contexts: Arc::new(std::sync::Mutex::new(Vec::new())),
+                snapshot_lines,
+            }
+        }
+
+        fn with_contexts(
+            fetch_count: Arc<AtomicUsize>,
+            contexts: Arc<std::sync::Mutex<Vec<ConnectorContext>>>,
+            snapshot_lines: Vec<serde_json::Value>,
+        ) -> Self {
+            Self {
+                fetch_count,
+                contexts,
                 snapshot_lines,
             }
         }
@@ -1583,9 +1853,13 @@ mod tests {
         fn fetch_snapshot_chunk(
             &mut self,
             _request: FetchSnapshotChunkRequest,
-            _ctx: &ConnectorContext,
+            ctx: &ConnectorContext,
         ) -> std::result::Result<FetchSnapshotChunkResponse, ConnectorError> {
             self.fetch_count.fetch_add(1, Ordering::SeqCst);
+            self.contexts
+                .lock()
+                .expect("fake connector contexts")
+                .push(ctx.clone());
             let records = self
                 .snapshot_lines
                 .iter()
@@ -1658,19 +1932,49 @@ mod tests {
         resource_rel: &str,
         connector: Box<dyn AppConnector>,
     ) {
+        install_snapshot_runtime_at(
+            wrapper,
+            app_id,
+            app_id,
+            app_id,
+            None,
+            None,
+            resource_rel,
+            connector,
+        )
+        .await;
+    }
+
+    async fn install_snapshot_runtime_at(
+        wrapper: &MountSnapshotReadThroughFs,
+        instance_id: &str,
+        app_id: &str,
+        app_mount_path: &str,
+        principal_id: Option<&str>,
+        profile_id: Option<&str>,
+        resource_rel: &str,
+        connector: Box<dyn AppConnector>,
+    ) {
         wrapper.ctx.runtime_configs.lock().await.insert(
-            app_id.to_string(),
-            AppfsRuntimeCliArgs {
+            instance_id.to_string(),
+            MountSnapshotRuntimeConfig {
+                instance_id: instance_id.to_string(),
                 app_id: app_id.to_string(),
+                app_mount_path: app_mount_path.to_string(),
                 session_id: Some("sess-test".to_string()),
+                principal_id: principal_id.map(ToOwned::to_owned),
+                profile_id: profile_id.map(ToOwned::to_owned),
                 bridge: test_bridge_args(),
             },
         );
         wrapper.ctx.runtimes.lock().await.insert(
-            app_id.to_string(),
+            instance_id.to_string(),
             MountSnapshotRuntime {
                 app_id: app_id.to_string(),
+                app_mount_path: app_mount_path.to_string(),
                 session_id: "sess-test".to_string(),
+                principal_id: principal_id.map(ToOwned::to_owned),
+                profile_id: profile_id.map(ToOwned::to_owned),
                 snapshot_specs: vec![SnapshotSpec {
                     template: resource_rel.to_string(),
                     max_materialized_bytes: 1024 * 1024,
@@ -1763,10 +2067,174 @@ mod tests {
                 "first content read should perform exactly one expansion"
             );
 
-            let materialized = fs::read(&snapshot_path).expect("read materialized snapshot");
+            let placeholder = fs::read(&snapshot_path).expect("read snapshot placeholder");
+            assert!(
+                placeholder.is_empty(),
+                "pread read-through must not mutate the placeholder file"
+            );
+        });
+    }
+
+    #[test]
+    fn materialized_snapshot_pread_uses_backing_cache() {
+        let temp = TempDir::new().expect("tempdir");
+        let snapshot_rel = "aiim/chats/chat-001/messages.res.jsonl";
+        let snapshot_path = temp.path().join(snapshot_rel);
+        fs::create_dir_all(snapshot_path.parent().expect("snapshot parent"))
+            .expect("create snapshot parent");
+        fs::write(&snapshot_path, b"{\"id\":\"cached\",\"text\":\"hot\"}\n")
+            .expect("seed hot snapshot cache");
+
+        let wrapper = build_wrapper(&temp, None);
+        let fetch_count = Arc::new(AtomicUsize::new(0));
+
+        crate::get_runtime().block_on(async move {
+            install_snapshot_runtime(
+                &wrapper,
+                "aiim",
+                "chats/chat-001/messages.res.jsonl",
+                Box::new(FakeSnapshotConnector::new(
+                    fetch_count.clone(),
+                    vec![json!({"id":"upstream","text":"should not fetch"})],
+                )),
+            )
+            .await;
+
+            let snapshot = wrapper
+                .ctx
+                .lookup_path(snapshot_rel)
+                .await
+                .expect("lookup snapshot")
+                .expect("snapshot stats");
+            wrapper
+                .ctx
+                .cache_path(snapshot.ino, snapshot_rel.to_string())
+                .await;
+            let file = wrapper
+                .open(snapshot.ino, OPEN_READ_ONLY)
+                .await
+                .expect("open snapshot");
+            let bytes = file.pread(0, 4096).await.expect("read cached snapshot");
             assert_eq!(
-                String::from_utf8(materialized).expect("utf8"),
-                "{\"id\":\"m-1\",\"text\":\"hello\"}\n"
+                String::from_utf8(bytes).expect("utf8"),
+                "{\"id\":\"cached\",\"text\":\"hot\"}\n"
+            );
+            assert_eq!(
+                fetch_count.load(Ordering::SeqCst),
+                0,
+                "hot backing cache should not trigger another upstream read"
+            );
+        });
+    }
+
+    #[test]
+    fn private_mount_path_snapshot_readthrough_uses_instance_context() {
+        let temp = TempDir::new().expect("tempdir");
+        let snapshot_rel = "private/default/tinode/inbox/recent.res.jsonl";
+        let snapshot_path = temp.path().join(snapshot_rel);
+        fs::create_dir_all(snapshot_path.parent().expect("snapshot parent"))
+            .expect("create snapshot parent");
+        fs::write(&snapshot_path, b"").expect("seed snapshot placeholder");
+
+        let wrapper = build_wrapper(&temp, None);
+        let fetch_count = Arc::new(AtomicUsize::new(0));
+        let contexts = Arc::new(std::sync::Mutex::new(Vec::new()));
+
+        crate::get_runtime().block_on(async move {
+            install_snapshot_runtime_at(
+                &wrapper,
+                "tinode--default",
+                "tinode",
+                "private/default/tinode",
+                Some("default"),
+                Some("tinode:default"),
+                "inbox/recent.res.jsonl",
+                Box::new(FakeSnapshotConnector::with_contexts(
+                    fetch_count.clone(),
+                    contexts.clone(),
+                    vec![json!({"message_id":"m-1","text":"hello default"})],
+                )),
+            )
+            .await;
+
+            let snapshot = wrapper
+                .ctx
+                .lookup_path(snapshot_rel)
+                .await
+                .expect("lookup snapshot")
+                .expect("snapshot stats");
+            wrapper
+                .ctx
+                .cache_path(snapshot.ino, snapshot_rel.to_string())
+                .await;
+            let file = wrapper
+                .open(snapshot.ino, OPEN_READ_ONLY)
+                .await
+                .expect("open snapshot");
+            let bytes = file.pread(0, 4096).await.expect("read snapshot");
+            assert_eq!(
+                String::from_utf8(bytes).expect("utf8"),
+                "{\"message_id\":\"m-1\",\"text\":\"hello default\"}\n"
+            );
+            assert_eq!(fetch_count.load(Ordering::SeqCst), 1);
+
+            let contexts = contexts.lock().expect("contexts");
+            assert_eq!(contexts.len(), 1);
+            assert_eq!(contexts[0].app_id, "tinode");
+            assert_eq!(contexts[0].principal_id.as_deref(), Some("default"));
+            assert_eq!(contexts[0].profile_id.as_deref(), Some("tinode:default"));
+
+            let placeholder = fs::read(&snapshot_path).expect("read snapshot placeholder");
+            assert!(
+                placeholder.is_empty(),
+                "private app pread read-through must not mutate the placeholder file"
+            );
+        });
+    }
+
+    #[test]
+    fn existing_snapshot_publish_keeps_target_path_present() {
+        let temp = TempDir::new().expect("tempdir");
+        let snapshot_rel = "private/default/tinode/inbox/recent.res.jsonl";
+        let snapshot_path = temp.path().join(snapshot_rel);
+        fs::create_dir_all(snapshot_path.parent().expect("snapshot parent"))
+            .expect("create snapshot parent");
+        fs::write(&snapshot_path, b"").expect("seed snapshot placeholder");
+
+        let wrapper = build_wrapper(&temp, None);
+        let fetch_count = Arc::new(AtomicUsize::new(0));
+
+        crate::get_runtime().block_on(async move {
+            install_snapshot_runtime_at(
+                &wrapper,
+                "tinode--default",
+                "tinode",
+                "private/default/tinode",
+                Some("default"),
+                Some("tinode:default"),
+                "inbox/recent.res.jsonl",
+                Box::new(FakeSnapshotConnector::new(
+                    fetch_count.clone(),
+                    vec![json!({"new":true})],
+                )),
+            )
+            .await;
+
+            wrapper
+                .ctx
+                .ensure_snapshot_materialized("tinode--default", "inbox/recent.res.jsonl", "read")
+                .await
+                .expect("materialize snapshot");
+
+            assert!(snapshot_path.exists(), "target path should remain present");
+            assert_eq!(
+                fs::read_to_string(&snapshot_path).expect("read snapshot"),
+                "{\"new\":true}\n"
+            );
+            assert_eq!(
+                fetch_count.load(Ordering::SeqCst),
+                1,
+                "existing target should still refresh from connector"
             );
         });
     }
@@ -1939,6 +2407,9 @@ mod tests {
     #[test]
     fn only_safe_action_paths_trigger_wake() {
         assert!(action_wake_is_relevant_path("_appfs/register_app.act"));
+        assert!(action_wake_is_relevant_path(
+            "_appfs/principals/create_principal.act"
+        ));
         assert!(action_wake_is_relevant_path(
             "contacts/zhangsan/send_message.act"
         ));

--- a/cli/src/cmd/appfs/paging.rs
+++ b/cli/src/cmd/appfs/paging.rs
@@ -96,6 +96,8 @@ impl AppfsAdapter {
             request_id: request_id.to_string(),
             client_token: client_token.clone(),
             trace_id: None,
+            principal_id: self.principal_id.clone(),
+            profile_id: self.profile_id.clone(),
         };
         match self.connector.fetch_live_page(
             FetchLivePageRequest {

--- a/cli/src/cmd/appfs/registry.rs
+++ b/cli/src/cmd/appfs/registry.rs
@@ -7,6 +7,9 @@ use std::path::{Path, PathBuf};
 
 pub(crate) const APPFS_REGISTRY_VERSION: u32 = 1;
 pub(crate) const APPFS_REGISTRY_REL_PATH: &str = "_appfs/apps.registry.json";
+pub(crate) const APPFS_APP_POLICY_REGISTRY_REL_PATH: &str = "_appfs/app-policies.registry.json";
+pub(crate) const APPFS_PRINCIPAL_REGISTRY_REL_PATH: &str = "_appfs/principals.registry.json";
+pub(crate) const APPFS_DEFAULT_PRINCIPAL_ID: &str = "default";
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub(crate) struct AppfsAppsRegistryDoc {
@@ -17,12 +20,79 @@ pub(crate) struct AppfsAppsRegistryDoc {
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub(crate) struct AppfsRegisteredAppDoc {
+    pub(crate) instance_id: String,
     pub(crate) app_id: String,
+    pub(crate) visibility: AppfsRegisteredAppVisibility,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) parent_app_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) principal_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) profile_id: Option<String>,
+    pub(crate) path: String,
     pub(crate) transport: AppfsRegistryTransportDoc,
     pub(crate) session_id: String,
     pub(crate) registered_at: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) active_scope: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum AppfsRegisteredAppVisibility {
+    Public,
+    PrivateInstance,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct AppfsAppPolicyRegistryDoc {
+    pub(crate) version: u32,
+    #[serde(default)]
+    pub(crate) apps: Vec<AppfsAppPolicyRecord>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct AppfsAppPolicyRecord {
+    pub(crate) app_id: String,
+    pub(crate) visibility: AppfsAppPolicyVisibility,
+    pub(crate) connector: String,
+    pub(crate) transport: AppfsRegistryTransportDoc,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) path: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) path_template: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) profile_template: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) credential_policy: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum AppfsAppPolicyVisibility {
+    Public,
+    Private,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[allow(dead_code)]
+pub(crate) struct PrincipalRegistryDoc {
+    pub(crate) version: u32,
+    pub(crate) default_principal_id: String,
+    #[serde(default)]
+    pub(crate) principals: Vec<PrincipalRecord>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[allow(dead_code)]
+pub(crate) struct PrincipalRecord {
+    pub(crate) principal_id: String,
+    pub(crate) display_name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) description: Option<String>,
+    pub(crate) kind: String,
+    pub(crate) created_at: String,
+    pub(crate) updated_at: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -51,6 +121,20 @@ pub(crate) fn app_registry_path(root: &Path) -> PathBuf {
     root.join(APPFS_REGISTRY_REL_PATH.replace('/', std::path::MAIN_SEPARATOR_STR))
 }
 
+pub(crate) fn app_policy_registry_path(root: &Path) -> PathBuf {
+    root.join(APPFS_APP_POLICY_REGISTRY_REL_PATH.replace('/', std::path::MAIN_SEPARATOR_STR))
+}
+
+pub(crate) fn principal_registry_path(root: &Path) -> PathBuf {
+    root.join(APPFS_PRINCIPAL_REGISTRY_REL_PATH.replace('/', std::path::MAIN_SEPARATOR_STR))
+}
+
+pub(crate) fn principal_record_path(root: &Path, principal_id: &str) -> PathBuf {
+    root.join("_appfs")
+        .join("principals")
+        .join(format!("{principal_id}.res.json"))
+}
+
 pub(crate) fn parse_app_registry_bytes(bytes: &[u8]) -> Result<AppfsAppsRegistryDoc> {
     let doc: AppfsAppsRegistryDoc =
         serde_json::from_slice(bytes).context("failed to parse AppFS app registry JSON")?;
@@ -68,39 +152,96 @@ pub(crate) fn read_app_registry(root: &Path) -> Result<Option<AppfsAppsRegistryD
     parse_app_registry_bytes(&bytes).map(Some)
 }
 
-pub(crate) fn write_app_registry(root: &Path, doc: &AppfsAppsRegistryDoc) -> Result<()> {
-    validate_app_registry(doc)?;
-    let path = app_registry_path(root);
-    let parent = path
-        .parent()
-        .ok_or_else(|| anyhow::anyhow!("invalid registry path {}", path.display()))?;
-    fs::create_dir_all(parent).with_context(|| {
+pub(crate) fn read_principal_registry(root: &Path) -> Result<Option<PrincipalRegistryDoc>> {
+    let path = principal_registry_path(root);
+    if !path.exists() {
+        return Ok(None);
+    }
+    let bytes = fs::read(&path)
+        .with_context(|| format!("failed to read AppFS principal registry {}", path.display()))?;
+    let doc: PrincipalRegistryDoc =
+        serde_json::from_slice(&bytes).context("failed to parse AppFS principal registry JSON")?;
+    validate_principal_registry(&doc)?;
+    Ok(Some(doc))
+}
+
+pub(crate) fn read_app_policy_registry(root: &Path) -> Result<Option<AppfsAppPolicyRegistryDoc>> {
+    let path = app_policy_registry_path(root);
+    if !path.exists() {
+        return Ok(None);
+    }
+    let bytes = fs::read(&path).with_context(|| {
         format!(
-            "failed to create AppFS registry directory {}",
-            parent.display()
+            "failed to read AppFS app policy registry {}",
+            path.display()
         )
     })?;
-    let tmp_path = path.with_extension("json.tmp");
-    let bytes = serde_json::to_vec_pretty(doc).context("failed to serialize AppFS app registry")?;
-    fs::write(&tmp_path, bytes).with_context(|| {
-        format!(
-            "failed to write temporary AppFS registry {}",
-            tmp_path.display()
-        )
-    })?;
+    let doc: AppfsAppPolicyRegistryDoc =
+        serde_json::from_slice(&bytes).context("failed to parse AppFS app policy registry JSON")?;
+    validate_app_policy_registry(&doc)?;
+    Ok(Some(doc))
+}
+
+pub(crate) fn write_principal_registry(root: &Path, doc: &PrincipalRegistryDoc) -> Result<()> {
+    validate_principal_registry(doc)?;
+    let path = principal_registry_path(root);
+    write_pretty_json_file(&path, doc, "AppFS principal registry")
+}
+
+pub(crate) fn write_principal_record_view(root: &Path, record: &PrincipalRecord) -> Result<()> {
+    let path = principal_record_path(root, &record.principal_id);
+    write_pretty_json_file(&path, record, "AppFS principal record")
+}
+
+pub(crate) fn delete_principal_record_view(root: &Path, principal_id: &str) -> Result<()> {
+    let path = principal_record_path(root, principal_id);
     if path.exists() {
         fs::remove_file(&path).with_context(|| {
             format!(
-                "failed to replace existing AppFS registry {}",
+                "failed to remove AppFS principal record view {}",
                 path.display()
             )
         })?;
     }
-    fs::rename(&tmp_path, &path)
-        .with_context(|| format!("failed to publish AppFS registry {}", path.display()))?;
     Ok(())
 }
 
+pub(crate) fn write_app_policy_registry(
+    root: &Path,
+    doc: &AppfsAppPolicyRegistryDoc,
+) -> Result<()> {
+    validate_app_policy_registry(doc)?;
+    let path = app_policy_registry_path(root);
+    write_pretty_json_file(&path, doc, "AppFS app policy registry")
+}
+
+pub(crate) fn write_app_registry(root: &Path, doc: &AppfsAppsRegistryDoc) -> Result<()> {
+    validate_app_registry(doc)?;
+    let path = app_registry_path(root);
+    write_pretty_json_file(&path, doc, "AppFS app registry")
+}
+
+fn write_pretty_json_file<T: Serialize>(path: &Path, doc: &T, label: &str) -> Result<()> {
+    let parent = path
+        .parent()
+        .ok_or_else(|| anyhow::anyhow!("invalid registry path {}", path.display()))?;
+    fs::create_dir_all(parent)
+        .with_context(|| format!("failed to create {label} directory {}", parent.display()))?;
+    let tmp_path = path.with_extension("json.tmp");
+    let bytes =
+        serde_json::to_vec_pretty(doc).with_context(|| format!("failed to serialize {label}"))?;
+    fs::write(&tmp_path, bytes)
+        .with_context(|| format!("failed to write temporary {label} {}", tmp_path.display()))?;
+    if path.exists() {
+        fs::remove_file(&path)
+            .with_context(|| format!("failed to replace existing {label} {}", path.display()))?;
+    }
+    fs::rename(&tmp_path, &path)
+        .with_context(|| format!("failed to publish {label} {}", path.display()))?;
+    Ok(())
+}
+
+#[allow(dead_code)]
 pub(crate) fn build_app_registry_doc(
     runtime_args: &[ResolvedAppfsRuntimeCliArgs],
     active_scopes: &HashMap<String, Option<String>>,
@@ -110,7 +251,7 @@ pub(crate) fn build_app_registry_doc(
         .map(|doc| {
             doc.apps
                 .iter()
-                .map(|app| (app.app_id.clone(), app.registered_at.clone()))
+                .map(|app| (app.instance_id.clone(), app.registered_at.clone()))
                 .collect::<HashMap<_, _>>()
         })
         .unwrap_or_default();
@@ -120,7 +261,13 @@ pub(crate) fn build_app_registry_doc(
         apps: runtime_args
             .iter()
             .map(|runtime| AppfsRegisteredAppDoc {
+                instance_id: runtime.app_id.clone(),
                 app_id: runtime.app_id.clone(),
+                visibility: AppfsRegisteredAppVisibility::Public,
+                parent_app_id: None,
+                principal_id: None,
+                profile_id: None,
+                path: runtime.app_id.clone(),
                 transport: transport_doc_from_bridge_args(&runtime.bridge),
                 session_id: runtime.session_id.clone(),
                 registered_at: existing_registered_at
@@ -148,7 +295,9 @@ pub(crate) fn runtime_args_from_registry(
         .collect())
 }
 
-fn transport_doc_from_bridge_args(args: &AppfsBridgeCliArgs) -> AppfsRegistryTransportDoc {
+pub(crate) fn transport_doc_from_bridge_args(
+    args: &AppfsBridgeCliArgs,
+) -> AppfsRegistryTransportDoc {
     let (kind, endpoint) = if let Some(endpoint) = args.adapter_http_endpoint.clone() {
         (AppfsRegistryTransportKind::Http, Some(endpoint))
     } else if let Some(endpoint) = args.adapter_grpc_endpoint.clone() {
@@ -169,7 +318,9 @@ fn transport_doc_from_bridge_args(args: &AppfsBridgeCliArgs) -> AppfsRegistryTra
     }
 }
 
-fn bridge_args_from_transport_doc(doc: &AppfsRegistryTransportDoc) -> AppfsBridgeCliArgs {
+pub(crate) fn bridge_args_from_transport_doc(
+    doc: &AppfsRegistryTransportDoc,
+) -> AppfsBridgeCliArgs {
     let (adapter_http_endpoint, adapter_grpc_endpoint) = match doc.kind {
         AppfsRegistryTransportKind::InProcess => (None, None),
         AppfsRegistryTransportKind::Http => (doc.endpoint.clone(), None),
@@ -198,14 +349,53 @@ fn validate_app_registry(doc: &AppfsAppsRegistryDoc) -> Result<()> {
     }
     let mut seen = HashMap::new();
     for app in &doc.apps {
+        if app.instance_id.trim().is_empty() {
+            anyhow::bail!("registry instance_id cannot be empty");
+        }
         if app.app_id.trim().is_empty() {
             anyhow::bail!("registry app_id cannot be empty");
+        }
+        if app.path.trim().is_empty() {
+            anyhow::bail!("registry path cannot be empty for app {}", app.app_id);
         }
         if app.session_id.trim().is_empty() {
             anyhow::bail!("registry session_id cannot be empty for app {}", app.app_id);
         }
-        if seen.insert(app.app_id.clone(), ()).is_some() {
-            anyhow::bail!("duplicate registry app_id {}", app.app_id);
+        if seen.insert(app.instance_id.clone(), ()).is_some() {
+            anyhow::bail!("duplicate registry instance_id {}", app.instance_id);
+        }
+        match app.visibility {
+            AppfsRegisteredAppVisibility::Public => {
+                if app.principal_id.is_some()
+                    || app.profile_id.is_some()
+                    || app.parent_app_id.is_some()
+                {
+                    anyhow::bail!(
+                        "public registry app {} cannot define private instance identity fields",
+                        app.app_id
+                    );
+                }
+            }
+            AppfsRegisteredAppVisibility::PrivateInstance => {
+                if app
+                    .principal_id
+                    .as_deref()
+                    .map(str::trim)
+                    .filter(|value| !value.is_empty())
+                    .is_none()
+                {
+                    anyhow::bail!("private registry app {} requires principal_id", app.app_id);
+                }
+                if app
+                    .parent_app_id
+                    .as_deref()
+                    .map(str::trim)
+                    .filter(|value| !value.is_empty())
+                    .is_none()
+                {
+                    anyhow::bail!("private registry app {} requires parent_app_id", app.app_id);
+                }
+            }
         }
         match app.transport.kind {
             AppfsRegistryTransportKind::InProcess => {
@@ -236,11 +426,134 @@ fn validate_app_registry(doc: &AppfsAppsRegistryDoc) -> Result<()> {
     Ok(())
 }
 
+fn validate_app_policy_registry(doc: &AppfsAppPolicyRegistryDoc) -> Result<()> {
+    if doc.version != APPFS_REGISTRY_VERSION {
+        anyhow::bail!(
+            "unsupported AppFS app policy registry version {} (expected {})",
+            doc.version,
+            APPFS_REGISTRY_VERSION
+        );
+    }
+    let mut seen = HashMap::new();
+    for app in &doc.apps {
+        if app.app_id.trim().is_empty() {
+            anyhow::bail!("app policy app_id cannot be empty");
+        }
+        if app.connector.trim().is_empty() {
+            anyhow::bail!(
+                "app policy connector cannot be empty for app {}",
+                app.app_id
+            );
+        }
+        if seen.insert(app.app_id.clone(), ()).is_some() {
+            anyhow::bail!("duplicate app policy app_id {}", app.app_id);
+        }
+        match app.visibility {
+            AppfsAppPolicyVisibility::Public => {
+                if app
+                    .path
+                    .as_deref()
+                    .map(str::trim)
+                    .filter(|value| !value.is_empty())
+                    .is_none()
+                {
+                    anyhow::bail!("public app policy {} requires path", app.app_id);
+                }
+                if app.path_template.is_some() || app.profile_template.is_some() {
+                    anyhow::bail!(
+                        "public app policy {} cannot define private templates",
+                        app.app_id
+                    );
+                }
+            }
+            AppfsAppPolicyVisibility::Private => {
+                if app.path.is_some() {
+                    anyhow::bail!("private app policy {} cannot define path", app.app_id);
+                }
+                let Some(path_template) = app.path_template.as_deref() else {
+                    anyhow::bail!("private app policy {} requires path_template", app.app_id);
+                };
+                if !path_template.contains("{principal_id}") {
+                    anyhow::bail!(
+                        "private app policy {} path_template must contain {{principal_id}}",
+                        app.app_id
+                    );
+                }
+                if let Some(profile_template) = app.profile_template.as_deref() {
+                    if !profile_template.contains("{principal_id}") {
+                        anyhow::bail!(
+                            "private app policy {} profile_template must contain {{principal_id}}",
+                            app.app_id
+                        );
+                    }
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+fn validate_principal_registry(doc: &PrincipalRegistryDoc) -> Result<()> {
+    if doc.version != APPFS_REGISTRY_VERSION {
+        anyhow::bail!(
+            "unsupported AppFS principal registry version {} (expected {})",
+            doc.version,
+            APPFS_REGISTRY_VERSION
+        );
+    }
+    validate_principal_id(&doc.default_principal_id)?;
+    let mut seen = HashMap::new();
+    for principal in &doc.principals {
+        validate_principal_id(&principal.principal_id)?;
+        if principal.display_name.trim().is_empty() {
+            anyhow::bail!(
+                "principal {} display_name cannot be empty",
+                principal.principal_id
+            );
+        }
+        if principal.kind.trim().is_empty() {
+            anyhow::bail!("principal {} kind cannot be empty", principal.principal_id);
+        }
+        if principal.created_at.trim().is_empty() || principal.updated_at.trim().is_empty() {
+            anyhow::bail!(
+                "principal {} timestamps cannot be empty",
+                principal.principal_id
+            );
+        }
+        if seen.insert(principal.principal_id.clone(), ()).is_some() {
+            anyhow::bail!("duplicate principal_id {}", principal.principal_id);
+        }
+    }
+    Ok(())
+}
+
+pub(crate) fn validate_principal_id(principal_id: &str) -> Result<()> {
+    if principal_id.trim() != principal_id || principal_id.is_empty() {
+        anyhow::bail!("principal_id cannot be empty or contain leading/trailing whitespace");
+    }
+    if principal_id == "." || principal_id == ".." {
+        anyhow::bail!("principal_id cannot be . or ..");
+    }
+    if principal_id.len() > 120 {
+        anyhow::bail!("principal_id cannot exceed 120 bytes");
+    }
+    if principal_id.contains(['/', '\\', '\0', ':']) {
+        anyhow::bail!("principal_id cannot contain path separators, NUL, or drive separators");
+    }
+    if !principal_id
+        .chars()
+        .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '_' | '-'))
+    {
+        anyhow::bail!("principal_id can only contain ASCII letters, digits, _ and -");
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
         app_registry_path, build_app_registry_doc, parse_app_registry_bytes, read_app_registry,
-        runtime_args_from_registry, write_app_registry,
+        runtime_args_from_registry, write_app_registry, AppfsRegisteredAppVisibility,
     };
     use crate::cmd::appfs::{AppfsBridgeCliArgs, ResolvedAppfsRuntimeCliArgs};
     use std::collections::HashMap;
@@ -277,7 +590,13 @@ mod tests {
             .expect("read registry")
             .expect("registry exists");
         assert_eq!(stored.apps.len(), 1);
+        assert_eq!(stored.apps[0].instance_id, "aiim");
         assert_eq!(stored.apps[0].app_id, "aiim");
+        assert_eq!(
+            stored.apps[0].visibility,
+            AppfsRegisteredAppVisibility::Public
+        );
+        assert_eq!(stored.apps[0].path, "aiim");
         assert_eq!(stored.apps[0].session_id, "sess-aiim");
         assert_eq!(stored.apps[0].active_scope.as_deref(), Some("chat-001"));
 
@@ -292,9 +611,16 @@ mod tests {
 
     #[test]
     fn registry_rejects_corrupt_payload() {
-        let err = parse_app_registry_bytes(br#"{"version":1,"apps":[{"app_id":"","session_id":"s","registered_at":"2026-03-25T00:00:00Z","transport":{"kind":"in_process","http_timeout_ms":1,"grpc_timeout_ms":1,"bridge_max_retries":1,"bridge_initial_backoff_ms":1,"bridge_max_backoff_ms":1,"bridge_circuit_breaker_failures":1,"bridge_circuit_breaker_cooldown_ms":1}}]}"#)
+        let err = parse_app_registry_bytes(br#"{"version":1,"apps":[{"instance_id":"bad","app_id":"","visibility":"public","path":"bad","session_id":"s","registered_at":"2026-03-25T00:00:00Z","transport":{"kind":"in_process","http_timeout_ms":1,"grpc_timeout_ms":1,"bridge_max_retries":1,"bridge_initial_backoff_ms":1,"bridge_max_backoff_ms":1,"bridge_circuit_breaker_failures":1,"bridge_circuit_breaker_cooldown_ms":1}}]}"#)
             .expect_err("invalid registry should fail");
         assert!(err.to_string().contains("app_id cannot be empty"));
+    }
+
+    #[test]
+    fn registry_rejects_old_app_registry_format() {
+        let err = parse_app_registry_bytes(br#"{"version":1,"apps":[{"app_id":"aiim","session_id":"sess-aiim","registered_at":"2026-03-25T00:00:00Z","active_scope":null,"transport":{"kind":"http","endpoint":"http://127.0.0.1:8080","http_timeout_ms":1,"grpc_timeout_ms":1,"bridge_max_retries":1,"bridge_initial_backoff_ms":1,"bridge_max_backoff_ms":1,"bridge_circuit_breaker_failures":1,"bridge_circuit_breaker_cooldown_ms":1}}]}"#)
+            .expect_err("old registry should fail");
+        assert!(format!("{err:#}").contains("missing field `instance_id`"));
     }
 
     #[test]

--- a/cli/src/cmd/appfs/registry_manager.rs
+++ b/cli/src/cmd/appfs/registry_manager.rs
@@ -1,6 +1,7 @@
 use super::action_dispatcher::RegisterAppRequest;
 use super::registry;
 use super::runtime_entry::read_active_scope;
+use super::runtime_entry::AppRuntimeRegistryMetadata;
 use super::{normalize_appfs_session_id, resolve_runtime_cli_args, ResolvedAppfsRuntimeCliArgs};
 use anyhow::Result;
 use std::collections::HashMap;
@@ -9,6 +10,7 @@ use std::path::{Path, PathBuf};
 pub(super) struct RegistryRuntimeSnapshot {
     pub(super) runtime: ResolvedAppfsRuntimeCliArgs,
     pub(super) app_dir: PathBuf,
+    pub(super) metadata: AppRuntimeRegistryMetadata,
 }
 
 pub(super) fn persist_runtime_registry(
@@ -20,20 +22,38 @@ pub(super) fn persist_runtime_registry(
         Some(existing) => Some(existing.clone()),
         None => registry::read_app_registry(root)?,
     };
-    let active_scopes = snapshots
-        .iter()
-        .map(|snapshot| {
-            (
-                snapshot.runtime.app_id.clone(),
-                read_active_scope(&snapshot.app_dir),
-            )
+    let existing_registered_at = existing
+        .as_ref()
+        .map(|doc| {
+            doc.apps
+                .iter()
+                .map(|app| (app.instance_id.clone(), app.registered_at.clone()))
+                .collect::<HashMap<_, _>>()
         })
-        .collect::<HashMap<_, _>>();
-    let runtime_args = snapshots
-        .iter()
-        .map(|snapshot| snapshot.runtime.clone())
-        .collect::<Vec<_>>();
-    let doc = registry::build_app_registry_doc(&runtime_args, &active_scopes, existing.as_ref());
+        .unwrap_or_default();
+    let now = chrono::Utc::now().to_rfc3339();
+    let doc = registry::AppfsAppsRegistryDoc {
+        version: registry::APPFS_REGISTRY_VERSION,
+        apps: snapshots
+            .iter()
+            .map(|snapshot| registry::AppfsRegisteredAppDoc {
+                instance_id: snapshot.metadata.instance_id.clone(),
+                app_id: snapshot.runtime.app_id.clone(),
+                visibility: snapshot.metadata.visibility,
+                parent_app_id: snapshot.metadata.parent_app_id.clone(),
+                principal_id: snapshot.metadata.principal_id.clone(),
+                profile_id: snapshot.metadata.profile_id.clone(),
+                path: snapshot.metadata.path.clone(),
+                transport: registry::transport_doc_from_bridge_args(&snapshot.runtime.bridge),
+                session_id: snapshot.runtime.session_id.clone(),
+                registered_at: existing_registered_at
+                    .get(&snapshot.metadata.instance_id)
+                    .cloned()
+                    .unwrap_or_else(|| now.clone()),
+                active_scope: read_active_scope(&snapshot.app_dir),
+            })
+            .collect(),
+    };
     if existing.as_ref() == Some(&doc) {
         return Ok(());
     }
@@ -47,7 +67,13 @@ pub(super) fn register_request_to_runtime(
     let doc = registry::AppfsAppsRegistryDoc {
         version: registry::APPFS_REGISTRY_VERSION,
         apps: vec![registry::AppfsRegisteredAppDoc {
-            app_id: request.app_id,
+            instance_id: request.app_id.clone(),
+            app_id: request.app_id.clone(),
+            visibility: registry::AppfsRegisteredAppVisibility::Public,
+            parent_app_id: None,
+            principal_id: None,
+            profile_id: None,
+            path: request.app_id.clone(),
             transport: request.transport,
             session_id: session_id.clone(),
             registered_at: chrono::Utc::now().to_rfc3339(),

--- a/cli/src/cmd/appfs/runtime_entry.rs
+++ b/cli/src/cmd/appfs/runtime_entry.rs
@@ -10,6 +10,17 @@ use std::path::Path;
 pub(super) struct AppRuntimeEntry {
     pub(super) runtime: ResolvedAppfsRuntimeCliArgs,
     pub(super) adapter: AppfsAdapter,
+    pub(super) registry_metadata: AppRuntimeRegistryMetadata,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct AppRuntimeRegistryMetadata {
+    pub(super) instance_id: String,
+    pub(super) visibility: crate::cmd::appfs::registry::AppfsRegisteredAppVisibility,
+    pub(super) parent_app_id: Option<String>,
+    pub(super) principal_id: Option<String>,
+    pub(super) profile_id: Option<String>,
+    pub(super) path: String,
 }
 
 pub(super) fn build_runtime_entry(
@@ -17,22 +28,48 @@ pub(super) fn build_runtime_entry(
     runtime: ResolvedAppfsRuntimeCliArgs,
     startup_bootstrap: Option<AppRuntimeStartupBootstrap>,
 ) -> Result<AppRuntimeEntry> {
-    let adapter = match startup_bootstrap {
-        Some(startup_bootstrap) => AppfsAdapter::new_with_bootstrap(
-            root.to_path_buf(),
-            runtime.app_id.clone(),
-            runtime.session_id.clone(),
-            build_appfs_bridge_config(runtime.bridge.clone()),
-            Some(startup_bootstrap),
-        )?,
-        None => AppfsAdapter::new(
-            root.to_path_buf(),
-            runtime.app_id.clone(),
-            runtime.session_id.clone(),
-            build_appfs_bridge_config(runtime.bridge.clone()),
-        )?,
-    };
-    Ok(AppRuntimeEntry { runtime, adapter })
+    build_runtime_entry_with_metadata(
+        root,
+        runtime.clone(),
+        AppRuntimeRegistryMetadata::public(runtime.app_id.clone()),
+        startup_bootstrap,
+    )
+}
+
+pub(super) fn build_runtime_entry_with_metadata(
+    root: &Path,
+    runtime: ResolvedAppfsRuntimeCliArgs,
+    metadata: AppRuntimeRegistryMetadata,
+    startup_bootstrap: Option<AppRuntimeStartupBootstrap>,
+) -> Result<AppRuntimeEntry> {
+    let adapter = AppfsAdapter::new_with_mount_path(
+        root.to_path_buf(),
+        runtime.app_id.clone(),
+        metadata.path.clone(),
+        metadata.principal_id.clone(),
+        metadata.profile_id.clone(),
+        runtime.session_id.clone(),
+        build_appfs_bridge_config(runtime.bridge.clone()),
+        startup_bootstrap,
+    )?;
+    Ok(AppRuntimeEntry {
+        runtime,
+        adapter,
+        registry_metadata: metadata,
+    })
+}
+
+impl AppRuntimeRegistryMetadata {
+    pub(super) fn public(app_id: String) -> Self {
+        Self {
+            instance_id: app_id.clone(),
+            visibility: crate::cmd::appfs::registry::AppfsRegisteredAppVisibility::Public,
+            parent_app_id: None,
+            principal_id: None,
+            profile_id: None,
+            path: app_id,
+        }
+    }
 }
 
 pub(super) fn read_active_scope(app_dir: &Path) -> Option<String> {

--- a/cli/src/cmd/appfs/runtime_manifest.rs
+++ b/cli/src/cmd/appfs/runtime_manifest.rs
@@ -12,7 +12,11 @@ pub(crate) const APPFS_MULTI_AGENT_MODE_SHARED: &str = "shared_mount_distinct_at
 const CONTROL_REGISTER_ACTION_PATH: &str = "/_appfs/register_app.act";
 const CONTROL_UNREGISTER_ACTION_PATH: &str = "/_appfs/unregister_app.act";
 const CONTROL_LIST_ACTION_PATH: &str = "/_appfs/list_apps.act";
+const CONTROL_CREATE_PRINCIPAL_ACTION_PATH: &str = "/_appfs/principals/create_principal.act";
+const CONTROL_UPDATE_PRINCIPAL_ACTION_PATH: &str = "/_appfs/principals/update_principal.act";
+const CONTROL_DELETE_PRINCIPAL_ACTION_PATH: &str = "/_appfs/principals/delete_principal.act";
 const CONTROL_REGISTRY_PATH: &str = "/_appfs/apps.registry.json";
+const CONTROL_PRINCIPALS_REGISTRY_PATH: &str = "/_appfs/principals.registry.json";
 const CONTROL_EVENTS_PATH: &str = "/_appfs/_stream/events.evt.jsonl";
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -20,7 +24,11 @@ pub(crate) struct AppfsRuntimeManifestControlPlaneDoc {
     pub(crate) register_action: String,
     pub(crate) unregister_action: String,
     pub(crate) list_action: String,
+    pub(crate) create_principal_action: String,
+    pub(crate) update_principal_action: String,
+    pub(crate) delete_principal_action: String,
     pub(crate) registry: String,
+    pub(crate) principals_registry: String,
     pub(crate) events: String,
 }
 
@@ -71,7 +79,11 @@ pub(crate) fn build_runtime_manifest(
             register_action: CONTROL_REGISTER_ACTION_PATH.to_string(),
             unregister_action: CONTROL_UNREGISTER_ACTION_PATH.to_string(),
             list_action: CONTROL_LIST_ACTION_PATH.to_string(),
+            create_principal_action: CONTROL_CREATE_PRINCIPAL_ACTION_PATH.to_string(),
+            update_principal_action: CONTROL_UPDATE_PRINCIPAL_ACTION_PATH.to_string(),
+            delete_principal_action: CONTROL_DELETE_PRINCIPAL_ACTION_PATH.to_string(),
             registry: CONTROL_REGISTRY_PATH.to_string(),
+            principals_registry: CONTROL_PRINCIPALS_REGISTRY_PATH.to_string(),
             events: CONTROL_EVENTS_PATH.to_string(),
         },
         capabilities: AppfsRuntimeManifestCapabilitiesDoc {

--- a/cli/src/cmd/appfs/runtime_supervisor.rs
+++ b/cli/src/cmd/appfs/runtime_supervisor.rs
@@ -2,7 +2,8 @@ use super::action_dispatcher;
 use super::registry;
 use super::registry_manager::{self, RegistryRuntimeSnapshot};
 use super::runtime_entry::{
-    build_runtime_entry, read_active_scope, transport_summary, AppRuntimeEntry,
+    build_runtime_entry, build_runtime_entry_with_metadata, read_active_scope, transport_summary,
+    AppRuntimeEntry, AppRuntimeRegistryMetadata,
 };
 use super::runtime_manifest;
 use super::supervisor_control;
@@ -54,6 +55,8 @@ impl AppfsRuntimeSupervisor {
 
     pub(super) fn prepare_action_sinks(&mut self) -> Result<()> {
         self.control_plane.prepare_action_sinks()?;
+        self.ensure_default_principal_for_private_policies()?;
+        self.materialize_private_apps_for_existing_principals()?;
         for entry in self.runtimes.values_mut() {
             entry.adapter.prepare_action_sinks()?;
         }
@@ -65,6 +68,7 @@ impl AppfsRuntimeSupervisor {
         for invocation in invocations {
             self.handle_control_invocation(invocation)?;
         }
+        self.materialize_private_apps_for_existing_principals()?;
         for entry in self.runtimes.values_mut() {
             entry.adapter.poll_once()?;
         }
@@ -108,6 +112,7 @@ impl AppfsRuntimeSupervisor {
             .map(|entry| RegistryRuntimeSnapshot {
                 runtime: entry.runtime.clone(),
                 app_dir: entry.adapter.app_dir.clone(),
+                metadata: entry.registry_metadata.clone(),
             })
             .collect::<Vec<_>>();
         registry_manager::persist_runtime_registry(&self.root, &snapshots, existing)
@@ -132,6 +137,21 @@ impl AppfsRuntimeSupervisor {
                 request_id,
                 client_token,
             } => self.handle_list_apps(&request_id, client_token),
+            supervisor_control::SupervisorControlInvocation::CreatePrincipal {
+                request_id,
+                client_token,
+                request,
+            } => self.handle_create_principal(&request_id, client_token, request),
+            supervisor_control::SupervisorControlInvocation::UpdatePrincipal {
+                request_id,
+                client_token,
+                request,
+            } => self.handle_update_principal(&request_id, client_token, request),
+            supervisor_control::SupervisorControlInvocation::DeletePrincipal {
+                request_id,
+                client_token,
+                request,
+            } => self.handle_delete_principal(&request_id, client_token, request),
         }
     }
 
@@ -250,4 +270,277 @@ impl AppfsRuntimeSupervisor {
         )?;
         Ok(())
     }
+
+    fn handle_create_principal(
+        &mut self,
+        request_id: &str,
+        client_token: Option<String>,
+        request: action_dispatcher::CreatePrincipalRequest,
+    ) -> Result<()> {
+        let mut doc = self.load_principal_registry()?;
+        if let Some(existing) = doc
+            .principals
+            .iter()
+            .find(|principal| principal.principal_id == request.principal_id)
+            .cloned()
+        {
+            registry::write_principal_record_view(&self.root, &existing)?;
+            let materialized = self.materialize_private_apps_for_principal(&existing)?;
+            self.control_plane.emit_completed(
+                "/_appfs/principals/create_principal.act",
+                request_id,
+                serde_json::json!({
+                    "principal_event": "principal.exists",
+                    "principal_id": existing.principal_id,
+                    "created": false,
+                    "exists": true,
+                    "app_instances": materialized,
+                }),
+                client_token,
+            )?;
+            return Ok(());
+        }
+
+        let now = chrono::Utc::now().to_rfc3339();
+        let record = registry::PrincipalRecord {
+            principal_id: request.principal_id,
+            display_name: request.display_name,
+            description: request.description,
+            kind: request.kind,
+            created_at: now.clone(),
+            updated_at: now,
+        };
+        doc.principals.push(record.clone());
+        registry::write_principal_registry(&self.root, &doc)?;
+        registry::write_principal_record_view(&self.root, &record)?;
+        let materialized = self.materialize_private_apps_for_principal(&record)?;
+        self.control_plane.emit_completed(
+            "/_appfs/principals/create_principal.act",
+            request_id,
+            serde_json::json!({
+                "principal_event": "principal.created",
+                "principal_id": record.principal_id,
+                "created": true,
+                "app_instances": materialized,
+            }),
+            client_token,
+        )?;
+        Ok(())
+    }
+
+    fn handle_update_principal(
+        &mut self,
+        request_id: &str,
+        client_token: Option<String>,
+        request: action_dispatcher::UpdatePrincipalRequest,
+    ) -> Result<()> {
+        let mut doc = self.load_principal_registry()?;
+        let Some(record) = doc
+            .principals
+            .iter_mut()
+            .find(|principal| principal.principal_id == request.principal_id)
+        else {
+            self.control_plane.emit_failed(
+                "/_appfs/principals/update_principal.act",
+                request_id,
+                "PRINCIPAL_NOT_FOUND",
+                &format!("principal {} is not registered", request.principal_id),
+                client_token,
+            )?;
+            return Ok(());
+        };
+
+        if let Some(display_name) = request.display_name {
+            record.display_name = display_name;
+        }
+        if let Some(description) = request.description {
+            record.description = Some(description);
+        }
+        if let Some(kind) = request.kind {
+            record.kind = kind;
+        }
+        record.updated_at = chrono::Utc::now().to_rfc3339();
+        let updated = record.clone();
+        registry::write_principal_registry(&self.root, &doc)?;
+        registry::write_principal_record_view(&self.root, &updated)?;
+        self.control_plane.emit_completed(
+            "/_appfs/principals/update_principal.act",
+            request_id,
+            serde_json::json!({
+                "principal_event": "principal.updated",
+                "principal_id": updated.principal_id,
+                "updated": true,
+            }),
+            client_token,
+        )?;
+        Ok(())
+    }
+
+    fn handle_delete_principal(
+        &mut self,
+        request_id: &str,
+        client_token: Option<String>,
+        request: action_dispatcher::DeletePrincipalRequest,
+    ) -> Result<()> {
+        let mut doc = self.load_principal_registry()?;
+        let before = doc.principals.len();
+        doc.principals
+            .retain(|principal| principal.principal_id != request.principal_id);
+        if doc.principals.len() == before {
+            self.control_plane.emit_failed(
+                "/_appfs/principals/delete_principal.act",
+                request_id,
+                "PRINCIPAL_NOT_FOUND",
+                &format!("principal {} is not registered", request.principal_id),
+                client_token,
+            )?;
+            return Ok(());
+        }
+        let credential_cleanup_requests = self
+            .runtimes
+            .values()
+            .filter(|entry| {
+                entry.registry_metadata.principal_id.as_deref()
+                    == Some(request.principal_id.as_str())
+            })
+            .filter_map(|entry| {
+                let profile_id = entry.registry_metadata.profile_id.as_ref()?;
+                Some(serde_json::json!({
+                    "instance_id": entry.registry_metadata.instance_id.as_str(),
+                    "app_id": entry.runtime.app_id.as_str(),
+                    "principal_id": request.principal_id.as_str(),
+                    "profile_id": profile_id,
+                    "status": "requested",
+                }))
+            })
+            .collect::<Vec<_>>();
+        registry::write_principal_registry(&self.root, &doc)?;
+        registry::delete_principal_record_view(&self.root, &request.principal_id)?;
+        self.control_plane.emit_completed(
+            "/_appfs/principals/delete_principal.act",
+            request_id,
+            serde_json::json!({
+                "principal_event": "principal.deleted",
+                "principal_id": request.principal_id,
+                "deleted": true,
+                "credentials_cleanup": "requested",
+                "credential_cleanup_requests": credential_cleanup_requests,
+            }),
+            client_token,
+        )?;
+        Ok(())
+    }
+
+    fn load_principal_registry(&self) -> Result<registry::PrincipalRegistryDoc> {
+        Ok(registry::read_principal_registry(&self.root)?.unwrap_or(
+            registry::PrincipalRegistryDoc {
+                version: registry::APPFS_REGISTRY_VERSION,
+                default_principal_id: registry::APPFS_DEFAULT_PRINCIPAL_ID.to_string(),
+                principals: Vec::new(),
+            },
+        ))
+    }
+
+    fn ensure_default_principal_for_private_policies(&mut self) -> Result<()> {
+        let Some(policy_doc) = registry::read_app_policy_registry(&self.root)? else {
+            return Ok(());
+        };
+        if !policy_doc
+            .apps
+            .iter()
+            .any(|policy| policy.visibility == registry::AppfsAppPolicyVisibility::Private)
+        {
+            return Ok(());
+        }
+
+        let mut doc = self.load_principal_registry()?;
+        if doc
+            .principals
+            .iter()
+            .any(|principal| principal.principal_id == registry::APPFS_DEFAULT_PRINCIPAL_ID)
+        {
+            return Ok(());
+        }
+
+        let now = chrono::Utc::now().to_rfc3339();
+        let record = registry::PrincipalRecord {
+            principal_id: registry::APPFS_DEFAULT_PRINCIPAL_ID.to_string(),
+            display_name: "Default agent".to_string(),
+            description: Some("The default AppFS agent principal.".to_string()),
+            kind: "agent".to_string(),
+            created_at: now.clone(),
+            updated_at: now,
+        };
+        doc.principals.push(record.clone());
+        registry::write_principal_registry(&self.root, &doc)?;
+        registry::write_principal_record_view(&self.root, &record)
+    }
+
+    fn materialize_private_apps_for_existing_principals(&mut self) -> Result<()> {
+        let doc = self.load_principal_registry()?;
+        for principal in doc.principals {
+            self.materialize_private_apps_for_principal(&principal)?;
+        }
+        Ok(())
+    }
+
+    fn materialize_private_apps_for_principal(
+        &mut self,
+        principal: &registry::PrincipalRecord,
+    ) -> Result<Vec<serde_json::Value>> {
+        let Some(policy_doc) = registry::read_app_policy_registry(&self.root)? else {
+            return Ok(Vec::new());
+        };
+        let mut materialized = Vec::new();
+        for policy in policy_doc
+            .apps
+            .iter()
+            .filter(|policy| policy.visibility == registry::AppfsAppPolicyVisibility::Private)
+        {
+            let instance_id = format!("{}--{}", policy.app_id, principal.principal_id);
+            if self.runtimes.contains_key(&instance_id) {
+                continue;
+            }
+            let path_template = policy.path_template.as_deref().ok_or_else(|| {
+                anyhow::anyhow!("private app policy {} missing path_template", policy.app_id)
+            })?;
+            let path = render_principal_template(path_template, &principal.principal_id);
+            let profile_id = policy
+                .profile_template
+                .as_deref()
+                .map(|template| render_principal_template(template, &principal.principal_id))
+                .unwrap_or_else(|| format!("{}:{}", policy.app_id, principal.principal_id));
+            let runtime = ResolvedAppfsRuntimeCliArgs {
+                app_id: policy.app_id.clone(),
+                session_id: super::normalize_appfs_session_id(None),
+                bridge: registry::bridge_args_from_transport_doc(&policy.transport),
+            };
+            let metadata = AppRuntimeRegistryMetadata {
+                instance_id: instance_id.clone(),
+                visibility: registry::AppfsRegisteredAppVisibility::PrivateInstance,
+                parent_app_id: Some(policy.app_id.clone()),
+                principal_id: Some(principal.principal_id.clone()),
+                profile_id: Some(profile_id.clone()),
+                path: path.clone(),
+            };
+            let mut entry = build_runtime_entry_with_metadata(&self.root, runtime, metadata, None)?;
+            entry.adapter.prepare_action_sinks()?;
+            self.runtimes.insert(instance_id.clone(), entry);
+            materialized.push(serde_json::json!({
+                "instance_id": instance_id,
+                "app_id": policy.app_id,
+                "principal_id": principal.principal_id,
+                "profile_id": profile_id,
+                "path": path,
+            }));
+        }
+        if !materialized.is_empty() {
+            self.sync_registry_to_disk(None)?;
+        }
+        Ok(materialized)
+    }
+}
+
+fn render_principal_template(template: &str, principal_id: &str) -> String {
+    template.replace("{principal_id}", principal_id)
 }

--- a/cli/src/cmd/appfs/snapshot_cache.rs
+++ b/cli/src/cmd/appfs/snapshot_cache.rs
@@ -52,6 +52,8 @@ impl AppfsAdapter {
                 request_id,
                 client_token: None,
                 trace_id: None,
+                principal_id: self.principal_id.clone(),
+                profile_id: self.profile_id.clone(),
             };
             match self
                 .connector
@@ -694,6 +696,8 @@ impl AppfsAdapter {
                 request_id: request_id.to_string(),
                 client_token: None,
                 trace_id: None,
+                principal_id: self.principal_id.clone(),
+                profile_id: self.profile_id.clone(),
             };
             let response = self
                 .connector

--- a/cli/src/cmd/appfs/supervisor_control.rs
+++ b/cli/src/cmd/appfs/supervisor_control.rs
@@ -8,8 +8,10 @@ use std::path::{Path, PathBuf};
 use uuid::Uuid;
 
 use super::action_dispatcher::{
-    normalize_actionline_payload, parse_list_apps_request, parse_register_app_request,
-    parse_unregister_app_request, RegisterAppRequest, UnregisterAppRequest,
+    normalize_actionline_payload, parse_create_principal_request, parse_delete_principal_request,
+    parse_list_apps_request, parse_register_app_request, parse_unregister_app_request,
+    parse_update_principal_request, CreatePrincipalRequest, DeletePrincipalRequest,
+    RegisterAppRequest, UnregisterAppRequest, UpdatePrincipalRequest,
 };
 use super::errors::{ERR_INVALID_ARGUMENT, ERR_INVALID_PAYLOAD};
 use super::shared::{decode_jsonl_line, extract_client_token};
@@ -20,6 +22,9 @@ const CONTROL_SESSION_ID: &str = "runtime-control";
 const CONTROL_REGISTER_ACTION: &str = "register_app.act";
 const CONTROL_UNREGISTER_ACTION: &str = "unregister_app.act";
 const CONTROL_LIST_ACTION: &str = "list_apps.act";
+const CONTROL_CREATE_PRINCIPAL_ACTION: &str = "principals/create_principal.act";
+const CONTROL_UPDATE_PRINCIPAL_ACTION: &str = "principals/update_principal.act";
+const CONTROL_DELETE_PRINCIPAL_ACTION: &str = "principals/delete_principal.act";
 
 type NormalizedPayload = (String, Option<String>);
 type NormalizePayloadError = (&'static str, &'static str, Option<String>);
@@ -39,6 +44,21 @@ pub(super) enum SupervisorControlInvocation {
     List {
         request_id: String,
         client_token: Option<String>,
+    },
+    CreatePrincipal {
+        request_id: String,
+        client_token: Option<String>,
+        request: CreatePrincipalRequest,
+    },
+    UpdatePrincipal {
+        request_id: String,
+        client_token: Option<String>,
+        request: UpdatePrincipalRequest,
+    },
+    DeletePrincipal {
+        request_id: String,
+        client_token: Option<String>,
+        request: DeletePrincipalRequest,
     },
 }
 
@@ -78,8 +98,10 @@ impl SupervisorControlPlane {
 
     pub(super) fn prepare_action_sinks(&mut self) -> Result<()> {
         let control_dir = self.root.join(CONTROL_APP_ID);
+        let principals_dir = control_dir.join("principals");
         let stream_dir = control_dir.join("_stream");
         ensure_dir_exists(&control_dir, "AppFS control dir")?;
+        ensure_dir_exists(&principals_dir, "AppFS principals control dir")?;
         ensure_dir_exists(&stream_dir, "AppFS control stream dir")?;
         ensure_dir_exists(&self.replay_dir, "AppFS control replay dir")?;
         if !self.events_path.exists() {
@@ -110,6 +132,9 @@ impl SupervisorControlPlane {
             CONTROL_REGISTER_ACTION,
             CONTROL_UNREGISTER_ACTION,
             CONTROL_LIST_ACTION,
+            CONTROL_CREATE_PRINCIPAL_ACTION,
+            CONTROL_UPDATE_PRINCIPAL_ACTION,
+            CONTROL_DELETE_PRINCIPAL_ACTION,
         ] {
             let action_path = control_dir.join(action_name);
             if !action_path.exists() {
@@ -130,6 +155,9 @@ impl SupervisorControlPlane {
             CONTROL_LIST_ACTION,
             CONTROL_REGISTER_ACTION,
             CONTROL_UNREGISTER_ACTION,
+            CONTROL_CREATE_PRINCIPAL_ACTION,
+            CONTROL_UPDATE_PRINCIPAL_ACTION,
+            CONTROL_DELETE_PRINCIPAL_ACTION,
         ] {
             out.extend(self.drain_action_file(action_name)?);
         }
@@ -389,6 +417,21 @@ fn parse_invocation(
                 client_token,
             })
         }
+        CONTROL_CREATE_PRINCIPAL_ACTION => Ok(SupervisorControlInvocation::CreatePrincipal {
+            request_id: request_id.to_string(),
+            client_token,
+            request: parse_create_principal_request(payload_json)?,
+        }),
+        CONTROL_UPDATE_PRINCIPAL_ACTION => Ok(SupervisorControlInvocation::UpdatePrincipal {
+            request_id: request_id.to_string(),
+            client_token,
+            request: parse_update_principal_request(payload_json)?,
+        }),
+        CONTROL_DELETE_PRINCIPAL_ACTION => Ok(SupervisorControlInvocation::DeletePrincipal {
+            request_id: request_id.to_string(),
+            client_token,
+            request: parse_delete_principal_request(payload_json)?,
+        }),
         _ => Err(ERR_INVALID_ARGUMENT),
     }
 }
@@ -398,6 +441,9 @@ fn control_action_path(action_name: &str) -> &'static str {
         CONTROL_REGISTER_ACTION => "/_appfs/register_app.act",
         CONTROL_UNREGISTER_ACTION => "/_appfs/unregister_app.act",
         CONTROL_LIST_ACTION => "/_appfs/list_apps.act",
+        CONTROL_CREATE_PRINCIPAL_ACTION => "/_appfs/principals/create_principal.act",
+        CONTROL_UPDATE_PRINCIPAL_ACTION => "/_appfs/principals/update_principal.act",
+        CONTROL_DELETE_PRINCIPAL_ACTION => "/_appfs/principals/delete_principal.act",
         _ => "/_appfs/unknown.act",
     }
 }
@@ -457,6 +503,31 @@ fn write_json_file(path: &Path, value: &JsonValue) -> Result<()> {
         )
     })?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::SupervisorControlPlane;
+    use tempfile::TempDir;
+
+    #[test]
+    fn supervisor_control_prepares_principal_action_sinks() {
+        let temp = TempDir::new().expect("tempdir");
+        let mut control =
+            SupervisorControlPlane::new(temp.path().to_path_buf(), false).expect("control plane");
+        control.prepare_action_sinks().expect("prepare sinks");
+
+        for rel_path in [
+            "_appfs/principals/create_principal.act",
+            "_appfs/principals/update_principal.act",
+            "_appfs/principals/delete_principal.act",
+        ] {
+            assert!(
+                temp.path().join(rel_path).exists(),
+                "{rel_path} should exist"
+            );
+        }
+    }
 }
 
 fn ensure_dir_exists(path: &Path, label: &str) -> Result<()> {

--- a/cli/src/cmd/appfs/tests.rs
+++ b/cli/src/cmd/appfs/tests.rs
@@ -1,9 +1,11 @@
 use serde_json::Value;
 
 use super::action_dispatcher::{
-    parse_action_line, parse_enter_scope_request, parse_list_apps_request, parse_paging_request,
-    parse_register_app_request, parse_snapshot_refresh_request, parse_structure_refresh_request,
-    parse_unregister_app_request, validate_submit_payload as validate_payload,
+    parse_action_line, parse_create_principal_request, parse_delete_principal_request,
+    parse_ensure_credentials_request, parse_enter_scope_request, parse_list_apps_request,
+    parse_paging_request, parse_register_app_request, parse_snapshot_refresh_request,
+    parse_structure_refresh_request, parse_unregister_app_request, parse_update_principal_request,
+    validate_submit_payload as validate_payload,
 };
 use super::errors::{ERR_INVALID_ARGUMENT, ERR_INVALID_PAYLOAD};
 use super::registry::AppfsRegistryTransportKind;
@@ -285,6 +287,19 @@ fn parse_structure_refresh_allows_optional_target_scope() {
 }
 
 #[test]
+fn parse_ensure_credentials_allows_optional_expected_profile() {
+    let req = parse_ensure_credentials_request(r#"{}"#).expect("expected default ensure");
+    assert_eq!(req.expected_profile_id, None);
+
+    let req = parse_ensure_credentials_request(r#"{"expected_profile_id":"tinode:default"}"#)
+        .expect("expected profile guard");
+    assert_eq!(req.expected_profile_id.as_deref(), Some("tinode:default"));
+
+    assert!(parse_ensure_credentials_request(r#"{"expected_profile_id":42}"#).is_err());
+    assert!(parse_ensure_credentials_request(r#"[]"#).is_err());
+}
+
+#[test]
 fn parse_register_app_request_requires_transport_and_app_id() {
     let req = parse_register_app_request(
         r#"{"app_id":"notion","session_id":"sess-notion","transport":{"kind":"http","endpoint":"http://127.0.0.1:8080","http_timeout_ms":5000,"grpc_timeout_ms":5000,"bridge_max_retries":2,"bridge_initial_backoff_ms":100,"bridge_max_backoff_ms":1000,"bridge_circuit_breaker_failures":5,"bridge_circuit_breaker_cooldown_ms":3000}}"#,
@@ -308,6 +323,56 @@ fn parse_unregister_app_request_requires_app_id() {
 fn parse_list_apps_request_requires_json_object() {
     assert!(parse_list_apps_request(r#"{}"#).is_ok());
     assert!(parse_list_apps_request(r#"[]"#).is_err());
+}
+
+#[test]
+fn parse_create_principal_request_requires_safe_principal_id() {
+    let req = parse_create_principal_request(
+        r#"{"principal_id":"incident-reporter","display_name":"Incident reporter","description":"Summarizes incidents.","kind":"agent"}"#,
+    )
+    .expect("valid principal create request");
+    assert_eq!(req.principal_id, "incident-reporter");
+    assert_eq!(req.display_name, "Incident reporter");
+    assert_eq!(req.description.as_deref(), Some("Summarizes incidents."));
+    assert_eq!(req.kind, "agent");
+
+    assert!(parse_create_principal_request(
+        r#"{"principal_id":"","display_name":"Default agent"}"#
+    )
+    .is_err());
+    assert!(parse_create_principal_request(
+        r#"{"principal_id":"../default","display_name":"Default agent"}"#
+    )
+    .is_err());
+    assert!(parse_create_principal_request(
+        r#"{"principal_id":"default\\evil","display_name":"Default agent"}"#
+    )
+    .is_err());
+    assert!(parse_create_principal_request(
+        r#"{"principal_id":".","display_name":"Default agent"}"#
+    )
+    .is_err());
+    assert!(parse_create_principal_request(
+        r#"{"principal_id":"default:ads","display_name":"Default agent"}"#
+    )
+    .is_err());
+}
+
+#[test]
+fn parse_update_and_delete_principal_requests_require_principal_id() {
+    let req = parse_update_principal_request(
+        r#"{"principal_id":"default","display_name":"Default agent v2"}"#,
+    )
+    .expect("valid principal update request");
+    assert_eq!(req.principal_id, "default");
+    assert_eq!(req.display_name.as_deref(), Some("Default agent v2"));
+
+    let req = parse_delete_principal_request(r#"{"principal_id":"default"}"#)
+        .expect("valid principal delete request");
+    assert_eq!(req.principal_id, "default");
+
+    assert!(parse_update_principal_request(r#"{}"#).is_err());
+    assert!(parse_delete_principal_request(r#"{"principal_id":".."}"#).is_err());
 }
 
 #[test]

--- a/cli/src/cmd/appfs/tree_sync.rs
+++ b/cli/src/cmd/appfs/tree_sync.rs
@@ -34,25 +34,41 @@ pub(super) struct StructureSyncOutcome {
     pub(super) manifest_json: Option<String>,
 }
 
+#[allow(dead_code)]
 pub(super) fn ensure_app_structure_initialized(
     root: &Path,
     app_id: &str,
     session_id: &str,
     bridge_config: &AppfsBridgeConfig,
 ) -> Result<()> {
-    let app_dir = root.join(app_id);
+    ensure_app_structure_initialized_at(root, app_id, app_id, None, None, session_id, bridge_config)
+}
+
+pub(super) fn ensure_app_structure_initialized_at(
+    root: &Path,
+    app_id: &str,
+    app_mount_path: &str,
+    principal_id: Option<String>,
+    profile_id: Option<String>,
+    session_id: &str,
+    bridge_config: &AppfsBridgeConfig,
+) -> Result<()> {
+    let app_dir = root.join(app_mount_path);
     let manifest_path = app_dir.join("_meta").join("manifest.res.json");
     let requires_bootstrap = !app_dir.exists() || !manifest_path.exists();
     if !requires_bootstrap {
-        bootstrap_runtime_scaffolding(root, app_id)?;
+        bootstrap_runtime_scaffolding(root, app_mount_path)?;
         return Ok(());
     }
 
     let mut connector = build_app_connector(app_id, bridge_config)?;
 
-    let mut service = AppTreeSyncService::new(
+    let mut service = AppTreeSyncService::new_with_mount_path(
         root.to_path_buf(),
         app_id.to_string(),
+        app_mount_path.to_string(),
+        principal_id,
+        profile_id,
         session_id.to_string(),
     );
     service.sync_initial(&mut *connector)?;
@@ -63,6 +79,8 @@ pub(super) async fn ensure_app_structure_initialized_in_db(
     agent: &SdkAgentFS,
     app_id: &str,
     session_id: &str,
+    principal_id: Option<String>,
+    profile_id: Option<String>,
     bridge_config: &AppfsBridgeConfig,
 ) -> Result<()> {
     let state = load_state_from_agentfs(agent, app_id).await?;
@@ -72,6 +90,8 @@ pub(super) async fn ensure_app_structure_initialized_in_db(
         request_id: "structure-init".to_string(),
         client_token: None,
         trace_id: None,
+        principal_id,
+        profile_id,
     };
     let mut connector = build_app_connector(app_id, bridge_config)?;
     eprintln!(
@@ -139,6 +159,8 @@ pub(super) async fn refresh_app_structure_in_db(
     agent: &SdkAgentFS,
     app_id: &str,
     session_id: &str,
+    principal_id: Option<String>,
+    profile_id: Option<String>,
     connector: &mut dyn AppConnector,
     reason: AppStructureSyncReason,
     target_scope: Option<String>,
@@ -151,6 +173,8 @@ pub(super) async fn refresh_app_structure_in_db(
         request_id: "structure-refresh".to_string(),
         client_token: None,
         trace_id: None,
+        principal_id,
+        profile_id,
     };
     eprintln!(
         "[structure.sync] op=refresh_app_structure app={} reason={} target_scope={} trigger_action_path={} known_revision={}",
@@ -235,6 +259,8 @@ pub(super) fn refresh_app_structure(
     root: &Path,
     app_id: &str,
     session_id: &str,
+    principal_id: Option<String>,
+    profile_id: Option<String>,
     connector: &mut dyn AppConnector,
     reason: AppStructureSyncReason,
     target_scope: Option<String>,
@@ -243,6 +269,8 @@ pub(super) fn refresh_app_structure(
     let mut service = AppTreeSyncService::new(
         root.to_path_buf(),
         app_id.to_string(),
+        principal_id,
+        profile_id,
         session_id.to_string(),
     );
     service.refresh(connector, reason, target_scope, trigger_action_path)
@@ -251,14 +279,44 @@ pub(super) fn refresh_app_structure(
 struct AppTreeSyncService {
     root: PathBuf,
     app_id: String,
+    app_mount_path: String,
+    principal_id: Option<String>,
+    profile_id: Option<String>,
     session_id: String,
 }
 
 impl AppTreeSyncService {
-    fn new(root: PathBuf, app_id: String, session_id: String) -> Self {
+    fn new(
+        root: PathBuf,
+        app_id: String,
+        principal_id: Option<String>,
+        profile_id: Option<String>,
+        session_id: String,
+    ) -> Self {
+        Self::new_with_mount_path(
+            root,
+            app_id.clone(),
+            app_id,
+            principal_id,
+            profile_id,
+            session_id,
+        )
+    }
+
+    fn new_with_mount_path(
+        root: PathBuf,
+        app_id: String,
+        app_mount_path: String,
+        principal_id: Option<String>,
+        profile_id: Option<String>,
+        session_id: String,
+    ) -> Self {
         Self {
             root,
             app_id,
+            app_mount_path,
+            principal_id,
+            profile_id,
             session_id,
         }
     }
@@ -281,7 +339,7 @@ impl AppTreeSyncService {
 
         match response.result {
             AppStructureSyncResult::Unchanged { .. } => {
-                bootstrap_runtime_scaffolding(&self.root, &self.app_id)?;
+                bootstrap_runtime_scaffolding(&self.root, &self.app_mount_path)?;
                 eprintln!(
                     "[structure.sync] result app={} changed=false revision={} active_scope={}",
                     self.app_id,
@@ -391,7 +449,7 @@ impl AppTreeSyncService {
             active_scope: snapshot.active_scope,
             owned_paths: desired_owned_paths.into_iter().collect(),
         })?;
-        bootstrap_runtime_scaffolding(&self.root, &self.app_id)?;
+        bootstrap_runtime_scaffolding(&self.root, &self.app_mount_path)?;
         Ok(())
     }
 
@@ -570,6 +628,8 @@ impl AppTreeSyncService {
             request_id: request_id.to_string(),
             client_token: None,
             trace_id: None,
+            principal_id: self.principal_id.clone(),
+            profile_id: self.profile_id.clone(),
         }
     }
 
@@ -597,7 +657,7 @@ impl AppTreeSyncService {
     }
 
     fn app_dir(&self) -> PathBuf {
-        self.root.join(&self.app_id)
+        self.root.join(&self.app_mount_path)
     }
 }
 
@@ -1038,6 +1098,8 @@ mod tests {
         let mut service = AppTreeSyncService::new(
             temp.path().to_path_buf(),
             "aiim".to_string(),
+            None,
+            None,
             "sess-test".to_string(),
         );
         let mut connector = DemoAppConnector::new("aiim".to_string());
@@ -1063,6 +1125,8 @@ mod tests {
         let mut service = AppTreeSyncService::new(
             temp.path().to_path_buf(),
             "aiim".to_string(),
+            None,
+            None,
             "sess-test".to_string(),
         );
         let mut connector = DemoAppConnector::new("aiim".to_string());
@@ -1101,6 +1165,8 @@ mod tests {
         let mut service = AppTreeSyncService::new(
             temp.path().to_path_buf(),
             "aiim".to_string(),
+            None,
+            None,
             "sess-test".to_string(),
         );
         let mut connector = DemoAppConnector::new("aiim".to_string());
@@ -1164,9 +1230,16 @@ mod tests {
             adapter_bridge_circuit_breaker_cooldown_ms: 3_000,
         });
 
-        super::ensure_app_structure_initialized_in_db(&agent, "aiim", "sess-test", &bridge)
-            .await
-            .expect("db structure init");
+        super::ensure_app_structure_initialized_in_db(
+            &agent,
+            "aiim",
+            "sess-test",
+            None,
+            None,
+            &bridge,
+        )
+        .await
+        .expect("db structure init");
 
         assert!(agent
             .fs
@@ -1238,9 +1311,16 @@ mod tests {
             adapter_bridge_circuit_breaker_cooldown_ms: 3_000,
         });
 
-        super::ensure_app_structure_initialized_in_db(&agent, "aiim", "sess-test", &bridge)
-            .await
-            .expect("db structure init");
+        super::ensure_app_structure_initialized_in_db(
+            &agent,
+            "aiim",
+            "sess-test",
+            None,
+            None,
+            &bridge,
+        )
+        .await
+        .expect("db structure init");
         let before_cursor = agent
             .fs
             .read_file("/aiim/_stream/cursor.res.json")
@@ -1253,6 +1333,8 @@ mod tests {
             &agent,
             "aiim",
             "sess-test",
+            None,
+            None,
             &mut *connector,
             agentfs_sdk::AppStructureSyncReason::EnterScope,
             Some("chat-long".to_string()),

--- a/examples/appfs/bridges/grpc-python/proto/appfs_connector.proto
+++ b/examples/appfs/bridges/grpc-python/proto/appfs_connector.proto
@@ -8,6 +8,8 @@ message ConnectorContext {
   string request_id = 3;
   optional string client_token = 4;
   optional string trace_id = 5;
+  optional string principal_id = 6;
+  optional string profile_id = 7;
 }
 
 enum ConnectorTransport {

--- a/examples/appfs/bridges/grpc-python/proto/appfs_structure.proto
+++ b/examples/appfs/bridges/grpc-python/proto/appfs_structure.proto
@@ -8,6 +8,8 @@ message ConnectorContext {
   string request_id = 3;
   optional string client_token = 4;
   optional string trace_id = 5;
+  optional string principal_id = 6;
+  optional string profile_id = 7;
 }
 
 message ConnectorError {

--- a/sdk/rust/Cargo.lock
+++ b/sdk/rust/Cargo.lock
@@ -53,6 +53,7 @@ version = "0.7.0-beta.1"
 dependencies = [
  "aegis",
  "async-trait",
+ "base64",
  "criterion",
  "libc",
  "lru",
@@ -64,6 +65,7 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "tracing",
+ "tungstenite",
  "turso",
 ]
 
@@ -190,6 +192,15 @@ name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "branches"
@@ -516,12 +527,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
 ]
 
 [[package]]
@@ -2022,6 +2049,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sha1_smol"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2382,6 +2420,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "tungstenite"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18e5b8366ee7a95b16d32197d0b2604b43a0be89dc5fac9f8e96ccafbaedda8a"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.8.5",
+ "sha1",
+ "thiserror 1.0.69",
+ "utf-8",
+]
+
+[[package]]
 name = "turso"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2629,6 +2685,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "utf8_iter"

--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -16,6 +16,8 @@ libc = "0.2"
 thiserror = "1.0"
 lru = "0.12"
 tracing = "0.1"
+base64 = "0.22"
+tungstenite = "0.24"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 # `aegis`'s C/NEON backend fails to compile with Apple clang on arm64 due to

--- a/sdk/rust/src/appfs_connector.rs
+++ b/sdk/rust/src/appfs_connector.rs
@@ -16,6 +16,9 @@ pub mod connector_error_codes {
     pub const UPSTREAM_UNAVAILABLE: &str = "UPSTREAM_UNAVAILABLE";
     pub const RATE_LIMITED: &str = "RATE_LIMITED";
     pub const AUTH_EXPIRED: &str = "AUTH_EXPIRED";
+    pub const PROFILE_NOT_READY: &str = "PROFILE_NOT_READY";
+    pub const PROFILE_NOT_FOUND: &str = "PROFILE_NOT_FOUND";
+    pub const CREDENTIALS_FAILED: &str = "CREDENTIALS_FAILED";
     pub const PERMISSION_DENIED: &str = "PERMISSION_DENIED";
     pub const RESOURCE_EXHAUSTED: &str = "RESOURCE_EXHAUSTED";
     pub const TIMEOUT: &str = "TIMEOUT";
@@ -53,6 +56,10 @@ pub struct ConnectorContext {
     pub client_token: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub trace_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub principal_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub profile_id: Option<String>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -190,6 +197,16 @@ pub struct SubmitActionResponse {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub estimated_duration_ms: Option<u32>,
     pub outcome: SubmitActionOutcome,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ConnectorInboundEvent {
+    pub event_type: String,
+    pub path: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub content: Option<JsonValue>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error: Option<JsonValue>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Error, Serialize, Deserialize)]
@@ -332,6 +349,13 @@ pub trait AppConnector: Send {
         ctx: &ConnectorContext,
     ) -> std::result::Result<SubmitActionResponse, ConnectorError>;
 
+    fn drain_inbound_events(
+        &mut self,
+        _ctx: &ConnectorContext,
+    ) -> std::result::Result<Vec<ConnectorInboundEvent>, ConnectorError> {
+        Ok(Vec::new())
+    }
+
     fn get_app_structure(
         &mut self,
         _request: GetAppStructureRequest,
@@ -352,6 +376,7 @@ pub trait AppConnector: Send {
 #[cfg(test)]
 mod tests {
     use super::connector_error_codes as code;
+    use super::ConnectorContext;
 
     #[test]
     fn connector_error_codes_match_expected_set() {
@@ -365,6 +390,9 @@ mod tests {
             code::UPSTREAM_UNAVAILABLE,
             code::RATE_LIMITED,
             code::AUTH_EXPIRED,
+            code::PROFILE_NOT_READY,
+            code::PROFILE_NOT_FOUND,
+            code::CREDENTIALS_FAILED,
             code::PERMISSION_DENIED,
             code::RESOURCE_EXHAUSTED,
             code::TIMEOUT,
@@ -382,6 +410,9 @@ mod tests {
             "UPSTREAM_UNAVAILABLE",
             "RATE_LIMITED",
             "AUTH_EXPIRED",
+            "PROFILE_NOT_READY",
+            "PROFILE_NOT_FOUND",
+            "CREDENTIALS_FAILED",
             "PERMISSION_DENIED",
             "RESOURCE_EXHAUSTED",
             "TIMEOUT",
@@ -390,5 +421,37 @@ mod tests {
         ];
 
         assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn connector_context_roundtrips_principal_and_profile() {
+        let ctx = ConnectorContext {
+            app_id: "tinode".to_string(),
+            session_id: "sess-1".to_string(),
+            request_id: "req-1".to_string(),
+            client_token: None,
+            trace_id: None,
+            principal_id: Some("default".to_string()),
+            profile_id: Some("tinode:default".to_string()),
+        };
+
+        let json = serde_json::to_value(&ctx).expect("serialize context");
+        assert_eq!(json["app_id"], "tinode");
+        assert_eq!(json["principal_id"], "default");
+        assert_eq!(json["profile_id"], "tinode:default");
+
+        let restored: ConnectorContext = serde_json::from_value(json).expect("deserialize context");
+        assert_eq!(restored, ctx);
+    }
+
+    #[test]
+    fn connector_context_accepts_public_context_without_principal() {
+        let restored: ConnectorContext =
+            serde_json::from_str(r#"{"app_id":"aiim","session_id":"sess-1","request_id":"req-1"}"#)
+                .expect("deserialize public context");
+
+        assert_eq!(restored.app_id, "aiim");
+        assert_eq!(restored.principal_id, None);
+        assert_eq!(restored.profile_id, None);
     }
 }

--- a/sdk/rust/src/appfs_demo_adapter.rs
+++ b/sdk/rust/src/appfs_demo_adapter.rs
@@ -1,14 +1,14 @@
 use crate::{
-    ActionExecutionMode, ActionStreamingPlan, AdapterControlActionV1, AdapterControlOutcomeV1,
-    AdapterErrorV1, AdapterExecutionModeV1, AdapterInputModeV1, AdapterSnapshotMetaV1,
-    AdapterStreamingPlanV1, AdapterSubmitOutcomeV1, AppAdapterV1, AppConnector, AppStructureNode,
-    AppStructureNodeKind, AppStructureSnapshot, AppStructureSyncReason, AppStructureSyncResult,
-    AuthStatus, ConnectorContext, ConnectorError, ConnectorInfo, ConnectorTransport,
-    FetchLivePageRequest, FetchLivePageResponse, FetchSnapshotChunkRequest,
-    FetchSnapshotChunkResponse, GetAppStructureRequest, GetAppStructureResponse, HealthStatus,
-    LiveMode, LivePageInfo, RefreshAppStructureRequest, RefreshAppStructureResponse,
-    RequestContextV1, SnapshotMeta, SnapshotRecord, SnapshotResume, SubmitActionOutcome,
-    SubmitActionRequest, SubmitActionResponse,
+    connector_error_codes, ActionExecutionMode, ActionStreamingPlan, AdapterControlActionV1,
+    AdapterControlOutcomeV1, AdapterErrorV1, AdapterExecutionModeV1, AdapterInputModeV1,
+    AdapterSnapshotMetaV1, AdapterStreamingPlanV1, AdapterSubmitOutcomeV1, AppAdapterV1,
+    AppConnector, AppStructureNode, AppStructureNodeKind, AppStructureSnapshot,
+    AppStructureSyncReason, AppStructureSyncResult, AuthStatus, ConnectorContext, ConnectorError,
+    ConnectorInfo, ConnectorTransport, FetchLivePageRequest, FetchLivePageResponse,
+    FetchSnapshotChunkRequest, FetchSnapshotChunkResponse, GetAppStructureRequest,
+    GetAppStructureResponse, HealthStatus, LiveMode, LivePageInfo, RefreshAppStructureRequest,
+    RefreshAppStructureResponse, RequestContextV1, SnapshotMeta, SnapshotRecord, SnapshotResume,
+    SubmitActionOutcome, SubmitActionRequest, SubmitActionResponse,
 };
 use serde_json::{json, Value as JsonValue};
 use std::time::Duration;
@@ -229,7 +229,10 @@ impl DemoAppConnector {
         })
     }
 
-    fn base_structure_nodes(scope: Option<&str>) -> Vec<AppStructureNode> {
+    fn base_structure_nodes(
+        scope: Option<&str>,
+        include_credentials: bool,
+    ) -> Vec<AppStructureNode> {
         let mut nodes = vec![
             AppStructureNode {
                 path: "_meta".to_string(),
@@ -337,6 +340,20 @@ impl DemoAppConnector {
             },
         ];
 
+        if include_credentials {
+            nodes.push(AppStructureNode {
+                path: "_app/ensure_credentials.act".to_string(),
+                kind: AppStructureNodeKind::ActionFile,
+                manifest_entry: Some(Self::action_manifest(
+                    "_app/ensure_credentials.act",
+                    "inline",
+                )),
+                seed_content: None,
+                mutable: true,
+                scope: None,
+            });
+        }
+
         match scope {
             Some("chat-long") => {
                 nodes.push(AppStructureNode {
@@ -404,6 +421,7 @@ impl DemoAppConnector {
     fn structure_snapshot(
         &self,
         scope: Option<&str>,
+        include_credentials: bool,
     ) -> std::result::Result<AppStructureSnapshot, ConnectorError> {
         let active_scope = match scope {
             None | Some("chat-001") => "chat-001".to_string(),
@@ -428,7 +446,7 @@ impl DemoAppConnector {
                 "_paging".to_string(),
                 "_app".to_string(),
             ],
-            nodes: Self::base_structure_nodes(Some(&active_scope)),
+            nodes: Self::base_structure_nodes(Some(&active_scope), include_credentials),
         })
     }
 }
@@ -767,15 +785,45 @@ impl AppConnector for DemoAppConnector {
         if request.path.contains("rate_limited") {
             return Err(Self::err("RATE_LIMITED", "upstream rate limited", true));
         }
+        if request.path == "/_app/ensure_credentials.act" {
+            let Some(profile_id) = ctx.profile_id.as_deref() else {
+                return Err(Self::err(
+                    connector_error_codes::PROFILE_NOT_READY,
+                    "demo credentials require profile_id",
+                    false,
+                ));
+            };
+            return Ok(SubmitActionResponse {
+                request_id: ctx.request_id.clone(),
+                estimated_duration_ms: Some(50),
+                outcome: SubmitActionOutcome::Completed {
+                    content: json!({
+                        "credential_status": "ready",
+                        "profile_id": profile_id,
+                        "upstream_user_id": format!("demo-user-{profile_id}"),
+                        "login": format!("demo-{profile_id}"),
+                        "last_ready_at": "2026-05-06T00:00:00Z",
+                        "token": "demo-secret-token",
+                    }),
+                },
+            });
+        }
 
         let outcome = match request.execution_mode {
-            ActionExecutionMode::Inline => SubmitActionOutcome::Completed {
-                content: json!({
+            ActionExecutionMode::Inline => {
+                let mut content = json!({
                     "ok": true,
                     "path": request.path,
                     "echo": request.payload,
-                }),
-            },
+                });
+                if let Some(principal_id) = ctx.principal_id.as_deref() {
+                    content["principal_id"] = json!(principal_id);
+                }
+                if let Some(profile_id) = ctx.profile_id.as_deref() {
+                    content["profile_id"] = json!(profile_id);
+                }
+                SubmitActionOutcome::Completed { content }
+            }
             ActionExecutionMode::Streaming => SubmitActionOutcome::Streaming {
                 plan: ActionStreamingPlan {
                     accepted_content: Some(json!({"state":"accepted"})),
@@ -794,9 +842,9 @@ impl AppConnector for DemoAppConnector {
     fn get_app_structure(
         &mut self,
         request: GetAppStructureRequest,
-        _ctx: &ConnectorContext,
+        ctx: &ConnectorContext,
     ) -> std::result::Result<GetAppStructureResponse, ConnectorError> {
-        let snapshot = self.structure_snapshot(None)?;
+        let snapshot = self.structure_snapshot(None, ctx.profile_id.is_some())?;
         if request.known_revision.as_deref() == Some(snapshot.revision.as_str()) {
             return Ok(GetAppStructureResponse {
                 result: AppStructureSyncResult::Unchanged {
@@ -815,7 +863,7 @@ impl AppConnector for DemoAppConnector {
     fn refresh_app_structure(
         &mut self,
         request: RefreshAppStructureRequest,
-        _ctx: &ConnectorContext,
+        ctx: &ConnectorContext,
     ) -> std::result::Result<RefreshAppStructureResponse, ConnectorError> {
         if matches!(request.reason, AppStructureSyncReason::EnterScope)
             && request.target_scope.is_none()
@@ -826,7 +874,8 @@ impl AppConnector for DemoAppConnector {
                 false,
             ));
         }
-        let snapshot = self.structure_snapshot(request.target_scope.as_deref())?;
+        let snapshot =
+            self.structure_snapshot(request.target_scope.as_deref(), ctx.profile_id.is_some())?;
         if request.known_revision.as_deref() == Some(snapshot.revision.as_str()) {
             return Ok(RefreshAppStructureResponse {
                 result: AppStructureSyncResult::Unchanged {
@@ -872,6 +921,8 @@ mod tests {
             request_id: "req-connector-1".to_string(),
             client_token: Some("tok-connector-1".to_string()),
             trace_id: trace_id.map(|v| v.to_string()),
+            principal_id: None,
+            profile_id: None,
         }
     }
 
@@ -1268,6 +1319,35 @@ mod tests {
             .expect_err("invalid payload should return mapped error");
         assert_eq!(err.code, "INVALID_PAYLOAD");
         assert!(!err.retryable);
+    }
+
+    #[test]
+    fn demo_connector_echoes_effective_principal_context() {
+        let mut connector = DemoAppConnector::new("tinode".to_string());
+        let mut ctx = connector_ctx(None);
+        ctx.app_id = "tinode".to_string();
+        ctx.principal_id = Some("default".to_string());
+        ctx.profile_id = Some("tinode:default".to_string());
+
+        let response = connector
+            .submit_action(
+                SubmitActionRequest {
+                    path: "/contacts/zhangsan/send_message.act".to_string(),
+                    payload: serde_json::json!({"profile_id":"attacker"}),
+                    execution_mode: ActionExecutionMode::Inline,
+                },
+                &ctx,
+            )
+            .expect("inline submit should succeed");
+
+        match response.outcome {
+            SubmitActionOutcome::Completed { content } => {
+                assert_eq!(content["principal_id"], "default");
+                assert_eq!(content["profile_id"], "tinode:default");
+                assert_eq!(content["echo"]["profile_id"], "attacker");
+            }
+            _ => panic!("expected completed outcome"),
+        }
     }
 
     #[test]

--- a/sdk/rust/src/credential_store.rs
+++ b/sdk/rust/src/credential_store.rs
@@ -1,0 +1,281 @@
+use crate::error::{Error, Result};
+use crate::KvStore;
+use serde::{Deserialize, Serialize};
+use serde_json::Value as JsonValue;
+
+/// Safe model-visible credential states.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ConnectorCredentialStatus {
+    Missing,
+    Ready,
+    Expired,
+    Failed,
+}
+
+/// Private credential record stored outside the AppFS mount tree.
+///
+/// The `credentials` payload may contain tokens or other secrets. Never render
+/// this whole record into AppFS resources, events, skills, or session files.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ConnectorCredentialRecord {
+    pub profile_id: String,
+    pub credential_status: ConnectorCredentialStatus,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub upstream_user_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub login: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub display_name: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_ready_at: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub expires_at: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub credentials: Option<JsonValue>,
+}
+
+/// Safe summary that can be exposed in AppFS event content or resources.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ConnectorCredentialSummary {
+    pub credential_status: ConnectorCredentialStatus,
+    pub profile_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub upstream_user_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub login: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub display_name: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_ready_at: Option<String>,
+}
+
+impl ConnectorCredentialRecord {
+    #[must_use]
+    pub fn safe_summary(&self) -> ConnectorCredentialSummary {
+        ConnectorCredentialSummary {
+            credential_status: self.credential_status,
+            profile_id: self.profile_id.clone(),
+            upstream_user_id: self.upstream_user_id.clone(),
+            login: self.login.clone(),
+            display_name: self.display_name.clone(),
+            last_ready_at: self.last_ready_at.clone(),
+        }
+    }
+}
+
+impl ConnectorCredentialSummary {
+    /// Build a safe summary from connector-returned content by whitelisting
+    /// fields. Unknown fields, including tokens or credential blobs, are dropped.
+    #[must_use]
+    pub fn from_connector_content(content: &JsonValue, fallback_profile_id: &str) -> Self {
+        Self {
+            credential_status: content
+                .get("credential_status")
+                .and_then(JsonValue::as_str)
+                .and_then(parse_credential_status)
+                .unwrap_or(ConnectorCredentialStatus::Ready),
+            profile_id: fallback_profile_id.to_string(),
+            upstream_user_id: optional_summary_string(content, "upstream_user_id"),
+            login: optional_summary_string(content, "login"),
+            display_name: optional_summary_string(content, "display_name"),
+            last_ready_at: optional_summary_string(content, "last_ready_at"),
+        }
+    }
+}
+
+/// KV-backed connector credential state.
+#[derive(Clone)]
+pub struct ConnectorCredentialStore {
+    connector_name: String,
+    kv: KvStore,
+}
+
+impl ConnectorCredentialStore {
+    pub async fn new(db_path: &str, connector_name: impl Into<String>) -> Result<Self> {
+        let connector_name = validate_key_component("connector_name", connector_name.into())?;
+        let kv = KvStore::new(db_path).await?;
+        Ok(Self { connector_name, kv })
+    }
+
+    pub fn from_kv(kv: KvStore, connector_name: impl Into<String>) -> Result<Self> {
+        let connector_name = validate_key_component("connector_name", connector_name.into())?;
+        Ok(Self { connector_name, kv })
+    }
+
+    #[must_use]
+    pub fn connector_name(&self) -> &str {
+        &self.connector_name
+    }
+
+    pub fn key_for_profile(&self, profile_id: &str) -> Result<String> {
+        connector_credentials_key(&self.connector_name, profile_id)
+    }
+
+    pub async fn put(&self, record: &ConnectorCredentialRecord) -> Result<()> {
+        let key = self.key_for_profile(&record.profile_id)?;
+        self.kv.set(&key, record).await
+    }
+
+    pub async fn get(&self, profile_id: &str) -> Result<Option<ConnectorCredentialRecord>> {
+        let key = self.key_for_profile(profile_id)?;
+        self.kv.get(&key).await
+    }
+
+    pub async fn summary(&self, profile_id: &str) -> Result<Option<ConnectorCredentialSummary>> {
+        Ok(self
+            .get(profile_id)
+            .await?
+            .map(|record| record.safe_summary()))
+    }
+
+    pub async fn delete(&self, profile_id: &str) -> Result<()> {
+        let key = self.key_for_profile(profile_id)?;
+        self.kv.delete(&key).await
+    }
+}
+
+pub fn connector_credentials_key(connector_name: &str, profile_id: &str) -> Result<String> {
+    let connector_name = validate_key_component("connector_name", connector_name)?;
+    let profile_id = validate_key_component("profile_id", profile_id)?;
+    Ok(format!(
+        "connector:{connector_name}:profile:{profile_id}:credentials"
+    ))
+}
+
+fn optional_summary_string(content: &JsonValue, field: &str) -> Option<String> {
+    content
+        .get(field)
+        .and_then(JsonValue::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+}
+
+fn parse_credential_status(value: &str) -> Option<ConnectorCredentialStatus> {
+    match value {
+        "missing" => Some(ConnectorCredentialStatus::Missing),
+        "ready" => Some(ConnectorCredentialStatus::Ready),
+        "expired" => Some(ConnectorCredentialStatus::Expired),
+        "failed" => Some(ConnectorCredentialStatus::Failed),
+        _ => None,
+    }
+}
+
+fn validate_key_component(field_name: &str, value: impl AsRef<str>) -> Result<String> {
+    let value = value.as_ref().trim();
+    if value.is_empty() || value.contains(['\0', '\r', '\n']) {
+        return Err(Error::Internal(format!(
+            "{field_name} must be non-empty and cannot contain control separators"
+        )));
+    }
+    Ok(value.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        connector_credentials_key, ConnectorCredentialRecord, ConnectorCredentialStatus,
+        ConnectorCredentialStore,
+    };
+    use serde_json::json;
+
+    #[test]
+    fn credential_key_uses_connector_profile_shape() {
+        let key =
+            connector_credentials_key("tinode-http", "tinode:default").expect("credential key");
+
+        assert_eq!(
+            key,
+            "connector:tinode-http:profile:tinode:default:credentials"
+        );
+        assert!(connector_credentials_key("", "tinode:default").is_err());
+        assert!(connector_credentials_key("tinode-http", "").is_err());
+        assert!(connector_credentials_key("tinode\nhttp", "tinode:default").is_err());
+    }
+
+    #[test]
+    fn safe_summary_drops_secret_credential_payload() {
+        let record = ConnectorCredentialRecord {
+            profile_id: "tinode:default".to_string(),
+            credential_status: ConnectorCredentialStatus::Ready,
+            upstream_user_id: Some("usr123".to_string()),
+            login: Some("appfs_default".to_string()),
+            display_name: Some("Default agent".to_string()),
+            last_ready_at: Some("2026-05-06T00:00:00Z".to_string()),
+            expires_at: Some("2026-05-07T00:00:00Z".to_string()),
+            credentials: Some(json!({
+                "token": "secret-token",
+                "refresh_token": "secret-refresh"
+            })),
+        };
+
+        let summary = serde_json::to_value(record.safe_summary()).expect("summary json");
+        assert_eq!(summary["credential_status"], "ready");
+        assert_eq!(summary["profile_id"], "tinode:default");
+        assert_eq!(summary["upstream_user_id"], "usr123");
+        assert!(summary.get("credentials").is_none());
+        assert!(!summary.to_string().contains("secret-token"));
+    }
+
+    #[test]
+    fn summary_from_connector_content_whitelists_fields() {
+        let content = json!({
+            "credential_status": "ready",
+            "profile_id": "connector-returned-value",
+            "upstream_user_id": "usr123",
+            "login": "appfs_default",
+            "token": "do-not-leak"
+        });
+
+        let summary =
+            super::ConnectorCredentialSummary::from_connector_content(&content, "tinode:default");
+        let summary_json = serde_json::to_value(summary).expect("summary json");
+        assert_eq!(summary_json["profile_id"], "tinode:default");
+        assert!(summary_json.get("token").is_none());
+        assert!(!summary_json.to_string().contains("do-not-leak"));
+    }
+
+    #[tokio::test]
+    async fn credential_store_round_trips_private_record_by_profile() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let db_path = temp.path().join("credentials.db");
+        let store =
+            ConnectorCredentialStore::new(db_path.to_str().expect("utf8 db path"), "tinode-http")
+                .await
+                .expect("credential store");
+        let record = ConnectorCredentialRecord {
+            profile_id: "tinode:default".to_string(),
+            credential_status: ConnectorCredentialStatus::Ready,
+            upstream_user_id: Some("usr123".to_string()),
+            login: Some("appfs_default".to_string()),
+            display_name: None,
+            last_ready_at: Some("2026-05-06T00:00:00Z".to_string()),
+            expires_at: None,
+            credentials: Some(json!({"token": "secret-token"})),
+        };
+
+        store.put(&record).await.expect("put record");
+        assert_eq!(
+            store
+                .get("tinode:default")
+                .await
+                .expect("get record")
+                .as_ref(),
+            Some(&record)
+        );
+        let summary = store
+            .summary("tinode:default")
+            .await
+            .expect("summary")
+            .expect("summary exists");
+        assert_eq!(summary.profile_id, "tinode:default");
+
+        store.delete("tinode:default").await.expect("delete");
+        assert!(store
+            .get("tinode:default")
+            .await
+            .expect("get after delete")
+            .is_none());
+    }
+}

--- a/sdk/rust/src/lib.rs
+++ b/sdk/rust/src/lib.rs
@@ -4,10 +4,12 @@ pub mod appfs_connector;
 pub mod appfs_demo_adapter;
 pub mod bulk_materialize;
 pub mod connection_pool;
+pub mod credential_store;
 pub mod error;
 pub mod filesystem;
 pub mod kvstore;
 pub mod schema;
+pub mod tinode_connector;
 pub mod toolcalls;
 
 use error::{Error, Result};
@@ -34,15 +36,19 @@ pub use appfs_adapter_testkit::{
 pub use appfs_connector::{
     connector_error_codes, ActionExecutionMode, ActionStreamingPlan, AppConnector,
     AppStructureNode, AppStructureNodeKind, AppStructureSnapshot, AppStructureSyncReason,
-    AppStructureSyncResult, AuthStatus, ConnectorContext, ConnectorError, ConnectorInfo,
-    ConnectorTransport, FetchLivePageRequest, FetchLivePageResponse, FetchSnapshotChunkRequest,
-    FetchSnapshotChunkResponse, GetAppStructureRequest, GetAppStructureResponse, HealthStatus,
-    LiveMode, LivePageInfo, RefreshAppStructureRequest, RefreshAppStructureResponse, SnapshotMeta,
-    SnapshotRecord, SnapshotResume, SubmitActionOutcome, SubmitActionRequest, SubmitActionResponse,
-    APPFS_CONNECTOR_SDK_VERSION,
+    AppStructureSyncResult, AuthStatus, ConnectorContext, ConnectorError, ConnectorInboundEvent,
+    ConnectorInfo, ConnectorTransport, FetchLivePageRequest, FetchLivePageResponse,
+    FetchSnapshotChunkRequest, FetchSnapshotChunkResponse, GetAppStructureRequest,
+    GetAppStructureResponse, HealthStatus, LiveMode, LivePageInfo, RefreshAppStructureRequest,
+    RefreshAppStructureResponse, SnapshotMeta, SnapshotRecord, SnapshotResume, SubmitActionOutcome,
+    SubmitActionRequest, SubmitActionResponse, APPFS_CONNECTOR_SDK_VERSION,
 };
 pub use appfs_demo_adapter::{DemoAppAdapterV1, DemoAppConnector};
 pub use bulk_materialize::{BulkMaterializeEntry, BulkMaterializePlan};
+pub use credential_store::{
+    connector_credentials_key, ConnectorCredentialRecord, ConnectorCredentialStatus,
+    ConnectorCredentialStore, ConnectorCredentialSummary,
+};
 #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
 pub use filesystem::HostFS;
 pub use filesystem::{
@@ -53,6 +59,7 @@ pub use filesystem::{
 };
 pub use kvstore::KvStore;
 pub use schema::{SchemaVersion, AGENTFS_SCHEMA_VERSION};
+pub use tinode_connector::{TinodeConnector, TinodeConnectorConfig};
 pub use toolcalls::{ToolCall, ToolCallStats, ToolCallStatus, ToolCalls};
 
 /// Directory containing agentfs databases

--- a/sdk/rust/src/tinode_connector.rs
+++ b/sdk/rust/src/tinode_connector.rs
@@ -1,0 +1,4672 @@
+use crate::credential_store::{ConnectorCredentialRecord, ConnectorCredentialStatus};
+use crate::{
+    connector_error_codes, ActionExecutionMode, AppConnector, AppStructureNode,
+    AppStructureNodeKind, AppStructureSnapshot, AppStructureSyncResult, AuthStatus,
+    ConnectorContext, ConnectorError, ConnectorInboundEvent, ConnectorInfo, ConnectorTransport,
+    FetchLivePageRequest, FetchLivePageResponse, FetchSnapshotChunkRequest,
+    FetchSnapshotChunkResponse, GetAppStructureRequest, GetAppStructureResponse, HealthStatus,
+    RefreshAppStructureRequest, RefreshAppStructureResponse, SnapshotMeta, SnapshotRecord,
+    SubmitActionOutcome, SubmitActionRequest, SubmitActionResponse,
+};
+use base64::{engine::general_purpose::STANDARD as BASE64_STANDARD, Engine as _};
+use serde_json::{json, Map as JsonMap, Value as JsonValue};
+use std::collections::{HashMap, HashSet};
+use std::net::TcpStream;
+use std::sync::{Mutex, OnceLock};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use tungstenite::stream::MaybeTlsStream;
+use tungstenite::{connect, Message, WebSocket};
+
+const TINODE_APP_ID: &str = "tinode";
+const TINODE_CREDENTIAL_POLICY_AUTO_CREATE: &str = "auto-create";
+const TINODE_STRUCTURE_REVISION: &str = "tinode-skeleton-v0";
+const DEFAULT_TINODE_API_KEY: &str = "AQEAAAABAAD_rAp4DJh05a1HAwFT3A6K";
+const DEFAULT_TINODE_ACCOUNT_PASSWORD: &str = "TinodeSmoke123!";
+const DEFAULT_TINODE_PROTOCOL_VERSION: &str = "0.25";
+const DEFAULT_TINODE_TIMEOUT_MS: u64 = 10_000;
+const CONNECTOR_SIDE_EVENTS_FIELD: &str = "_appfs_events";
+const TINODE_LOGIN_MIN_LEN: usize = 4;
+// Tinode's basic authenticator allows 32 runes, but the MySQL-backed auth
+// record stores `basic:<login>` in a 32-byte unique key. Keep generated logins
+// conservative so account creation does not surface as a server-side 500.
+const TINODE_LOGIN_MAX_LEN: usize = 26;
+const TINODE_LOGIN_HASH_LEN: usize = 8;
+
+type TinodeSocket = WebSocket<MaybeTlsStream<TcpStream>>;
+
+/// Tinode connector configuration.
+///
+/// Endpoint and login prefix are infrastructure configuration. The API key and
+/// account password are used only by the connector process and must never be
+/// rendered into AppFS files, events, skills, or session logs.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TinodeConnectorConfig {
+    pub endpoint: String,
+    pub credential_policy: String,
+    pub login_prefix: String,
+    pub api_key: String,
+    pub account_password: String,
+    pub protocol_version: String,
+    pub request_timeout_ms: u64,
+}
+
+impl TinodeConnectorConfig {
+    pub fn new(
+        endpoint: impl Into<String>,
+        credential_policy: impl Into<String>,
+        login_prefix: impl Into<String>,
+    ) -> std::result::Result<Self, ConnectorError> {
+        Self::with_options(
+            endpoint,
+            credential_policy,
+            login_prefix,
+            DEFAULT_TINODE_API_KEY,
+            DEFAULT_TINODE_ACCOUNT_PASSWORD,
+            DEFAULT_TINODE_PROTOCOL_VERSION,
+            DEFAULT_TINODE_TIMEOUT_MS,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn with_options(
+        endpoint: impl Into<String>,
+        credential_policy: impl Into<String>,
+        login_prefix: impl Into<String>,
+        api_key: impl Into<String>,
+        account_password: impl Into<String>,
+        protocol_version: impl Into<String>,
+        request_timeout_ms: u64,
+    ) -> std::result::Result<Self, ConnectorError> {
+        let config = Self {
+            endpoint: endpoint.into(),
+            credential_policy: credential_policy.into(),
+            login_prefix: login_prefix.into(),
+            api_key: api_key.into(),
+            account_password: account_password.into(),
+            protocol_version: protocol_version.into(),
+            request_timeout_ms,
+        };
+        config.validate()
+    }
+
+    pub fn from_env() -> std::result::Result<Self, ConnectorError> {
+        let endpoint = std::env::var("APPFS_TINODE_ENDPOINT").map_err(|_| {
+            connector_err(
+                connector_error_codes::INVALID_ARGUMENT,
+                "APPFS_TINODE_ENDPOINT is required for the in-process Tinode connector",
+                false,
+            )
+        })?;
+        let login_prefix = std::env::var("APPFS_TINODE_LOGIN_PREFIX").map_err(|_| {
+            connector_err(
+                connector_error_codes::INVALID_ARGUMENT,
+                "APPFS_TINODE_LOGIN_PREFIX is required for the in-process Tinode connector",
+                false,
+            )
+        })?;
+        let credential_policy = std::env::var("APPFS_TINODE_CREDENTIAL_POLICY")
+            .unwrap_or_else(|_| TINODE_CREDENTIAL_POLICY_AUTO_CREATE.to_string());
+        let api_key =
+            std::env::var("APPFS_TINODE_API_KEY").unwrap_or_else(|_| DEFAULT_TINODE_API_KEY.into());
+        let account_password = std::env::var("APPFS_TINODE_ACCOUNT_PASSWORD")
+            .unwrap_or_else(|_| DEFAULT_TINODE_ACCOUNT_PASSWORD.into());
+        let protocol_version = std::env::var("APPFS_TINODE_PROTOCOL_VERSION")
+            .unwrap_or_else(|_| DEFAULT_TINODE_PROTOCOL_VERSION.into());
+        let request_timeout_ms = std::env::var("APPFS_TINODE_TIMEOUT_MS")
+            .ok()
+            .and_then(|value| value.parse::<u64>().ok())
+            .unwrap_or(DEFAULT_TINODE_TIMEOUT_MS);
+
+        Self::with_options(
+            endpoint,
+            credential_policy,
+            login_prefix,
+            api_key,
+            account_password,
+            protocol_version,
+            request_timeout_ms,
+        )
+    }
+
+    fn validate(mut self) -> std::result::Result<Self, ConnectorError> {
+        self.endpoint = self.endpoint.trim().trim_end_matches('/').to_string();
+        self.credential_policy = self.credential_policy.trim().to_string();
+        self.login_prefix = self.login_prefix.trim().to_string();
+        self.api_key = self.api_key.trim().to_string();
+        self.account_password = self.account_password.trim().to_string();
+        self.protocol_version = self.protocol_version.trim().to_string();
+
+        if self.endpoint.is_empty()
+            || !(self.endpoint.starts_with("http://") || self.endpoint.starts_with("https://"))
+        {
+            return Err(connector_err(
+                connector_error_codes::INVALID_ARGUMENT,
+                "Tinode connector endpoint must be an http(s) URL",
+                false,
+            ));
+        }
+        if self.credential_policy != TINODE_CREDENTIAL_POLICY_AUTO_CREATE {
+            return Err(connector_err(
+                connector_error_codes::INVALID_ARGUMENT,
+                "Tinode connector v0 supports only credential_policy=auto-create",
+                false,
+            ));
+        }
+        if !is_safe_login_prefix(&self.login_prefix) {
+            return Err(connector_err(
+                connector_error_codes::INVALID_ARGUMENT,
+                "Tinode login prefix must contain only ASCII letters, digits, '_' or '-'",
+                false,
+            ));
+        }
+        if self.api_key.is_empty() {
+            return Err(connector_err(
+                connector_error_codes::INVALID_ARGUMENT,
+                "Tinode API key must be non-empty",
+                false,
+            ));
+        }
+        if self.account_password.is_empty() {
+            return Err(connector_err(
+                connector_error_codes::INVALID_ARGUMENT,
+                "Tinode account password must be non-empty",
+                false,
+            ));
+        }
+        if self.protocol_version.is_empty() {
+            return Err(connector_err(
+                connector_error_codes::INVALID_ARGUMENT,
+                "Tinode protocol version must be non-empty",
+                false,
+            ));
+        }
+        if self.request_timeout_ms == 0 {
+            return Err(connector_err(
+                connector_error_codes::INVALID_ARGUMENT,
+                "Tinode request timeout must be positive",
+                false,
+            ));
+        }
+
+        Ok(self)
+    }
+}
+
+#[derive(Default)]
+struct TinodeSharedState {
+    credentials: HashMap<String, ConnectorCredentialRecord>,
+    principal_profiles: HashMap<String, String>,
+}
+
+static TINODE_SHARED_STATE: OnceLock<Mutex<TinodeSharedState>> = OnceLock::new();
+
+fn tinode_shared_state() -> &'static Mutex<TinodeSharedState> {
+    TINODE_SHARED_STATE.get_or_init(|| Mutex::new(TinodeSharedState::default()))
+}
+
+/// Tinode AppFS connector.
+///
+/// PR8 adds the first real business path: auto-create connector-private
+/// credentials for the effective profile and send a direct message using a
+/// root `contacts/send_message.act` action.
+pub struct TinodeConnector {
+    config: TinodeConnectorConfig,
+    shared_namespace: String,
+    credential_create_attempts: u64,
+    credentials: HashMap<String, ConnectorCredentialRecord>,
+    contacts: HashMap<String, TinodeContact>,
+    direct_messages: HashMap<String, Vec<TinodeMessageRecord>>,
+    groups: HashMap<String, TinodeGroupRecord>,
+    group_messages: HashMap<String, Vec<TinodeGroupMessageRecord>>,
+    inbox_recent: Vec<InboxRecord>,
+    unread_message_ids: HashSet<String>,
+    last_direct_seq_by_contact: HashMap<String, i64>,
+    gateway: Box<dyn TinodeGateway>,
+}
+
+impl TinodeConnector {
+    pub fn new(config: TinodeConnectorConfig) -> Self {
+        let gateway = Box::new(WebSocketTinodeGateway::new(config.clone()));
+        Self::new_with_gateway(config, gateway)
+    }
+
+    fn new_with_gateway(config: TinodeConnectorConfig, gateway: Box<dyn TinodeGateway>) -> Self {
+        let shared_namespace = shared_state_namespace(&config);
+        Self {
+            config,
+            shared_namespace,
+            credential_create_attempts: 0,
+            credentials: HashMap::new(),
+            contacts: HashMap::new(),
+            direct_messages: HashMap::new(),
+            groups: HashMap::new(),
+            group_messages: HashMap::new(),
+            inbox_recent: Vec::new(),
+            unread_message_ids: HashSet::new(),
+            last_direct_seq_by_contact: HashMap::new(),
+            gateway,
+        }
+    }
+
+    pub fn from_env() -> std::result::Result<Self, ConnectorError> {
+        Ok(Self::new(TinodeConnectorConfig::from_env()?))
+    }
+
+    #[must_use]
+    pub fn config(&self) -> &TinodeConnectorConfig {
+        &self.config
+    }
+
+    #[must_use]
+    pub fn credential_create_attempts(&self) -> u64 {
+        self.credential_create_attempts
+    }
+
+    fn snapshot(&self, ctx: &ConnectorContext) -> AppStructureSnapshot {
+        AppStructureSnapshot {
+            app_id: TINODE_APP_ID.to_string(),
+            revision: self.structure_revision(ctx),
+            active_scope: None,
+            ownership_prefixes: vec![
+                "_app".to_string(),
+                "contacts".to_string(),
+                "groups".to_string(),
+                "inbox".to_string(),
+                "topics".to_string(),
+            ],
+            nodes: self.structure_nodes(ctx),
+        }
+    }
+
+    fn structure_revision(&self, ctx: &ConnectorContext) -> String {
+        let profile_id = effective_profile_id(ctx).unwrap_or_else(|_| "missing-profile".into());
+        let credential_status = self
+            .credentials
+            .get(&profile_id)
+            .map(|record| credential_status_label(record.credential_status))
+            .unwrap_or("missing");
+        format!(
+            "{TINODE_STRUCTURE_REVISION}-contacts{}-groups{}-inbox{}-{credential_status}",
+            self.contacts.len(),
+            self.groups.len(),
+            self.inbox_recent.len()
+        )
+    }
+
+    fn structure_nodes(&self, ctx: &ConnectorContext) -> Vec<AppStructureNode> {
+        let mut nodes = vec![
+            dir("_app"),
+            static_json("_app/actions.res.json", self.actions_resource()),
+            static_json("_app/control.res.json", self.control_resource()),
+            static_json("_app/skill.res.json", self.skill_resource()),
+            static_json("_app/self.res.json", self.self_resource(ctx)),
+            action("_app/ensure_credentials.act"),
+            action("_app/refresh_structure.act"),
+            action("_app/refresh_inbox.act"),
+            dir("contacts"),
+            snapshot_jsonl("contacts/index.res.jsonl"),
+            action("contacts/send_message.act"),
+            action("contacts/resolve.act"),
+            snapshot_jsonl("contacts/search_results.res.jsonl"),
+            dir("groups"),
+            snapshot_jsonl("groups/index.res.jsonl"),
+            action("groups/create_group.act"),
+            dir("inbox"),
+            snapshot_jsonl("inbox/recent.res.jsonl"),
+            snapshot_jsonl("inbox/unread.res.jsonl"),
+            action("inbox/mark_read.act"),
+            dir("topics"),
+            snapshot_jsonl("topics/index.res.jsonl"),
+        ];
+
+        let mut contact_keys = self.contacts.keys().cloned().collect::<Vec<_>>();
+        contact_keys.sort();
+        for key in contact_keys {
+            nodes.push(dir(&format!("contacts/{key}")));
+            nodes.push(snapshot_jsonl(&format!(
+                "contacts/{key}/messages.res.jsonl"
+            )));
+            nodes.push(action(&format!("contacts/{key}/send_message.act")));
+        }
+
+        let mut group_keys = self.groups.keys().cloned().collect::<Vec<_>>();
+        group_keys.sort();
+        for key in group_keys {
+            if let Some(group) = self.groups.get(&key) {
+                nodes.push(dir(&format!("groups/{key}")));
+                nodes.push(static_json(
+                    &format!("groups/{key}/group.res.json"),
+                    group.to_resource_line(),
+                ));
+                nodes.push(snapshot_jsonl(&format!("groups/{key}/messages.res.jsonl")));
+                nodes.push(action(&format!("groups/{key}/send_message.act")));
+                nodes.push(action(&format!("groups/{key}/invite_members.act")));
+            }
+        }
+
+        nodes.sort_by(|a, b| a.path.cmp(&b.path));
+        nodes
+    }
+
+    fn skill_resource(&self) -> JsonValue {
+        json!({
+            "app_id": TINODE_APP_ID,
+            "description": "Tinode private chat app for the current AppFS principal.",
+            "when_to_use": [
+                "Use when the user wants to send messages through Tinode to a person or another agent.",
+                "Use when the user wants to inspect the current principal's Tinode inbox, contacts, or groups.",
+                "Load this skill before performing Tinode private-app action-file operations."
+            ],
+            "overview_markdown": "Tinode is the current AppFS principal's private chat app. Each principal has an independent Tinode profile and credentials. Operate only under the current app root, usually `private/<principal-id>/tinode`.",
+            "allowed_tools": ["bash", "read_file", "glob_search"],
+            "include_generated_sections": {
+                "scope_summary": false,
+                "control_actions": true,
+                "recommended_actions": true,
+                "contact_routing": true
+            }
+        })
+    }
+
+    fn control_resource(&self) -> JsonValue {
+        json!({
+            "app_id": TINODE_APP_ID,
+            "description": "Private Tinode chat control plane for the active AppFS principal.",
+            "events_path": "_stream/events.evt.jsonl",
+            "actions": [
+                {
+                    "name": "ensure_credentials",
+                    "path": "_app/ensure_credentials.act",
+                    "summary": "Create or reuse the current principal's Tinode credentials without exposing secrets.",
+                    "example_payload": {
+                        "expected_profile_id": "tinode:default",
+                        "client_token": "ensure-tinode-default"
+                    },
+                    "use_when": [
+                        "Tinode reports PROFILE_NOT_READY or the user asks to initialize the current agent's Tinode identity."
+                    ]
+                },
+                {
+                    "name": "refresh_inbox",
+                    "path": "_app/refresh_inbox.act",
+                    "summary": "Refresh inbox resources for the current Tinode profile.",
+                    "example_payload": {
+                        "client_token": "refresh-inbox-001"
+                    },
+                    "use_when": [
+                        "Inbox resources look stale and no AppFS event reminder has arrived."
+                    ]
+                }
+            ]
+        })
+    }
+
+    fn actions_resource(&self) -> JsonValue {
+        json!({
+            "app_id": TINODE_APP_ID,
+            "recommended_actions": [
+                {
+                    "name": "send_direct_message",
+                    "path": "contacts/send_message.act",
+                    "summary": "Send a Tinode direct message. Use `to` with `basic:<login>`, `tinode_user:<usr-id>`, or `principal:<principal-id>`.",
+                    "example_payload": {
+                        "to": "principal:code-implementer",
+                        "text": "请接手实现这个任务。",
+                        "client_token": "msg-to-agent-001"
+                    },
+                    "use_when": [
+                        "The user asks to message another agent or a Tinode contact and the exact contact path is unknown.",
+                        "The user asks default to delegate work to a forked principal such as code-implementer."
+                    ]
+                },
+                {
+                    "name": "create_group",
+                    "path": "groups/create_group.act",
+                    "summary": "Create a Tinode group and invite members.",
+                    "example_payload": {
+                        "title": "multi-agent-smoke",
+                        "members": ["principal:code-implementer"],
+                        "client_token": "grp-multi-agent-001"
+                    },
+                    "use_when": [
+                        "The user wants multiple agents or contacts to collaborate in one Tinode group."
+                    ]
+                },
+                {
+                    "name": "mark_inbox_read",
+                    "path": "inbox/mark_read.act",
+                    "summary": "Mark inbox messages as read for the current principal.",
+                    "example_payload": {
+                        "client_token": "mark-read-001"
+                    },
+                    "use_when": [
+                        "The user asks to acknowledge or clear read state for Tinode inbox messages."
+                    ]
+                }
+            ],
+            "contact_routes": [
+                {
+                    "mention_tokens": ["another agent", "其他 agent", "code-implementer", "principal:<principal-id>"],
+                    "send_message_path": "contacts/send_message.act"
+                }
+            ]
+        })
+    }
+
+    fn self_resource(&self, ctx: &ConnectorContext) -> JsonValue {
+        let principal_id = ctx.principal_id.as_deref().unwrap_or("default");
+        let profile_id = ctx
+            .profile_id
+            .as_deref()
+            .unwrap_or("tinode:unknown-profile");
+
+        if let Some(record) = self.credentials.get(profile_id) {
+            let summary = record.safe_summary();
+            return json!({
+                "app_id": TINODE_APP_ID,
+                "principal_id": principal_id,
+                "profile_id": summary.profile_id,
+                "credential_policy": self.config.credential_policy,
+                "credential_status": summary.credential_status,
+                "tinode_user_id": summary.upstream_user_id,
+                "login": summary.login,
+                "display_name": summary.display_name.unwrap_or_else(|| principal_id.to_string()),
+                "owner_ref": principal_id,
+            });
+        }
+
+        json!({
+            "app_id": TINODE_APP_ID,
+            "principal_id": principal_id,
+            "profile_id": profile_id,
+            "credential_policy": self.config.credential_policy,
+            "credential_status": "missing",
+            "tinode_user_id": null,
+            "login": null,
+            "display_name": principal_id,
+            "owner_ref": null,
+        })
+    }
+
+    fn fetch_snapshot_response(
+        &self,
+        request: FetchSnapshotChunkRequest,
+    ) -> std::result::Result<FetchSnapshotChunkResponse, ConnectorError> {
+        let normalized = normalize_path(&request.resource_path);
+        if !is_tinode_snapshot_resource(&normalized) {
+            return Err(connector_err(
+                connector_error_codes::NOT_SUPPORTED,
+                format!(
+                    "unknown Tinode snapshot resource: {}",
+                    request.resource_path
+                ),
+                false,
+            ));
+        }
+
+        let records = match normalized.as_str() {
+            "contacts/index.res.jsonl" => self.contact_index_records(),
+            "groups/index.res.jsonl" => self.group_index_records(),
+            "inbox/recent.res.jsonl" => self.inbox_records(false),
+            "inbox/unread.res.jsonl" => self.inbox_records(true),
+            "contacts/search_results.res.jsonl" | "topics/index.res.jsonl" => Vec::new(),
+            path if contact_messages_key(path).is_some() => {
+                let key = contact_messages_key(path).expect("checked contact messages path");
+                self.contact_message_records(key)
+            }
+            path if group_messages_key(path).is_some() => {
+                let key = group_messages_key(path).expect("checked group messages path");
+                self.group_message_records(key)
+            }
+            _ => Vec::new(),
+        };
+        let emitted_bytes = records
+            .iter()
+            .map(|record| {
+                serde_json::to_string(&record.line)
+                    .unwrap_or_default()
+                    .len() as u64
+                    + 1
+            })
+            .sum();
+
+        Ok(FetchSnapshotChunkResponse {
+            records,
+            emitted_bytes,
+            next_cursor: None,
+            has_more: false,
+            revision: Some(TINODE_STRUCTURE_REVISION.to_string()),
+        })
+    }
+
+    fn contact_index_records(&self) -> Vec<SnapshotRecord> {
+        let mut contacts = self.contacts.values().cloned().collect::<Vec<_>>();
+        contacts.sort_by(|a, b| a.key.cmp(&b.key));
+        contacts
+            .into_iter()
+            .map(|contact| SnapshotRecord {
+                record_key: contact.key.clone(),
+                ordering_key: contact.key.clone(),
+                line: contact.to_resource_line(),
+            })
+            .collect()
+    }
+
+    fn contact_message_records(&self, contact_key: &str) -> Vec<SnapshotRecord> {
+        self.direct_messages
+            .get(contact_key)
+            .cloned()
+            .unwrap_or_default()
+            .into_iter()
+            .map(|message| SnapshotRecord {
+                record_key: message.message_id.clone(),
+                ordering_key: message.created_at_ms.to_string(),
+                line: message.to_resource_line(),
+            })
+            .collect()
+    }
+
+    fn group_index_records(&self) -> Vec<SnapshotRecord> {
+        let mut groups = self.groups.values().cloned().collect::<Vec<_>>();
+        groups.sort_by(|a, b| a.key.cmp(&b.key));
+        groups
+            .into_iter()
+            .map(|group| SnapshotRecord {
+                record_key: group.key.clone(),
+                ordering_key: group.created_at_ms.to_string(),
+                line: group.to_resource_line(),
+            })
+            .collect()
+    }
+
+    fn group_message_records(&self, group_key: &str) -> Vec<SnapshotRecord> {
+        self.group_messages
+            .get(group_key)
+            .cloned()
+            .unwrap_or_default()
+            .into_iter()
+            .map(|message| SnapshotRecord {
+                record_key: message.message_id.clone(),
+                ordering_key: message.created_at_ms.to_string(),
+                line: message.to_resource_line(),
+            })
+            .collect()
+    }
+
+    fn inbox_records(&self, unread_only: bool) -> Vec<SnapshotRecord> {
+        self.inbox_recent
+            .iter()
+            .filter(|record| !unread_only || self.unread_message_ids.contains(&record.message_id))
+            .cloned()
+            .map(|record| SnapshotRecord {
+                record_key: record.message_id.clone(),
+                ordering_key: record.created_at_ms.to_string(),
+                line: record.to_resource_line(self.unread_message_ids.contains(&record.message_id)),
+            })
+            .collect()
+    }
+
+    fn ensure_credentials(
+        &mut self,
+        ctx: &ConnectorContext,
+    ) -> std::result::Result<(ConnectorCredentialRecord, bool), ConnectorError> {
+        let profile_id = effective_profile_id(ctx)?;
+        let principal_id = ctx.principal_id.as_deref().unwrap_or("default");
+        if let Some(record) = self.ready_credential_record_for_profile(&profile_id, principal_id) {
+            return Ok((record, false));
+        }
+
+        self.credential_create_attempts += 1;
+        let login = login_for_profile(&self.config, principal_id, &profile_id);
+        let display_name = display_name_for_principal(principal_id);
+        let request = TinodeAccountRequest {
+            profile_id: profile_id.clone(),
+            login: login.clone(),
+            password: self.config.account_password.clone(),
+            display_name: display_name.clone(),
+            tags: vec![
+                login.clone(),
+                profile_id.clone(),
+                principal_id.to_string(),
+                "appfs-agent".to_string(),
+            ],
+        };
+        let account = self.gateway.create_or_reuse_account(request)?;
+        let record = ConnectorCredentialRecord {
+            profile_id: profile_id.clone(),
+            credential_status: ConnectorCredentialStatus::Ready,
+            upstream_user_id: Some(account.tinode_user_id.clone()),
+            login: Some(account.login.clone()),
+            display_name: Some(account.display_name.clone()),
+            last_ready_at: Some(now_millis_string()),
+            expires_at: None,
+            credentials: Some(json!({
+                "scheme": "tinode_token",
+                "token": account.token,
+            })),
+        };
+        self.credentials.insert(profile_id, record.clone());
+        self.store_shared_credential(principal_id, &record);
+        Ok((record, true))
+    }
+
+    fn ready_credential_record_for_profile(
+        &mut self,
+        profile_id: &str,
+        principal_id: &str,
+    ) -> Option<ConnectorCredentialRecord> {
+        if let Some(record) = self.credentials.get(profile_id).cloned() {
+            if record.credential_status == ConnectorCredentialStatus::Ready {
+                self.remember_principal_profile(principal_id, &record);
+                return Some(record);
+            }
+        }
+        if let Some(record) = self.shared_credential(profile_id) {
+            if record.credential_status == ConnectorCredentialStatus::Ready {
+                self.credentials
+                    .insert(profile_id.to_string(), record.clone());
+                self.remember_principal_profile(principal_id, &record);
+                return Some(record);
+            }
+        }
+        None
+    }
+
+    fn shared_credential(&self, profile_id: &str) -> Option<ConnectorCredentialRecord> {
+        let state = tinode_shared_state().lock().ok()?;
+        state
+            .credentials
+            .get(&shared_credential_key(&self.shared_namespace, profile_id))
+            .cloned()
+    }
+
+    fn store_shared_credential(&self, principal_id: &str, record: &ConnectorCredentialRecord) {
+        if let Ok(mut state) = tinode_shared_state().lock() {
+            state.credentials.insert(
+                shared_credential_key(&self.shared_namespace, &record.profile_id),
+                record.clone(),
+            );
+            state.principal_profiles.insert(
+                shared_principal_key(&self.shared_namespace, principal_id),
+                record.profile_id.clone(),
+            );
+        }
+    }
+
+    fn remember_principal_profile(&self, principal_id: &str, record: &ConnectorCredentialRecord) {
+        if let Ok(mut state) = tinode_shared_state().lock() {
+            state.principal_profiles.insert(
+                shared_principal_key(&self.shared_namespace, principal_id),
+                record.profile_id.clone(),
+            );
+        }
+    }
+
+    fn remember_shared_principal_contacts(
+        &mut self,
+        credentials: &TinodeCredentials,
+        current_principal_id: Option<&str>,
+    ) -> std::result::Result<(), ConnectorError> {
+        let state = tinode_shared_state().lock().map_err(|_| {
+            connector_err(
+                connector_error_codes::INTERNAL,
+                "Tinode shared credential state is poisoned",
+                true,
+            )
+        })?;
+        let principal_prefix = format!("{}|principal:", self.shared_namespace);
+        let mut contacts = Vec::new();
+        for (principal_key, profile_id) in &state.principal_profiles {
+            let Some(principal_id) = principal_key.strip_prefix(&principal_prefix) else {
+                continue;
+            };
+            if current_principal_id == Some(principal_id) || profile_id == &credentials.profile_id {
+                continue;
+            }
+            let Some(record) = state
+                .credentials
+                .get(&shared_credential_key(&self.shared_namespace, profile_id))
+            else {
+                continue;
+            };
+            if record.credential_status != ConnectorCredentialStatus::Ready {
+                continue;
+            }
+            let Some(tinode_user_id) = record.upstream_user_id.clone() else {
+                continue;
+            };
+            if tinode_user_id == credentials.tinode_user_id {
+                continue;
+            }
+            contacts.push(TinodeContact {
+                key: sanitize_path_key(principal_id),
+                tinode_user_id,
+                basic_login: record.login.clone(),
+                display_name: record.display_name.clone(),
+            });
+        }
+        drop(state);
+
+        for contact in contacts {
+            self.contacts.entry(contact.key.clone()).or_insert(contact);
+        }
+        Ok(())
+    }
+
+    fn resolve_recipient(
+        &mut self,
+        credentials: &TinodeCredentials,
+        reference: RecipientRef,
+    ) -> std::result::Result<TinodeContact, ConnectorError> {
+        match reference {
+            RecipientRef::Basic(login) => {
+                let key = contact_key_from_basic_login(&login);
+                if let Some(contact) = self.contacts.get(&key) {
+                    return Ok(contact.clone());
+                }
+                let contact = self.gateway.resolve_basic_user(credentials, &login)?;
+                self.contacts.insert(contact.key.clone(), contact.clone());
+                Ok(contact)
+            }
+            RecipientRef::ContactKey(key) => self.contacts.get(&key).cloned().ok_or_else(|| {
+                connector_err(
+                    connector_error_codes::PROFILE_NOT_FOUND,
+                    format!("Tinode contact `{key}` is not known yet; use contacts/send_message.act with to=\"basic:<login>\" first"),
+                    false,
+                )
+            }),
+            RecipientRef::TinodeUser(tinode_user_id) => Ok(TinodeContact {
+                key: contact_key_from_tinode_user(&tinode_user_id),
+                tinode_user_id,
+                basic_login: None,
+                display_name: None,
+            }),
+            RecipientRef::Principal(principal_id) => self.resolve_principal_contact(&principal_id),
+        }
+    }
+
+    fn resolve_principal_contact(
+        &self,
+        principal_id: &str,
+    ) -> std::result::Result<TinodeContact, ConnectorError> {
+        let member = self.resolve_principal_group_member(principal_id)?;
+        Ok(TinodeContact {
+            key: sanitize_path_key(principal_id),
+            tinode_user_id: member.tinode_user_id,
+            basic_login: member.basic_login,
+            display_name: member.display_name,
+        })
+    }
+
+    fn resolve_principal_group_member(
+        &self,
+        principal_id: &str,
+    ) -> std::result::Result<TinodeGroupMember, ConnectorError> {
+        let state = tinode_shared_state().lock().map_err(|_| {
+            connector_err(
+                connector_error_codes::INTERNAL,
+                "Tinode shared credential state is poisoned",
+                true,
+            )
+        })?;
+        let principal_key = shared_principal_key(&self.shared_namespace, principal_id);
+        let profile_id = state
+            .principal_profiles
+            .get(&principal_key)
+            .cloned()
+            .ok_or_else(|| {
+                connector_err(
+                    connector_error_codes::PROFILE_NOT_READY,
+                    format!(
+                        "Tinode profile for principal:{principal_id} is not ready; start that agent and run _app/ensure_credentials.act first"
+                    ),
+                    true,
+                )
+            })?;
+        let record = state
+            .credentials
+            .get(&shared_credential_key(&self.shared_namespace, &profile_id))
+            .ok_or_else(|| {
+                connector_err(
+                    connector_error_codes::PROFILE_NOT_READY,
+                    format!(
+                        "Tinode credentials for principal:{principal_id} profile {profile_id} are not ready"
+                    ),
+                    true,
+                )
+            })?;
+        let tinode_user_id = record.upstream_user_id.clone().ok_or_else(|| {
+            connector_err(
+                connector_error_codes::PROFILE_NOT_READY,
+                format!("Tinode credentials for principal:{principal_id} have no upstream user id"),
+                true,
+            )
+        })?;
+        Ok(TinodeGroupMember {
+            kind: "principal".to_string(),
+            principal_id: Some(principal_id.to_string()),
+            profile_id: Some(profile_id),
+            contact_key: None,
+            tinode_user_id,
+            basic_login: record.login.clone(),
+            display_name: record.display_name.clone(),
+        })
+    }
+
+    fn submit_ensure_credentials(
+        &mut self,
+        ctx: &ConnectorContext,
+    ) -> std::result::Result<SubmitActionResponse, ConnectorError> {
+        let (record, _) = self.ensure_credentials(ctx)?;
+        Ok(completed_response(
+            ctx,
+            serde_json::to_value(record.safe_summary()).map_err(|err| {
+                connector_err(
+                    connector_error_codes::INTERNAL,
+                    format!("failed to encode credential summary: {err}"),
+                    true,
+                )
+            })?,
+        ))
+    }
+
+    fn submit_resolve_contact(
+        &mut self,
+        request: SubmitActionRequest,
+        ctx: &ConnectorContext,
+    ) -> std::result::Result<SubmitActionResponse, ConnectorError> {
+        let reference = recipient_ref_from_payload(&request.payload)?;
+        let (record, created_credentials) = self.ensure_credentials(ctx)?;
+        let credentials = credentials_from_record(&record)?;
+        let contact = self.resolve_recipient(&credentials, reference)?;
+        let mut content = json!({
+            "ok": true,
+            "contact": contact.to_resource_line(),
+        });
+        add_side_event(
+            &mut content,
+            "profile.credentials.ready",
+            Some(serde_json::to_value(record.safe_summary()).map_err(|err| {
+                connector_err(
+                    connector_error_codes::INTERNAL,
+                    format!("failed to encode credential summary: {err}"),
+                    true,
+                )
+            })?),
+            created_credentials,
+        );
+        add_side_event(
+            &mut content,
+            "contact.resolved",
+            Some(json!({ "contact": contact.to_resource_line() })),
+            true,
+        );
+        Ok(completed_response(ctx, content))
+    }
+
+    fn submit_send_message(
+        &mut self,
+        request: SubmitActionRequest,
+        ctx: &ConnectorContext,
+    ) -> std::result::Result<SubmitActionResponse, ConnectorError> {
+        let normalized_path = normalize_path(&request.path);
+        let (reference, text) = message_target_and_text(&normalized_path, &request.payload)?;
+        let (record, created_credentials) = self.ensure_credentials(ctx)?;
+        let credentials = credentials_from_record(&record)?;
+        let contact = self.resolve_recipient(&credentials, reference)?;
+        let receipt = self.gateway.send_direct_message(
+            &credentials,
+            &contact,
+            &text,
+            ctx.client_token.as_deref(),
+        )?;
+        let message = TinodeMessageRecord {
+            message_id: receipt.message_id.clone(),
+            contact_key: contact.key.clone(),
+            direction: "outbound".to_string(),
+            text: text.clone(),
+            created_at_ms: now_millis(),
+            seq: receipt.seq,
+        };
+        self.direct_messages
+            .entry(contact.key.clone())
+            .or_default()
+            .push(message.clone());
+
+        let safe_summary = record.safe_summary();
+        let mut content = json!({
+            "ok": true,
+            "conversation_type": "direct",
+            "principal_id": ctx.principal_id.as_deref().unwrap_or("default"),
+            "profile_id": safe_summary.profile_id,
+            "message_id": receipt.message_id,
+            "topic": receipt.topic,
+            "to": contact.to_resource_line(),
+            "text_preview": text_preview(&text),
+        });
+        add_side_event(
+            &mut content,
+            "action.accepted",
+            Some(json!({
+                "conversation_type": "direct",
+                "path": request.path,
+                "profile_id": safe_summary.profile_id,
+            })),
+            true,
+        );
+        add_side_event(
+            &mut content,
+            "profile.credentials.ready",
+            Some(serde_json::to_value(safe_summary.clone()).map_err(|err| {
+                connector_err(
+                    connector_error_codes::INTERNAL,
+                    format!("failed to encode credential summary: {err}"),
+                    true,
+                )
+            })?),
+            created_credentials,
+        );
+        add_side_event(
+            &mut content,
+            "message.sent",
+            Some(json!({
+                "conversation_type": "direct",
+                "principal_id": ctx.principal_id.as_deref().unwrap_or("default"),
+                "profile_id": safe_summary.profile_id,
+                "path": request.path,
+                "message_id": message.message_id,
+                "to_display_name": contact.display_name,
+                "to_tinode_user_id": contact.tinode_user_id,
+                "text_preview": text_preview(&text),
+                "client_token": ctx.client_token,
+            })),
+            true,
+        );
+
+        Ok(completed_response(ctx, content))
+    }
+
+    fn submit_create_group(
+        &mut self,
+        request: SubmitActionRequest,
+        ctx: &ConnectorContext,
+    ) -> std::result::Result<SubmitActionResponse, ConnectorError> {
+        let title = group_title_from_payload(&request.payload)?;
+        let group_key = group_key_from_payload(&request.payload, &title);
+        let member_refs = group_member_refs_from_payload(&request.payload)?;
+        let initial_message = request
+            .payload
+            .get("initial_message")
+            .and_then(JsonValue::as_str)
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(ToOwned::to_owned);
+        let (record, created_credentials) = self.ensure_credentials(ctx)?;
+        let credentials = credentials_from_record(&record)?;
+        let members = self.resolve_group_members(&credentials, member_refs)?;
+        let receipt = self.gateway.create_group(
+            &credentials,
+            &title,
+            &members,
+            ctx.client_token.as_deref(),
+        )?;
+        let created_at_ms = now_millis();
+        let group = TinodeGroupRecord {
+            key: group_key.clone(),
+            title: title.clone(),
+            topic_id: receipt.topic.clone(),
+            members: members.clone(),
+            created_at_ms,
+            last_message_at_ms: None,
+        };
+        self.groups.insert(group_key.clone(), group.clone());
+
+        let mut sent_initial = None;
+        if let Some(text) = initial_message {
+            let receipt = self.gateway.send_group_message(
+                &credentials,
+                &group,
+                &text,
+                ctx.client_token.as_deref(),
+            )?;
+            let message = TinodeGroupMessageRecord::outbound(&group, receipt, text);
+            sent_initial = Some(message.message_id.clone());
+            self.group_messages
+                .entry(group_key.clone())
+                .or_default()
+                .push(message);
+            if let Some(group) = self.groups.get_mut(&group_key) {
+                group.last_message_at_ms = Some(now_millis());
+            }
+        }
+
+        let safe_summary = record.safe_summary();
+        let mut content = json!({
+            "ok": true,
+            "conversation_type": "group",
+            "principal_id": ctx.principal_id.as_deref().unwrap_or("default"),
+            "profile_id": safe_summary.profile_id,
+            "group_key": group_key,
+            "topic": group.topic_id,
+            "title": group.title,
+            "member_count": group.members.len(),
+            "initial_message_id": sent_initial,
+            "structure_changed": true,
+        });
+        add_side_event(
+            &mut content,
+            "action.accepted",
+            Some(json!({
+                "conversation_type": "group",
+                "path": request.path,
+                "profile_id": safe_summary.profile_id,
+            })),
+            true,
+        );
+        add_side_event(
+            &mut content,
+            "profile.credentials.ready",
+            Some(serde_json::to_value(safe_summary.clone()).map_err(|err| {
+                connector_err(
+                    connector_error_codes::INTERNAL,
+                    format!("failed to encode credential summary: {err}"),
+                    true,
+                )
+            })?),
+            created_credentials,
+        );
+        add_side_event(
+            &mut content,
+            "group.created",
+            Some(json!({
+                "principal_id": ctx.principal_id.as_deref().unwrap_or("default"),
+                "profile_id": safe_summary.profile_id,
+                "path": format!("groups/{}/group.res.json", group.key),
+                "group_key": group.key,
+                "topic": group.topic_id,
+                "title": group.title,
+                "member_count": group.members.len(),
+            })),
+            true,
+        );
+        Ok(completed_response(ctx, content))
+    }
+
+    fn submit_invite_group_members(
+        &mut self,
+        request: SubmitActionRequest,
+        ctx: &ConnectorContext,
+        group_key: &str,
+    ) -> std::result::Result<SubmitActionResponse, ConnectorError> {
+        let member_refs = group_member_refs_from_payload(&request.payload)?;
+        let (record, created_credentials) = self.ensure_credentials(ctx)?;
+        let credentials = credentials_from_record(&record)?;
+        let members = self.resolve_group_members(&credentials, member_refs)?;
+        let group = self.groups.get(group_key).cloned().ok_or_else(|| {
+            connector_err(
+                connector_error_codes::PROFILE_NOT_FOUND,
+                format!("Tinode group `{group_key}` is not known yet"),
+                false,
+            )
+        })?;
+        self.gateway
+            .invite_group_members(&credentials, &group, &members)?;
+        if let Some(stored) = self.groups.get_mut(group_key) {
+            for member in members {
+                if !stored
+                    .members
+                    .iter()
+                    .any(|existing| existing.tinode_user_id == member.tinode_user_id)
+                {
+                    stored.members.push(member);
+                }
+            }
+        }
+        let safe_summary = record.safe_summary();
+        let mut content = json!({
+            "ok": true,
+            "conversation_type": "group",
+            "group_key": group_key,
+            "topic": group.topic_id,
+            "profile_id": safe_summary.profile_id,
+            "structure_changed": true,
+        });
+        add_side_event(
+            &mut content,
+            "profile.credentials.ready",
+            Some(serde_json::to_value(safe_summary.clone()).map_err(|err| {
+                connector_err(
+                    connector_error_codes::INTERNAL,
+                    format!("failed to encode credential summary: {err}"),
+                    true,
+                )
+            })?),
+            created_credentials,
+        );
+        add_side_event(
+            &mut content,
+            "group.members.invited",
+            Some(json!({
+                "profile_id": safe_summary.profile_id,
+                "group_key": group_key,
+                "topic": group.topic_id,
+            })),
+            true,
+        );
+        Ok(completed_response(ctx, content))
+    }
+
+    fn submit_send_group_message(
+        &mut self,
+        request: SubmitActionRequest,
+        ctx: &ConnectorContext,
+        group_key: &str,
+    ) -> std::result::Result<SubmitActionResponse, ConnectorError> {
+        let text = text_from_payload(&request.payload, "Tinode group send_message")?;
+        let (record, created_credentials) = self.ensure_credentials(ctx)?;
+        let credentials = credentials_from_record(&record)?;
+        let group = self.groups.get(group_key).cloned().ok_or_else(|| {
+            connector_err(
+                connector_error_codes::PROFILE_NOT_FOUND,
+                format!("Tinode group `{group_key}` is not known yet"),
+                false,
+            )
+        })?;
+        let receipt = self.gateway.send_group_message(
+            &credentials,
+            &group,
+            &text,
+            ctx.client_token.as_deref(),
+        )?;
+        let message = TinodeGroupMessageRecord::outbound(&group, receipt.clone(), text.clone());
+        self.group_messages
+            .entry(group_key.to_string())
+            .or_default()
+            .push(message.clone());
+        if let Some(group) = self.groups.get_mut(group_key) {
+            group.last_message_at_ms = Some(now_millis());
+        }
+
+        let safe_summary = record.safe_summary();
+        let mut content = json!({
+            "ok": true,
+            "conversation_type": "group",
+            "principal_id": ctx.principal_id.as_deref().unwrap_or("default"),
+            "profile_id": safe_summary.profile_id,
+            "group_key": group_key,
+            "topic": group.topic_id,
+            "message_id": receipt.message_id,
+            "text_preview": text_preview(&text),
+        });
+        add_side_event(
+            &mut content,
+            "profile.credentials.ready",
+            Some(serde_json::to_value(safe_summary.clone()).map_err(|err| {
+                connector_err(
+                    connector_error_codes::INTERNAL,
+                    format!("failed to encode credential summary: {err}"),
+                    true,
+                )
+            })?),
+            created_credentials,
+        );
+        add_side_event(
+            &mut content,
+            "message.sent",
+            Some(json!({
+                "conversation_type": "group",
+                "principal_id": ctx.principal_id.as_deref().unwrap_or("default"),
+                "profile_id": safe_summary.profile_id,
+                "path": request.path,
+                "group_key": group_key,
+                "topic": group.topic_id,
+                "message_id": message.message_id,
+                "text_preview": text_preview(&text),
+                "client_token": ctx.client_token,
+            })),
+            true,
+        );
+
+        Ok(completed_response(ctx, content))
+    }
+
+    fn resolve_group_members(
+        &mut self,
+        credentials: &TinodeCredentials,
+        refs: Vec<RecipientRef>,
+    ) -> std::result::Result<Vec<TinodeGroupMember>, ConnectorError> {
+        let mut members = Vec::new();
+        let mut seen = HashSet::new();
+        for reference in refs {
+            let member = self.resolve_group_member(credentials, reference)?;
+            if seen.insert(member.tinode_user_id.clone()) {
+                members.push(member);
+            }
+        }
+        Ok(members)
+    }
+
+    fn resolve_group_member(
+        &mut self,
+        credentials: &TinodeCredentials,
+        reference: RecipientRef,
+    ) -> std::result::Result<TinodeGroupMember, ConnectorError> {
+        match reference {
+            RecipientRef::Principal(principal_id) => {
+                self.resolve_principal_group_member(&principal_id)
+            }
+            RecipientRef::ContactKey(key) => {
+                let contact = self.resolve_recipient(credentials, RecipientRef::ContactKey(key))?;
+                Ok(TinodeGroupMember::from_contact("contact", contact))
+            }
+            RecipientRef::Basic(login) => {
+                let contact = self.resolve_recipient(credentials, RecipientRef::Basic(login))?;
+                Ok(TinodeGroupMember::from_contact("basic", contact))
+            }
+            RecipientRef::TinodeUser(tinode_user_id) => Ok(TinodeGroupMember::from_contact(
+                "tinode_user",
+                TinodeContact {
+                    key: contact_key_from_tinode_user(&tinode_user_id),
+                    tinode_user_id,
+                    basic_login: None,
+                    display_name: None,
+                },
+            )),
+        }
+    }
+
+    fn drain_inbound_for_ctx(
+        &mut self,
+        ctx: &ConnectorContext,
+    ) -> std::result::Result<Vec<ConnectorInboundEvent>, ConnectorError> {
+        let Ok(profile_id) = effective_profile_id(ctx) else {
+            return Ok(Vec::new());
+        };
+        let principal_id = ctx.principal_id.as_deref().unwrap_or("default");
+        let Some(record) = self.ready_credential_record_for_profile(&profile_id, principal_id)
+        else {
+            return Ok(Vec::new());
+        };
+        if record.credential_status != ConnectorCredentialStatus::Ready {
+            return Ok(Vec::new());
+        }
+        let credentials = credentials_from_record(&record)?;
+        self.remember_shared_principal_contacts(&credentials, Some(principal_id))?;
+        let contacts = self.contacts.values().cloned().collect::<Vec<_>>();
+        if contacts.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let mut events = Vec::new();
+        for contact in contacts {
+            let since_seq = self
+                .last_direct_seq_by_contact
+                .get(&contact.key)
+                .copied()
+                .or_else(|| {
+                    self.direct_messages.get(&contact.key).and_then(|messages| {
+                        messages.iter().filter_map(|message| message.seq).max()
+                    })
+                });
+            let inbound_messages =
+                self.gateway
+                    .fetch_direct_messages(&credentials, &contact, since_seq)?;
+            for inbound in inbound_messages {
+                if inbound.from_tinode_user_id == credentials.tinode_user_id {
+                    self.last_direct_seq_by_contact
+                        .insert(contact.key.clone(), inbound.seq);
+                    continue;
+                }
+                let message_id = format!("tinode:{}:{}", inbound.topic, inbound.seq);
+                if self
+                    .direct_messages
+                    .get(&contact.key)
+                    .map(|messages| {
+                        messages
+                            .iter()
+                            .any(|message| message.message_id == message_id)
+                    })
+                    .unwrap_or(false)
+                {
+                    self.last_direct_seq_by_contact
+                        .insert(contact.key.clone(), inbound.seq);
+                    continue;
+                }
+
+                let message = TinodeMessageRecord {
+                    message_id: message_id.clone(),
+                    contact_key: contact.key.clone(),
+                    direction: "inbound".to_string(),
+                    text: inbound.text.clone(),
+                    created_at_ms: now_millis(),
+                    seq: Some(inbound.seq),
+                };
+                self.direct_messages
+                    .entry(contact.key.clone())
+                    .or_default()
+                    .push(message.clone());
+                self.last_direct_seq_by_contact
+                    .insert(contact.key.clone(), inbound.seq);
+                self.unread_message_ids.insert(message_id.clone());
+
+                let inbox_record = InboxRecord {
+                    message_id: message_id.clone(),
+                    contact_key: contact.key.clone(),
+                    conversation_type: "direct".to_string(),
+                    from_tinode_user_id: inbound.from_tinode_user_id.clone(),
+                    from_display_name: contact.display_name.clone(),
+                    text: inbound.text.clone(),
+                    created_at_ms: message.created_at_ms,
+                    requires_attention: true,
+                };
+                self.inbox_recent.push(inbox_record.clone());
+                events.push(ConnectorInboundEvent {
+                    event_type: "message.received".to_string(),
+                    path: format!("contacts/{}/messages.res.jsonl", contact.key),
+                    content: Some(inbox_record.to_event_content(&profile_id)),
+                    error: None,
+                });
+                events.push(ConnectorInboundEvent {
+                    event_type: "inbox.updated".to_string(),
+                    path: "inbox/unread.res.jsonl".to_string(),
+                    content: Some(json!({
+                        "message_id": message_id,
+                        "conversation_type": "direct",
+                        "contact_key": contact.key,
+                        "unread_count": self.unread_message_ids.len(),
+                    })),
+                    error: None,
+                });
+            }
+        }
+        Ok(events)
+    }
+
+    fn submit_refresh_inbox(
+        &mut self,
+        ctx: &ConnectorContext,
+    ) -> std::result::Result<SubmitActionResponse, ConnectorError> {
+        let events = self.drain_inbound_for_ctx(ctx)?;
+        let mut content = json!({
+            "ok": true,
+            "refreshed": true,
+            "event_count": events.len(),
+            "unread_count": self.unread_message_ids.len(),
+        });
+        for event in events {
+            add_side_event_with_path(
+                &mut content,
+                &event.event_type,
+                &event.path,
+                event.content,
+                true,
+            );
+        }
+        Ok(completed_response(ctx, content))
+    }
+
+    fn submit_mark_read(
+        &mut self,
+        request: SubmitActionRequest,
+        ctx: &ConnectorContext,
+    ) -> std::result::Result<SubmitActionResponse, ConnectorError> {
+        let mark_all = request
+            .payload
+            .get("all")
+            .and_then(JsonValue::as_bool)
+            .unwrap_or(false);
+        let message_id = request
+            .payload
+            .get("message_id")
+            .and_then(JsonValue::as_str)
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(ToOwned::to_owned);
+
+        let mut cleared = Vec::new();
+        if mark_all {
+            cleared.extend(self.unread_message_ids.drain());
+        } else if let Some(message_id) = message_id {
+            if self.unread_message_ids.remove(&message_id) {
+                cleared.push(message_id);
+            }
+        } else {
+            return Err(connector_err(
+                connector_error_codes::INVALID_ARGUMENT,
+                "Tinode inbox/mark_read.act requires `all=true` or a non-empty `message_id`",
+                false,
+            ));
+        }
+
+        let mut content = json!({
+            "ok": true,
+            "cleared": cleared,
+            "unread_count": self.unread_message_ids.len(),
+        });
+        let cleared_for_event = content.get("cleared").cloned().unwrap_or_else(|| json!([]));
+        add_side_event_with_path(
+            &mut content,
+            "message.read",
+            "inbox/unread.res.jsonl",
+            Some(json!({
+                "cleared": cleared_for_event,
+                "unread_count": self.unread_message_ids.len(),
+            })),
+            true,
+        );
+        Ok(completed_response(ctx, content))
+    }
+}
+
+impl AppConnector for TinodeConnector {
+    fn connector_id(&self) -> std::result::Result<ConnectorInfo, ConnectorError> {
+        Ok(ConnectorInfo {
+            connector_id: "tinode-in-process".to_string(),
+            version: "0.2.0".to_string(),
+            app_id: TINODE_APP_ID.to_string(),
+            transport: ConnectorTransport::InProcess,
+            supports_snapshot: true,
+            supports_live: false,
+            supports_action: true,
+            optional_features: vec![
+                "tinode".to_string(),
+                "skeleton_tree".to_string(),
+                "credential_policy:auto-create".to_string(),
+                "direct_message".to_string(),
+                "inbound_inbox".to_string(),
+            ],
+        })
+    }
+
+    fn health(
+        &mut self,
+        ctx: &ConnectorContext,
+    ) -> std::result::Result<HealthStatus, ConnectorError> {
+        let auth_status = effective_profile_id(ctx)
+            .ok()
+            .and_then(|profile_id| self.credentials.get(&profile_id).cloned())
+            .map(|record| {
+                if record.credential_status == ConnectorCredentialStatus::Ready {
+                    AuthStatus::Valid
+                } else {
+                    AuthStatus::Invalid
+                }
+            })
+            .unwrap_or(AuthStatus::Invalid);
+        Ok(HealthStatus {
+            healthy: true,
+            auth_status,
+            message: Some("Tinode connector is configured".to_string()),
+            checked_at: now_millis_string(),
+        })
+    }
+
+    fn prewarm_snapshot_meta(
+        &mut self,
+        resource_path: &str,
+        _timeout: Duration,
+        _ctx: &ConnectorContext,
+    ) -> std::result::Result<SnapshotMeta, ConnectorError> {
+        if !is_tinode_snapshot_resource(resource_path) {
+            return Err(connector_err(
+                connector_error_codes::NOT_SUPPORTED,
+                format!("unknown Tinode snapshot resource: {resource_path}"),
+                false,
+            ));
+        }
+        Ok(SnapshotMeta {
+            size_bytes: Some(0),
+            revision: Some(TINODE_STRUCTURE_REVISION.to_string()),
+            last_modified: Some(now_millis_string()),
+            item_count: Some(0),
+        })
+    }
+
+    fn fetch_snapshot_chunk(
+        &mut self,
+        request: FetchSnapshotChunkRequest,
+        ctx: &ConnectorContext,
+    ) -> std::result::Result<FetchSnapshotChunkResponse, ConnectorError> {
+        let normalized = normalize_path(&request.resource_path);
+        if tinode_snapshot_read_should_refresh_inbound(&normalized) {
+            self.drain_inbound_for_ctx(ctx)?;
+        }
+        self.fetch_snapshot_response(request)
+    }
+
+    fn fetch_live_page(
+        &mut self,
+        _request: FetchLivePageRequest,
+        _ctx: &ConnectorContext,
+    ) -> std::result::Result<FetchLivePageResponse, ConnectorError> {
+        Err(connector_err(
+            connector_error_codes::NOT_SUPPORTED,
+            "Tinode connector v0 does not expose live pageable resources",
+            false,
+        ))
+    }
+
+    fn submit_action(
+        &mut self,
+        request: SubmitActionRequest,
+        ctx: &ConnectorContext,
+    ) -> std::result::Result<SubmitActionResponse, ConnectorError> {
+        if !matches!(request.execution_mode, ActionExecutionMode::Inline) {
+            return Err(connector_err(
+                connector_error_codes::INVALID_ARGUMENT,
+                "Tinode actions must be inline in v0",
+                false,
+            ));
+        }
+
+        let normalized_path = normalize_path(&request.path);
+        match normalized_path.as_str() {
+            "_app/ensure_credentials.act" => self.submit_ensure_credentials(ctx),
+            "contacts/resolve.act" => self.submit_resolve_contact(request, ctx),
+            "contacts/send_message.act" => self.submit_send_message(request, ctx),
+            "_app/refresh_inbox.act" => self.submit_refresh_inbox(ctx),
+            "_app/refresh_structure.act" => Ok(completed_response(
+                ctx,
+                json!({ "ok": true, "refreshed": false, "reason": "no-op in Tinode connector v0" }),
+            )),
+            "inbox/mark_read.act" => self.submit_mark_read(request, ctx),
+            "groups/create_group.act" => self.submit_create_group(request, ctx),
+            path if group_send_message_key(path).is_some() => {
+                let group_key = group_send_message_key(path).expect("checked group send path");
+                self.submit_send_group_message(request, ctx, group_key)
+            }
+            path if group_invite_members_key(path).is_some() => {
+                let group_key = group_invite_members_key(path).expect("checked group invite path");
+                self.submit_invite_group_members(request, ctx, group_key)
+            }
+            path if contact_send_message_key(path).is_some() => {
+                self.submit_send_message(request, ctx)
+            }
+            _ => Err(connector_err(
+                connector_error_codes::NOT_SUPPORTED,
+                format!("unknown Tinode action: {}", request.path),
+                false,
+            )),
+        }
+    }
+
+    fn drain_inbound_events(
+        &mut self,
+        ctx: &ConnectorContext,
+    ) -> std::result::Result<Vec<ConnectorInboundEvent>, ConnectorError> {
+        self.drain_inbound_for_ctx(ctx)
+    }
+
+    fn get_app_structure(
+        &mut self,
+        request: GetAppStructureRequest,
+        ctx: &ConnectorContext,
+    ) -> std::result::Result<GetAppStructureResponse, ConnectorError> {
+        let snapshot = self.snapshot(ctx);
+        if request.known_revision.as_deref() == Some(snapshot.revision.as_str()) {
+            return Ok(GetAppStructureResponse {
+                result: AppStructureSyncResult::Unchanged {
+                    app_id: request.app_id,
+                    revision: snapshot.revision,
+                    active_scope: snapshot.active_scope,
+                },
+            });
+        }
+        Ok(GetAppStructureResponse {
+            result: AppStructureSyncResult::Snapshot { snapshot },
+        })
+    }
+
+    fn refresh_app_structure(
+        &mut self,
+        request: RefreshAppStructureRequest,
+        ctx: &ConnectorContext,
+    ) -> std::result::Result<RefreshAppStructureResponse, ConnectorError> {
+        let snapshot = self.snapshot(ctx);
+        if request.known_revision.as_deref() == Some(snapshot.revision.as_str()) {
+            return Ok(RefreshAppStructureResponse {
+                result: AppStructureSyncResult::Unchanged {
+                    app_id: request.app_id,
+                    revision: snapshot.revision,
+                    active_scope: snapshot.active_scope,
+                },
+            });
+        }
+        Ok(RefreshAppStructureResponse {
+            result: AppStructureSyncResult::Snapshot { snapshot },
+        })
+    }
+}
+
+trait TinodeGateway: Send {
+    fn create_or_reuse_account(
+        &mut self,
+        request: TinodeAccountRequest,
+    ) -> std::result::Result<TinodeAccount, ConnectorError>;
+
+    fn resolve_basic_user(
+        &mut self,
+        credentials: &TinodeCredentials,
+        login: &str,
+    ) -> std::result::Result<TinodeContact, ConnectorError>;
+
+    fn send_direct_message(
+        &mut self,
+        credentials: &TinodeCredentials,
+        contact: &TinodeContact,
+        text: &str,
+        client_token: Option<&str>,
+    ) -> std::result::Result<TinodeSendReceipt, ConnectorError>;
+
+    fn fetch_direct_messages(
+        &mut self,
+        credentials: &TinodeCredentials,
+        contact: &TinodeContact,
+        since_seq: Option<i64>,
+    ) -> std::result::Result<Vec<TinodeInboundMessage>, ConnectorError>;
+
+    fn create_group(
+        &mut self,
+        credentials: &TinodeCredentials,
+        title: &str,
+        members: &[TinodeGroupMember],
+        client_token: Option<&str>,
+    ) -> std::result::Result<TinodeGroupReceipt, ConnectorError>;
+
+    fn invite_group_members(
+        &mut self,
+        credentials: &TinodeCredentials,
+        group: &TinodeGroupRecord,
+        members: &[TinodeGroupMember],
+    ) -> std::result::Result<(), ConnectorError>;
+
+    fn send_group_message(
+        &mut self,
+        credentials: &TinodeCredentials,
+        group: &TinodeGroupRecord,
+        text: &str,
+        client_token: Option<&str>,
+    ) -> std::result::Result<TinodeSendReceipt, ConnectorError>;
+}
+
+#[derive(Debug, Clone)]
+struct TinodeAccountRequest {
+    profile_id: String,
+    login: String,
+    password: String,
+    display_name: String,
+    tags: Vec<String>,
+}
+
+#[derive(Debug, Clone)]
+struct TinodeAccount {
+    tinode_user_id: String,
+    login: String,
+    display_name: String,
+    token: String,
+}
+
+#[derive(Debug, Clone)]
+struct TinodeCredentials {
+    profile_id: String,
+    tinode_user_id: String,
+    login: String,
+    token: String,
+}
+
+#[derive(Debug, Clone)]
+struct TinodeContact {
+    key: String,
+    tinode_user_id: String,
+    basic_login: Option<String>,
+    display_name: Option<String>,
+}
+
+impl TinodeContact {
+    fn to_resource_line(&self) -> JsonValue {
+        json!({
+            "contact_key": self.key,
+            "tinode_user_id": self.tinode_user_id,
+            "basic_login": self.basic_login,
+            "display_name": self.display_name,
+        })
+    }
+}
+
+#[derive(Debug, Clone)]
+struct TinodeSendReceipt {
+    topic: String,
+    message_id: String,
+    seq: Option<i64>,
+}
+
+#[derive(Debug, Clone)]
+struct TinodeGroupReceipt {
+    topic: String,
+}
+
+#[derive(Debug, Clone)]
+struct TinodeGroupMember {
+    kind: String,
+    principal_id: Option<String>,
+    profile_id: Option<String>,
+    contact_key: Option<String>,
+    tinode_user_id: String,
+    basic_login: Option<String>,
+    display_name: Option<String>,
+}
+
+impl TinodeGroupMember {
+    fn from_contact(kind: &str, contact: TinodeContact) -> Self {
+        Self {
+            kind: kind.to_string(),
+            principal_id: None,
+            profile_id: None,
+            contact_key: Some(contact.key),
+            tinode_user_id: contact.tinode_user_id,
+            basic_login: contact.basic_login,
+            display_name: contact.display_name,
+        }
+    }
+
+    fn to_resource_line(&self) -> JsonValue {
+        json!({
+            "kind": self.kind,
+            "principal_id": self.principal_id,
+            "profile_id": self.profile_id,
+            "contact_key": self.contact_key,
+            "tinode_user_id": self.tinode_user_id,
+            "basic_login": self.basic_login,
+            "display_name": self.display_name,
+        })
+    }
+}
+
+#[derive(Debug, Clone)]
+struct TinodeGroupRecord {
+    key: String,
+    title: String,
+    topic_id: String,
+    members: Vec<TinodeGroupMember>,
+    created_at_ms: u128,
+    last_message_at_ms: Option<u128>,
+}
+
+impl TinodeGroupRecord {
+    fn to_resource_line(&self) -> JsonValue {
+        json!({
+            "group_key": self.key,
+            "title": self.title,
+            "topic_id": self.topic_id,
+            "path": format!("groups/{}", self.key),
+            "members": self
+                .members
+                .iter()
+                .map(TinodeGroupMember::to_resource_line)
+                .collect::<Vec<_>>(),
+            "member_count": self.members.len(),
+            "created_at_ms": self.created_at_ms,
+            "last_message_at_ms": self.last_message_at_ms,
+        })
+    }
+}
+
+#[derive(Debug, Clone)]
+struct TinodeGroupMessageRecord {
+    message_id: String,
+    group_key: String,
+    topic_id: String,
+    direction: String,
+    text: String,
+    created_at_ms: u128,
+    seq: Option<i64>,
+}
+
+impl TinodeGroupMessageRecord {
+    fn outbound(group: &TinodeGroupRecord, receipt: TinodeSendReceipt, text: String) -> Self {
+        Self {
+            message_id: receipt.message_id,
+            group_key: group.key.clone(),
+            topic_id: group.topic_id.clone(),
+            direction: "outbound".to_string(),
+            text,
+            created_at_ms: now_millis(),
+            seq: receipt.seq,
+        }
+    }
+
+    fn to_resource_line(&self) -> JsonValue {
+        json!({
+            "message_id": self.message_id,
+            "conversation_type": "group",
+            "group_key": self.group_key,
+            "topic_id": self.topic_id,
+            "direction": self.direction,
+            "text": self.text,
+            "created_at_ms": self.created_at_ms,
+            "seq": self.seq,
+        })
+    }
+}
+
+#[derive(Debug, Clone)]
+struct TinodeInboundMessage {
+    topic: String,
+    seq: i64,
+    from_tinode_user_id: String,
+    text: String,
+}
+
+#[derive(Debug, Clone)]
+struct TinodeMessageRecord {
+    message_id: String,
+    contact_key: String,
+    direction: String,
+    text: String,
+    created_at_ms: u128,
+    seq: Option<i64>,
+}
+
+impl TinodeMessageRecord {
+    fn to_resource_line(&self) -> JsonValue {
+        json!({
+            "message_id": self.message_id,
+            "contact_key": self.contact_key,
+            "direction": self.direction,
+            "text": self.text,
+            "created_at_ms": self.created_at_ms,
+            "seq": self.seq,
+        })
+    }
+}
+
+#[derive(Debug, Clone)]
+struct InboxRecord {
+    message_id: String,
+    contact_key: String,
+    conversation_type: String,
+    from_tinode_user_id: String,
+    from_display_name: Option<String>,
+    text: String,
+    created_at_ms: u128,
+    requires_attention: bool,
+}
+
+impl InboxRecord {
+    fn to_resource_line(&self, unread: bool) -> JsonValue {
+        json!({
+            "message_id": self.message_id,
+            "conversation_type": self.conversation_type,
+            "contact_key": self.contact_key,
+            "from_tinode_user_id": self.from_tinode_user_id,
+            "from_display_name": self.from_display_name,
+            "text": self.text,
+            "text_preview": text_preview(&self.text),
+            "created_at_ms": self.created_at_ms,
+            "requires_attention": self.requires_attention,
+            "unread": unread,
+        })
+    }
+
+    fn to_event_content(&self, profile_id: &str) -> JsonValue {
+        json!({
+            "profile_id": profile_id,
+            "conversation_type": self.conversation_type,
+            "contact_key": self.contact_key,
+            "message_id": self.message_id,
+            "from_tinode_user_id": self.from_tinode_user_id,
+            "from_display_name": self.from_display_name,
+            "text_preview": text_preview(&self.text),
+            "requires_attention": self.requires_attention,
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum RecipientRef {
+    Basic(String),
+    ContactKey(String),
+    TinodeUser(String),
+    Principal(String),
+}
+
+struct WebSocketTinodeGateway {
+    config: TinodeConnectorConfig,
+    clients: HashMap<String, TinodeWsClient>,
+}
+
+impl WebSocketTinodeGateway {
+    fn new(config: TinodeConnectorConfig) -> Self {
+        Self {
+            config,
+            clients: HashMap::new(),
+        }
+    }
+
+    fn ensure_client(
+        &mut self,
+        credentials: &TinodeCredentials,
+    ) -> std::result::Result<(), ConnectorError> {
+        if credentials.tinode_user_id.is_empty()
+            || credentials.login.is_empty()
+            || credentials.token.is_empty()
+        {
+            return Err(connector_err(
+                connector_error_codes::PROFILE_NOT_READY,
+                "Tinode credential record is incomplete",
+                false,
+            ));
+        }
+        if !self.clients.contains_key(&credentials.profile_id) {
+            let mut client = TinodeWsClient::connect(&self.config, &credentials.profile_id)?;
+            client.login_with_token(credentials)?;
+            self.clients.insert(credentials.profile_id.clone(), client);
+        }
+        Ok(())
+    }
+
+    fn with_client<T>(
+        &mut self,
+        credentials: &TinodeCredentials,
+        mut op: impl FnMut(&mut TinodeWsClient) -> std::result::Result<T, ConnectorError>,
+    ) -> std::result::Result<T, ConnectorError> {
+        self.ensure_client(credentials)?;
+        let profile_id = credentials.profile_id.clone();
+        let first = {
+            let client = self.clients.get_mut(&profile_id).ok_or_else(|| {
+                connector_err(
+                    connector_error_codes::INTERNAL,
+                    "missing Tinode client",
+                    true,
+                )
+            })?;
+            op(client)
+        };
+        if let Err(err) = first {
+            if is_tinode_session_reconnectable(&err) {
+                self.clients.remove(&profile_id);
+                self.ensure_client(credentials)?;
+                let client = self.clients.get_mut(&profile_id).ok_or_else(|| {
+                    connector_err(
+                        connector_error_codes::INTERNAL,
+                        "missing Tinode client after reconnect",
+                        true,
+                    )
+                })?;
+                return op(client);
+            }
+            return Err(err);
+        }
+        first
+    }
+}
+
+impl TinodeGateway for WebSocketTinodeGateway {
+    fn create_or_reuse_account(
+        &mut self,
+        request: TinodeAccountRequest,
+    ) -> std::result::Result<TinodeAccount, ConnectorError> {
+        let mut client = TinodeWsClient::connect(&self.config, &request.profile_id)?;
+        let account = match client.create_account(&request) {
+            Ok(account) => account,
+            Err(err) if is_tinode_duplicate_credential_error(&err) => {
+                client.login_with_basic_account(&request)?
+            }
+            Err(err) => return Err(err),
+        };
+        self.clients.insert(request.profile_id, client);
+        Ok(account)
+    }
+
+    fn resolve_basic_user(
+        &mut self,
+        credentials: &TinodeCredentials,
+        login: &str,
+    ) -> std::result::Result<TinodeContact, ConnectorError> {
+        self.with_client(credentials, |client| client.search_basic_user(login))
+    }
+
+    fn send_direct_message(
+        &mut self,
+        credentials: &TinodeCredentials,
+        contact: &TinodeContact,
+        text: &str,
+        client_token: Option<&str>,
+    ) -> std::result::Result<TinodeSendReceipt, ConnectorError> {
+        self.with_client(credentials, |client| {
+            client.send_direct_message(contact, text, client_token)
+        })
+    }
+
+    fn fetch_direct_messages(
+        &mut self,
+        credentials: &TinodeCredentials,
+        contact: &TinodeContact,
+        since_seq: Option<i64>,
+    ) -> std::result::Result<Vec<TinodeInboundMessage>, ConnectorError> {
+        self.with_client(credentials, |client| {
+            client.fetch_direct_messages(contact, since_seq)
+        })
+    }
+
+    fn create_group(
+        &mut self,
+        credentials: &TinodeCredentials,
+        title: &str,
+        members: &[TinodeGroupMember],
+        client_token: Option<&str>,
+    ) -> std::result::Result<TinodeGroupReceipt, ConnectorError> {
+        self.with_client(credentials, |client| {
+            client.create_group(title, members, client_token)
+        })
+    }
+
+    fn invite_group_members(
+        &mut self,
+        credentials: &TinodeCredentials,
+        group: &TinodeGroupRecord,
+        members: &[TinodeGroupMember],
+    ) -> std::result::Result<(), ConnectorError> {
+        self.with_client(credentials, |client| {
+            client.invite_group_members(group, members)
+        })
+    }
+
+    fn send_group_message(
+        &mut self,
+        credentials: &TinodeCredentials,
+        group: &TinodeGroupRecord,
+        text: &str,
+        client_token: Option<&str>,
+    ) -> std::result::Result<TinodeSendReceipt, ConnectorError> {
+        self.with_client(credentials, |client| {
+            client.send_group_message(group, text, client_token)
+        })
+    }
+}
+
+struct TinodeWsClient {
+    socket: TinodeSocket,
+    profile_id: String,
+    user_id: Option<String>,
+    token: Option<String>,
+    request_seq: u64,
+}
+
+impl TinodeWsClient {
+    fn connect(
+        config: &TinodeConnectorConfig,
+        profile_id: &str,
+    ) -> std::result::Result<Self, ConnectorError> {
+        let ws_url = to_websocket_url(&config.endpoint, &config.api_key);
+        let (socket, _) = connect(ws_url.as_str()).map_err(|err| {
+            connector_err(
+                connector_error_codes::UPSTREAM_UNAVAILABLE,
+                format!("failed to connect to Tinode websocket: {err}"),
+                true,
+            )
+        })?;
+        let mut client = Self {
+            socket,
+            profile_id: profile_id.to_string(),
+            user_id: None,
+            token: None,
+            request_seq: 0,
+        };
+        client.request(
+            "hi",
+            json!({
+                "ver": config.protocol_version,
+                "ua": "appfs-tinode-connector/0.2",
+            }),
+            "hi",
+        )?;
+        Ok(client)
+    }
+
+    fn create_account(
+        &mut self,
+        request: &TinodeAccountRequest,
+    ) -> std::result::Result<TinodeAccount, ConnectorError> {
+        let secret = BASE64_STANDARD.encode(format!("{}:{}", request.login, request.password));
+        let ctrl = self.request(
+            "acc",
+            json!({
+                "user": "new",
+                "scheme": "basic",
+                "secret": secret,
+                "login": true,
+                "tags": request.tags,
+                "desc": {
+                    "public": { "fn": request.display_name },
+                    "defacs": {
+                        "auth": "JRWPA",
+                        "anon": "N"
+                    }
+                }
+            }),
+            &format!("acc-{}", request.login),
+        )?;
+        let params = ctrl.get("params").cloned().unwrap_or_else(|| json!({}));
+        let user_id = params
+            .get("user")
+            .and_then(JsonValue::as_str)
+            .map(ToOwned::to_owned)
+            .ok_or_else(|| {
+                connector_err(
+                    connector_error_codes::UPSTREAM_UNAVAILABLE,
+                    "Tinode account creation did not return params.user",
+                    true,
+                )
+            })?;
+        let token = params
+            .get("token")
+            .and_then(JsonValue::as_str)
+            .map(ToOwned::to_owned)
+            .unwrap_or_default();
+
+        self.user_id = Some(user_id.clone());
+        self.token = Some(token.clone());
+        self.request(
+            "sub",
+            json!({
+                "topic": "me",
+                "get": { "what": "desc sub" }
+            }),
+            &format!("sub-me-{}", request.login),
+        )?;
+
+        Ok(TinodeAccount {
+            tinode_user_id: user_id,
+            login: request.login.clone(),
+            display_name: request.display_name.clone(),
+            token,
+        })
+    }
+
+    fn login_with_token(
+        &mut self,
+        credentials: &TinodeCredentials,
+    ) -> std::result::Result<(), ConnectorError> {
+        let suffix = self.next_suffix();
+        let ctrl = self.request(
+            "login",
+            json!({
+                "scheme": "token",
+                "secret": credentials.token,
+            }),
+            &format!("login-token-{suffix}"),
+        )?;
+        let params = ctrl.get("params").cloned().unwrap_or_else(|| json!({}));
+        self.user_id = Some(credentials.tinode_user_id.clone());
+        self.token = params
+            .get("token")
+            .and_then(JsonValue::as_str)
+            .map(ToOwned::to_owned)
+            .or_else(|| Some(credentials.token.clone()));
+        self.request(
+            "sub",
+            json!({
+                "topic": "me",
+                "get": { "what": "desc sub" },
+            }),
+            &format!("sub-me-token-{suffix}"),
+        )?;
+        Ok(())
+    }
+
+    fn login_with_basic_account(
+        &mut self,
+        request: &TinodeAccountRequest,
+    ) -> std::result::Result<TinodeAccount, ConnectorError> {
+        let secret = BASE64_STANDARD.encode(format!("{}:{}", request.login, request.password));
+        let ctrl = self.request(
+            "login",
+            json!({
+                "scheme": "basic",
+                "secret": secret,
+            }),
+            &format!("login-basic-{}", request.login),
+        )?;
+        let params = ctrl.get("params").cloned().unwrap_or_else(|| json!({}));
+        let user_id = params
+            .get("user")
+            .and_then(JsonValue::as_str)
+            .map(ToOwned::to_owned)
+            .ok_or_else(|| {
+                connector_err(
+                    connector_error_codes::UPSTREAM_UNAVAILABLE,
+                    "Tinode basic login did not return params.user",
+                    true,
+                )
+            })?;
+        let token = params
+            .get("token")
+            .and_then(JsonValue::as_str)
+            .map(ToOwned::to_owned)
+            .unwrap_or_default();
+
+        self.user_id = Some(user_id.clone());
+        self.token = Some(token.clone());
+        self.request(
+            "sub",
+            json!({
+                "topic": "me",
+                "get": { "what": "desc sub" },
+            }),
+            &format!("sub-me-basic-{}", request.login),
+        )?;
+        Ok(TinodeAccount {
+            tinode_user_id: user_id,
+            login: request.login.clone(),
+            display_name: request.display_name.clone(),
+            token,
+        })
+    }
+
+    fn search_basic_user(
+        &mut self,
+        login: &str,
+    ) -> std::result::Result<TinodeContact, ConnectorError> {
+        let query = format!("basic:{login}");
+        let suffix = self.next_suffix();
+        self.request(
+            "sub",
+            json!({ "topic": "fnd" }),
+            &format!("sub-fnd-{suffix}"),
+        )?;
+        self.request(
+            "set",
+            json!({ "topic": "fnd", "desc": { "public": query } }),
+            &format!("set-fnd-{suffix}"),
+        )?;
+        let meta = self.request_meta(
+            "get",
+            json!({ "topic": "fnd", "what": "sub" }),
+            &format!("get-fnd-{suffix}"),
+            Some("fnd"),
+        )?;
+        let _ = self.request(
+            "leave",
+            json!({ "topic": "fnd" }),
+            &format!("leave-fnd-{suffix}"),
+        );
+
+        let matches = meta
+            .get("sub")
+            .and_then(JsonValue::as_array)
+            .cloned()
+            .unwrap_or_default();
+        let found = matches
+            .into_iter()
+            .find_map(|entry| contact_from_search_entry(login, &entry))
+            .ok_or_else(|| {
+                connector_err(
+                    connector_error_codes::PROFILE_NOT_FOUND,
+                    format!("Tinode user not found for basic:{login}"),
+                    false,
+                )
+            })?;
+        Ok(found)
+    }
+
+    fn send_direct_message(
+        &mut self,
+        contact: &TinodeContact,
+        text: &str,
+        client_token: Option<&str>,
+    ) -> std::result::Result<TinodeSendReceipt, ConnectorError> {
+        let suffix = self.next_suffix();
+        let topic = contact.tinode_user_id.clone();
+        self.request(
+            "sub",
+            json!({ "topic": topic }),
+            &format!("sub-direct-{suffix}"),
+        )?;
+        let ctrl = self.request(
+            "pub",
+            json!({
+                "topic": contact.tinode_user_id,
+                "noecho": false,
+                "head": {
+                    "mime": "text/plain"
+                },
+                "content": tinode_text_plain_content(text)
+            }),
+            client_token.unwrap_or(&format!("pub-direct-{suffix}")),
+        )?;
+        let params = ctrl.get("params").cloned().unwrap_or_else(|| json!({}));
+        let seq = params.get("seq").and_then(JsonValue::as_i64);
+        let message_id = seq
+            .map(|seq| format!("tinode:{}:{seq}", contact.tinode_user_id))
+            .unwrap_or_else(|| format!("tinode:{}:{suffix}", contact.tinode_user_id));
+        Ok(TinodeSendReceipt {
+            topic: contact.tinode_user_id.clone(),
+            message_id,
+            seq,
+        })
+    }
+
+    fn fetch_direct_messages(
+        &mut self,
+        contact: &TinodeContact,
+        since_seq: Option<i64>,
+    ) -> std::result::Result<Vec<TinodeInboundMessage>, ConnectorError> {
+        let suffix = self.next_suffix();
+        let mut messages = self.request_data(
+            "sub",
+            tinode_sub_data_payload(&contact.tinode_user_id, since_seq, 50),
+            &format!("sub-inbox-{suffix}"),
+            &contact.tinode_user_id,
+        );
+        if messages.is_err() {
+            let _ = self.request(
+                "sub",
+                json!({ "topic": contact.tinode_user_id }),
+                &format!("sub-inbox-fallback-{suffix}"),
+            );
+            messages = Ok(Vec::new());
+        }
+        let payload = tinode_get_data_payload(&contact.tinode_user_id, since_seq, 50);
+        let mut fetched = self.request_data(
+            "get",
+            payload,
+            &format!("get-data-{suffix}"),
+            &contact.tinode_user_id,
+        )?;
+        fetched.extend(messages?);
+        Ok(dedupe_tinode_inbound_messages(fetched))
+    }
+
+    fn create_group(
+        &mut self,
+        title: &str,
+        members: &[TinodeGroupMember],
+        client_token: Option<&str>,
+    ) -> std::result::Result<TinodeGroupReceipt, ConnectorError> {
+        let suffix = self.next_suffix();
+        let ctrl = self.request(
+            "sub",
+            json!({
+                "topic": "new",
+                "set": {
+                    "desc": {
+                        "public": { "fn": title },
+                        "defacs": {
+                            "auth": "JRWPA",
+                            "anon": "N"
+                        }
+                    },
+                    "tags": [sanitize_path_key(title), "appfs-agent-group"]
+                }
+            }),
+            client_token.unwrap_or(&format!("sub-group-{suffix}")),
+        )?;
+        let topic = ctrl
+            .get("topic")
+            .and_then(JsonValue::as_str)
+            .or_else(|| {
+                ctrl.get("params")
+                    .and_then(|params| params.get("topic"))
+                    .and_then(JsonValue::as_str)
+            })
+            .map(ToOwned::to_owned)
+            .ok_or_else(|| {
+                connector_err(
+                    connector_error_codes::UPSTREAM_UNAVAILABLE,
+                    "Tinode group creation did not return a topic",
+                    true,
+                )
+            })?;
+        let record = TinodeGroupRecord {
+            key: sanitize_path_key(title),
+            title: title.to_string(),
+            topic_id: topic.clone(),
+            members: Vec::new(),
+            created_at_ms: now_millis(),
+            last_message_at_ms: None,
+        };
+        self.invite_group_members(&record, members)?;
+        Ok(TinodeGroupReceipt { topic })
+    }
+
+    fn invite_group_members(
+        &mut self,
+        group: &TinodeGroupRecord,
+        members: &[TinodeGroupMember],
+    ) -> std::result::Result<(), ConnectorError> {
+        for member in members {
+            self.request(
+                "set",
+                json!({
+                    "topic": group.topic_id,
+                    "sub": {
+                        "user": member.tinode_user_id,
+                        "mode": "JRWPA"
+                    }
+                }),
+                &format!("invite-{}-{}", group.topic_id, member.tinode_user_id),
+            )?;
+        }
+        Ok(())
+    }
+
+    fn send_group_message(
+        &mut self,
+        group: &TinodeGroupRecord,
+        text: &str,
+        client_token: Option<&str>,
+    ) -> std::result::Result<TinodeSendReceipt, ConnectorError> {
+        let suffix = self.next_suffix();
+        let _ = self.request(
+            "sub",
+            json!({ "topic": group.topic_id }),
+            &format!("sub-group-send-{suffix}"),
+        );
+        let ctrl = self.request(
+            "pub",
+            json!({
+                "topic": group.topic_id,
+                "noecho": false,
+                "head": {
+                    "mime": "text/plain"
+                },
+                "content": tinode_text_plain_content(text)
+            }),
+            client_token.unwrap_or(&format!("pub-group-{suffix}")),
+        )?;
+        let params = ctrl.get("params").cloned().unwrap_or_else(|| json!({}));
+        let seq = params.get("seq").and_then(JsonValue::as_i64);
+        let message_id = seq
+            .map(|seq| format!("tinode:{}:{seq}", group.topic_id))
+            .unwrap_or_else(|| format!("tinode:{}:{suffix}", group.topic_id));
+        Ok(TinodeSendReceipt {
+            topic: group.topic_id.clone(),
+            message_id,
+            seq,
+        })
+    }
+
+    fn request(
+        &mut self,
+        kind: &str,
+        payload: JsonValue,
+        id: &str,
+    ) -> std::result::Result<JsonValue, ConnectorError> {
+        let mut object = payload.as_object().cloned().ok_or_else(|| {
+            connector_err(
+                connector_error_codes::INVALID_PAYLOAD,
+                "Tinode request payload must be a JSON object",
+                false,
+            )
+        })?;
+        object.insert("id".to_string(), json!(id));
+        self.send_packet(json!({ kind: object }))?;
+        self.wait_for_ctrl(id, kind)
+    }
+
+    fn request_meta(
+        &mut self,
+        kind: &str,
+        payload: JsonValue,
+        id: &str,
+        topic: Option<&str>,
+    ) -> std::result::Result<JsonValue, ConnectorError> {
+        let mut object = payload.as_object().cloned().ok_or_else(|| {
+            connector_err(
+                connector_error_codes::INVALID_PAYLOAD,
+                "Tinode meta request payload must be a JSON object",
+                false,
+            )
+        })?;
+        object.insert("id".to_string(), json!(id));
+        self.send_packet(json!({ kind: object }))?;
+
+        let mut meta = None;
+        for _ in 0..200 {
+            let msg = self.read_message_json()?;
+            if let Some(ctrl) = msg.get("ctrl") {
+                if ctrl.get("id").and_then(JsonValue::as_str) == Some(id) {
+                    let code = ctrl.get("code").and_then(JsonValue::as_i64).unwrap_or(200);
+                    if code >= 400 {
+                        return Err(tinode_ctrl_error(kind, ctrl));
+                    }
+                    return Ok(meta.unwrap_or_else(|| json!({})));
+                }
+            }
+            if let Some(candidate) = msg.get("meta") {
+                let id_matches = candidate.get("id").and_then(JsonValue::as_str) == Some(id);
+                let topic_matches = topic
+                    .map(|topic| candidate.get("topic").and_then(JsonValue::as_str) == Some(topic))
+                    .unwrap_or(false);
+                if id_matches || topic_matches {
+                    meta = Some(candidate.clone());
+                }
+            }
+        }
+
+        meta.ok_or_else(|| {
+            connector_err(
+                connector_error_codes::TIMEOUT,
+                format!("Tinode did not return metadata for {kind} {id}"),
+                true,
+            )
+        })
+    }
+
+    fn request_data(
+        &mut self,
+        kind: &str,
+        payload: JsonValue,
+        id: &str,
+        topic: &str,
+    ) -> std::result::Result<Vec<TinodeInboundMessage>, ConnectorError> {
+        let mut object = payload.as_object().cloned().ok_or_else(|| {
+            connector_err(
+                connector_error_codes::INVALID_PAYLOAD,
+                "Tinode data request payload must be a JSON object",
+                false,
+            )
+        })?;
+        object.insert("id".to_string(), json!(id));
+        self.send_packet(json!({ kind: object }))?;
+
+        let mut messages = Vec::new();
+        for _ in 0..400 {
+            let msg = self.read_message_json()?;
+            if let Some(data) = msg.get("data") {
+                if data.get("topic").and_then(JsonValue::as_str) == Some(topic) {
+                    if let Some(message) = inbound_message_from_data(data) {
+                        messages.push(message);
+                    }
+                }
+                continue;
+            }
+            if let Some(meta) = msg.get("meta") {
+                let id_matches = meta.get("id").and_then(JsonValue::as_str) == Some(id);
+                let topic_matches = meta.get("topic").and_then(JsonValue::as_str) == Some(topic);
+                if id_matches || topic_matches {
+                    messages.extend(inbound_messages_from_meta(meta, topic));
+                }
+                continue;
+            }
+            if let Some(ctrl) = msg.get("ctrl") {
+                if ctrl.get("id").and_then(JsonValue::as_str) == Some(id) {
+                    let code = ctrl.get("code").and_then(JsonValue::as_i64).unwrap_or(200);
+                    if code >= 400 {
+                        return Err(tinode_ctrl_error(kind, ctrl));
+                    }
+                    return Ok(messages);
+                }
+            }
+        }
+        Err(connector_err(
+            connector_error_codes::TIMEOUT,
+            format!("Tinode did not return ctrl for {kind} id={id}"),
+            true,
+        ))
+    }
+
+    fn wait_for_ctrl(
+        &mut self,
+        id: &str,
+        label: &str,
+    ) -> std::result::Result<JsonValue, ConnectorError> {
+        for _ in 0..200 {
+            let msg = self.read_message_json()?;
+            let Some(ctrl) = msg.get("ctrl") else {
+                continue;
+            };
+            let id_matches = ctrl.get("id").and_then(JsonValue::as_str) == Some(id);
+            let anonymous_error = ctrl.get("code").and_then(JsonValue::as_i64).unwrap_or(200)
+                >= 400
+                && ctrl.get("id").is_none();
+            if id_matches || anonymous_error {
+                let code = ctrl.get("code").and_then(JsonValue::as_i64).unwrap_or(200);
+                if code >= 400 {
+                    return Err(tinode_ctrl_error(label, ctrl));
+                }
+                return Ok(ctrl.clone());
+            }
+        }
+        Err(connector_err(
+            connector_error_codes::TIMEOUT,
+            format!("Tinode did not return ctrl for {label} id={id}"),
+            true,
+        ))
+    }
+
+    fn send_packet(&mut self, packet: JsonValue) -> std::result::Result<(), ConnectorError> {
+        let text = serde_json::to_string(&packet).map_err(|err| {
+            connector_err(
+                connector_error_codes::INVALID_PAYLOAD,
+                format!("failed to encode Tinode packet: {err}"),
+                false,
+            )
+        })?;
+        self.socket.send(Message::Text(text)).map_err(|err| {
+            connector_err(
+                connector_error_codes::UPSTREAM_UNAVAILABLE,
+                format!("failed to send Tinode packet: {err}"),
+                true,
+            )
+        })
+    }
+
+    fn read_message_json(&mut self) -> std::result::Result<JsonValue, ConnectorError> {
+        loop {
+            let message = self.socket.read().map_err(|err| {
+                connector_err(
+                    connector_error_codes::UPSTREAM_UNAVAILABLE,
+                    format!("failed to read Tinode message: {err}"),
+                    true,
+                )
+            })?;
+            match message {
+                Message::Text(text) => {
+                    return serde_json::from_str(&text).map_err(|err| {
+                        connector_err(
+                            connector_error_codes::UPSTREAM_UNAVAILABLE,
+                            format!("failed to parse Tinode message: {err}"),
+                            true,
+                        )
+                    });
+                }
+                Message::Binary(bytes) => {
+                    return serde_json::from_slice(&bytes).map_err(|err| {
+                        connector_err(
+                            connector_error_codes::UPSTREAM_UNAVAILABLE,
+                            format!("failed to parse Tinode binary message: {err}"),
+                            true,
+                        )
+                    });
+                }
+                Message::Ping(payload) => {
+                    let _ = self.socket.send(Message::Pong(payload));
+                }
+                Message::Pong(_) => {}
+                Message::Close(_) => {
+                    return Err(connector_err(
+                        connector_error_codes::UPSTREAM_UNAVAILABLE,
+                        "Tinode websocket closed",
+                        true,
+                    ));
+                }
+                Message::Frame(_) => {}
+            }
+        }
+    }
+
+    fn next_suffix(&mut self) -> String {
+        self.request_seq = self.request_seq.saturating_add(1);
+        format!("{}-{}", self.profile_id.replace(':', "-"), self.request_seq)
+    }
+}
+
+fn completed_response(ctx: &ConnectorContext, content: JsonValue) -> SubmitActionResponse {
+    SubmitActionResponse {
+        request_id: ctx.request_id.clone(),
+        estimated_duration_ms: None,
+        outcome: SubmitActionOutcome::Completed { content },
+    }
+}
+
+fn dir(path: &str) -> AppStructureNode {
+    AppStructureNode {
+        path: path.to_string(),
+        kind: AppStructureNodeKind::Directory,
+        manifest_entry: None,
+        seed_content: None,
+        mutable: false,
+        scope: None,
+    }
+}
+
+fn action(path: &str) -> AppStructureNode {
+    AppStructureNode {
+        path: path.to_string(),
+        kind: AppStructureNodeKind::ActionFile,
+        manifest_entry: Some(json!({
+            "template": path,
+            "kind": "action",
+            "input_mode": "json",
+            "execution_mode": "inline",
+        })),
+        seed_content: None,
+        mutable: true,
+        scope: None,
+    }
+}
+
+fn static_json(path: &str, seed_content: JsonValue) -> AppStructureNode {
+    AppStructureNode {
+        path: path.to_string(),
+        kind: AppStructureNodeKind::StaticJsonResource,
+        manifest_entry: None,
+        seed_content: Some(seed_content),
+        mutable: false,
+        scope: None,
+    }
+}
+
+fn snapshot_jsonl(path: &str) -> AppStructureNode {
+    AppStructureNode {
+        path: path.to_string(),
+        kind: AppStructureNodeKind::SnapshotResource,
+        manifest_entry: Some(json!({
+            "template": path,
+            "kind": "resource",
+            "output_mode": "jsonl",
+            "snapshot": {
+                "max_materialized_bytes": 1048576,
+                "prewarm": true,
+                "prewarm_timeout_ms": 5000,
+                "read_through_timeout_ms": 10000,
+                "on_timeout": "return_stale"
+            }
+        })),
+        seed_content: None,
+        mutable: false,
+        scope: None,
+    }
+}
+
+fn is_tinode_snapshot_resource(path: &str) -> bool {
+    let normalized = normalize_path(path);
+    matches!(
+        normalized.as_str(),
+        "contacts/index.res.jsonl"
+            | "contacts/search_results.res.jsonl"
+            | "groups/index.res.jsonl"
+            | "inbox/recent.res.jsonl"
+            | "inbox/unread.res.jsonl"
+            | "topics/index.res.jsonl"
+    ) || contact_messages_key(&normalized).is_some()
+        || group_messages_key(&normalized).is_some()
+}
+
+fn tinode_snapshot_read_should_refresh_inbound(normalized_path: &str) -> bool {
+    matches!(
+        normalized_path,
+        "inbox/recent.res.jsonl" | "inbox/unread.res.jsonl"
+    ) || contact_messages_key(normalized_path).is_some()
+}
+
+fn contact_send_message_key(path: &str) -> Option<&str> {
+    let mut parts = path.split('/');
+    match (parts.next(), parts.next(), parts.next(), parts.next()) {
+        (Some("contacts"), Some(key), Some("send_message.act"), None) if !key.is_empty() => {
+            Some(key)
+        }
+        _ => None,
+    }
+}
+
+fn contact_messages_key(path: &str) -> Option<&str> {
+    let mut parts = path.split('/');
+    match (parts.next(), parts.next(), parts.next(), parts.next()) {
+        (Some("contacts"), Some(key), Some("messages.res.jsonl"), None) if !key.is_empty() => {
+            Some(key)
+        }
+        _ => None,
+    }
+}
+
+fn group_send_message_key(path: &str) -> Option<&str> {
+    let mut parts = path.split('/');
+    match (parts.next(), parts.next(), parts.next(), parts.next()) {
+        (Some("groups"), Some(key), Some("send_message.act"), None) if !key.is_empty() => Some(key),
+        _ => None,
+    }
+}
+
+fn group_invite_members_key(path: &str) -> Option<&str> {
+    let mut parts = path.split('/');
+    match (parts.next(), parts.next(), parts.next(), parts.next()) {
+        (Some("groups"), Some(key), Some("invite_members.act"), None) if !key.is_empty() => {
+            Some(key)
+        }
+        _ => None,
+    }
+}
+
+fn group_messages_key(path: &str) -> Option<&str> {
+    let mut parts = path.split('/');
+    match (parts.next(), parts.next(), parts.next(), parts.next()) {
+        (Some("groups"), Some(key), Some("messages.res.jsonl"), None) if !key.is_empty() => {
+            Some(key)
+        }
+        _ => None,
+    }
+}
+
+fn normalize_path(path: &str) -> String {
+    path.trim_start_matches('/')
+        .replace('\\', "/")
+        .trim()
+        .to_string()
+}
+
+fn is_safe_login_prefix(prefix: &str) -> bool {
+    !prefix.is_empty()
+        && prefix
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || b == b'_' || b == b'-')
+}
+
+fn effective_profile_id(ctx: &ConnectorContext) -> std::result::Result<String, ConnectorError> {
+    ctx.profile_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+        .ok_or_else(|| {
+            connector_err(
+                connector_error_codes::PROFILE_NOT_READY,
+                "Tinode private app requires profile_id in connector context",
+                false,
+            )
+        })
+}
+
+fn login_for_profile(
+    config: &TinodeConnectorConfig,
+    principal_id: &str,
+    profile_id: &str,
+) -> String {
+    let raw = format!("{}_{}", config.login_prefix, principal_id);
+    let sanitized = sanitize_tinode_login(&raw);
+    if sanitized.len() >= TINODE_LOGIN_MIN_LEN {
+        return constrain_tinode_login(&sanitized);
+    }
+    constrain_tinode_login(&sanitize_tinode_login(&format!(
+        "{}_{}",
+        config.login_prefix,
+        profile_id.replace(':', "_")
+    )))
+}
+
+fn shared_state_namespace(config: &TinodeConnectorConfig) -> String {
+    format!("{}|{}", config.endpoint, config.login_prefix)
+}
+
+fn shared_credential_key(namespace: &str, profile_id: &str) -> String {
+    format!("{namespace}|profile:{profile_id}")
+}
+
+fn shared_principal_key(namespace: &str, principal_id: &str) -> String {
+    format!("{namespace}|principal:{principal_id}")
+}
+
+fn sanitize_tinode_login(value: &str) -> String {
+    let mut out = value
+        .to_ascii_lowercase()
+        .chars()
+        .filter_map(|ch| {
+            if ch.is_ascii_alphanumeric() || ch == '_' || ch == '.' {
+                Some(ch)
+            } else if ch == '-' {
+                Some('_')
+            } else {
+                None
+            }
+        })
+        .collect::<String>();
+    while out.starts_with(['_', '.']) {
+        out.remove(0);
+    }
+    while out.ends_with(['_', '.']) {
+        out.pop();
+    }
+    if out.is_empty() {
+        out = "appfsagent".to_string();
+    }
+    out
+}
+
+fn constrain_tinode_login(value: &str) -> String {
+    let mut login = value.to_string();
+    if login.len() > TINODE_LOGIN_MAX_LEN {
+        let hash = stable_login_hash(&login);
+        let prefix_len = TINODE_LOGIN_MAX_LEN
+            .saturating_sub(1)
+            .saturating_sub(TINODE_LOGIN_HASH_LEN);
+        let mut prefix = login.chars().take(prefix_len).collect::<String>();
+        while prefix.ends_with(['_', '.']) {
+            prefix.pop();
+        }
+        if prefix.len() < TINODE_LOGIN_MIN_LEN {
+            prefix = "appfsagent".to_string();
+        }
+        login = format!("{prefix}_{hash}");
+    }
+    while login.len() < TINODE_LOGIN_MIN_LEN {
+        login.push('0');
+    }
+    login
+}
+
+fn stable_login_hash(value: &str) -> String {
+    let mut hash = 0x811c9dc5_u32;
+    for byte in value.as_bytes() {
+        hash ^= u32::from(*byte);
+        hash = hash.wrapping_mul(0x0100_0193);
+    }
+    format!("{hash:08x}")
+}
+
+fn display_name_for_principal(principal_id: &str) -> String {
+    if principal_id.trim().is_empty() {
+        "AppFS Agent".to_string()
+    } else {
+        format!("AppFS Agent {principal_id}")
+    }
+}
+
+fn credentials_from_record(
+    record: &ConnectorCredentialRecord,
+) -> std::result::Result<TinodeCredentials, ConnectorError> {
+    let tinode_user_id = record.upstream_user_id.clone().ok_or_else(|| {
+        connector_err(
+            connector_error_codes::PROFILE_NOT_READY,
+            "Tinode credential record has no upstream user id",
+            false,
+        )
+    })?;
+    let login = record.login.clone().ok_or_else(|| {
+        connector_err(
+            connector_error_codes::PROFILE_NOT_READY,
+            "Tinode credential record has no login",
+            false,
+        )
+    })?;
+    let token = record
+        .credentials
+        .as_ref()
+        .and_then(|value| value.get("token"))
+        .and_then(JsonValue::as_str)
+        .map(ToOwned::to_owned)
+        .ok_or_else(|| {
+            connector_err(
+                connector_error_codes::PROFILE_NOT_READY,
+                "Tinode credential record has no token",
+                false,
+            )
+        })?;
+    Ok(TinodeCredentials {
+        profile_id: record.profile_id.clone(),
+        tinode_user_id,
+        login,
+        token,
+    })
+}
+
+fn recipient_ref_from_payload(
+    payload: &JsonValue,
+) -> std::result::Result<RecipientRef, ConnectorError> {
+    let value = payload
+        .get("to")
+        .or_else(|| payload.get("query"))
+        .and_then(JsonValue::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| {
+            connector_err(
+                connector_error_codes::INVALID_ARGUMENT,
+                "Tinode recipient payload requires non-empty `to` or `query`",
+                false,
+            )
+        })?;
+    parse_recipient_ref(value)
+}
+
+fn message_target_and_text(
+    normalized_path: &str,
+    payload: &JsonValue,
+) -> std::result::Result<(RecipientRef, String), ConnectorError> {
+    let text = text_from_payload(payload, "Tinode send_message")?;
+
+    let reference = if normalized_path == "contacts/send_message.act" {
+        recipient_ref_from_payload(payload)?
+    } else if let Some(key) = contact_send_message_key(normalized_path) {
+        RecipientRef::ContactKey(key.to_string())
+    } else {
+        return Err(connector_err(
+            connector_error_codes::NOT_SUPPORTED,
+            format!("unknown Tinode send_message path: {normalized_path}"),
+            false,
+        ));
+    };
+
+    Ok((reference, text))
+}
+
+fn text_from_payload(
+    payload: &JsonValue,
+    label: &str,
+) -> std::result::Result<String, ConnectorError> {
+    payload
+        .get("text")
+        .and_then(JsonValue::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+        .ok_or_else(|| {
+            connector_err(
+                connector_error_codes::INVALID_ARGUMENT,
+                format!("{label} payload requires non-empty `text`"),
+                false,
+            )
+        })
+}
+
+fn group_title_from_payload(payload: &JsonValue) -> std::result::Result<String, ConnectorError> {
+    payload
+        .get("title")
+        .or_else(|| payload.get("display_name"))
+        .and_then(JsonValue::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+        .ok_or_else(|| {
+            connector_err(
+                connector_error_codes::INVALID_ARGUMENT,
+                "Tinode create_group payload requires non-empty `title` or `display_name`",
+                false,
+            )
+        })
+}
+
+fn group_key_from_payload(payload: &JsonValue, title: &str) -> String {
+    payload
+        .get("group_key")
+        .and_then(JsonValue::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(sanitize_path_key)
+        .filter(|value| !value.is_empty())
+        .unwrap_or_else(|| sanitize_path_key(title))
+}
+
+fn group_member_refs_from_payload(
+    payload: &JsonValue,
+) -> std::result::Result<Vec<RecipientRef>, ConnectorError> {
+    let Some(members) = payload.get("members").and_then(JsonValue::as_array) else {
+        return Ok(Vec::new());
+    };
+    members
+        .iter()
+        .map(|member| {
+            let value = member.as_str().ok_or_else(|| {
+                connector_err(
+                    connector_error_codes::INVALID_ARGUMENT,
+                    "Tinode group members must be strings",
+                    false,
+                )
+            })?;
+            parse_recipient_ref(value)
+        })
+        .collect()
+}
+
+fn parse_recipient_ref(value: &str) -> std::result::Result<RecipientRef, ConnectorError> {
+    let value = value.trim();
+    if let Some(login) = value.strip_prefix("basic:") {
+        let login = login.trim();
+        if login.is_empty() {
+            return Err(connector_err(
+                connector_error_codes::INVALID_ARGUMENT,
+                "Tinode basic recipient cannot be empty",
+                false,
+            ));
+        }
+        return Ok(RecipientRef::Basic(login.to_string()));
+    }
+    if let Some(user_id) = value.strip_prefix("tinode_user:") {
+        let user_id = user_id.trim();
+        if user_id.is_empty() {
+            return Err(connector_err(
+                connector_error_codes::INVALID_ARGUMENT,
+                "Tinode user recipient cannot be empty",
+                false,
+            ));
+        }
+        return Ok(RecipientRef::TinodeUser(user_id.to_string()));
+    }
+    if let Some(principal_id) = value.strip_prefix("principal:") {
+        let principal_id = principal_id.trim();
+        if !is_safe_principal_ref(principal_id) {
+            return Err(connector_err(
+                connector_error_codes::INVALID_ARGUMENT,
+                "Tinode principal recipient must use a safe AppFS principal id",
+                false,
+            ));
+        }
+        return Ok(RecipientRef::Principal(principal_id.to_string()));
+    }
+    Err(connector_err(
+        connector_error_codes::INVALID_ARGUMENT,
+        "Tinode v0 supports explicit recipients in the form basic:<login>, tinode_user:<usr-id>, or principal:<principal-id>",
+        false,
+    ))
+}
+
+fn contact_key_from_basic_login(login: &str) -> String {
+    sanitize_path_key(login)
+}
+
+fn contact_key_from_tinode_user(user_id: &str) -> String {
+    sanitize_path_key(user_id)
+}
+
+fn is_safe_principal_ref(value: &str) -> bool {
+    !value.is_empty()
+        && value.len() <= 64
+        && value
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'.' | b'_' | b'-'))
+}
+
+fn sanitize_path_key(value: &str) -> String {
+    let mut out = value
+        .to_ascii_lowercase()
+        .chars()
+        .filter_map(|ch| {
+            if ch.is_ascii_alphanumeric() || ch == '_' || ch == '-' || ch == '.' {
+                Some(ch)
+            } else {
+                None
+            }
+        })
+        .collect::<String>();
+    if out.is_empty() {
+        out = "contact".to_string();
+    }
+    out
+}
+
+fn contact_from_search_entry(login: &str, entry: &JsonValue) -> Option<TinodeContact> {
+    let user_id = entry
+        .get("topic")
+        .or_else(|| entry.get("user"))
+        .and_then(JsonValue::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())?
+        .to_string();
+    let display_name = entry
+        .get("public")
+        .and_then(|value| value.get("fn"))
+        .and_then(JsonValue::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned);
+    Some(TinodeContact {
+        key: contact_key_from_basic_login(login),
+        tinode_user_id: user_id,
+        basic_login: Some(login.to_string()),
+        display_name,
+    })
+}
+
+fn inbound_message_from_data(data: &JsonValue) -> Option<TinodeInboundMessage> {
+    let topic = data
+        .get("topic")
+        .and_then(JsonValue::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())?
+        .to_string();
+    let seq = data.get("seq").and_then(JsonValue::as_i64)?;
+    let from_tinode_user_id = data
+        .get("from")
+        .or_else(|| data.get("from_user_id"))
+        .and_then(JsonValue::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())?
+        .to_string();
+    let text = tinode_text_from_content(data.get("content")?)?
+        .trim()
+        .to_string();
+    if text.is_empty() {
+        return None;
+    }
+    Some(TinodeInboundMessage {
+        topic,
+        seq,
+        from_tinode_user_id,
+        text,
+    })
+}
+
+fn tinode_text_from_content(content: &JsonValue) -> Option<&str> {
+    content.as_str().or_else(|| {
+        content
+            .get("txt")
+            .or_else(|| content.get("text"))
+            .and_then(JsonValue::as_str)
+    })
+}
+
+fn tinode_text_plain_content(text: &str) -> JsonValue {
+    json!(text)
+}
+
+fn tinode_get_data_options(since_seq: Option<i64>, limit: i64) -> JsonValue {
+    let mut data = json!({ "limit": limit });
+    if let Some(since_seq) = since_seq {
+        data["since"] = json!(since_seq.saturating_add(1));
+    }
+    data
+}
+
+fn tinode_get_data_payload(topic: &str, since_seq: Option<i64>, limit: i64) -> JsonValue {
+    json!({
+        "topic": topic,
+        "what": "data",
+        "data": tinode_get_data_options(since_seq, limit),
+    })
+}
+
+fn tinode_sub_data_payload(topic: &str, since_seq: Option<i64>, limit: i64) -> JsonValue {
+    json!({
+        "topic": topic,
+        "get": {
+            "what": "data",
+            "data": tinode_get_data_options(since_seq, limit),
+        },
+    })
+}
+
+fn inbound_messages_from_meta(meta: &JsonValue, fallback_topic: &str) -> Vec<TinodeInboundMessage> {
+    let topic = meta
+        .get("topic")
+        .and_then(JsonValue::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or(fallback_topic);
+    meta.get("data")
+        .and_then(JsonValue::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(|entry| {
+            if entry.get("topic").is_some() {
+                inbound_message_from_data(entry)
+            } else {
+                let mut entry = entry.clone();
+                if let Some(object) = entry.as_object_mut() {
+                    object.insert("topic".to_string(), json!(topic));
+                }
+                inbound_message_from_data(&entry)
+            }
+        })
+        .collect()
+}
+
+fn dedupe_tinode_inbound_messages(
+    messages: Vec<TinodeInboundMessage>,
+) -> Vec<TinodeInboundMessage> {
+    let mut seen = HashSet::new();
+    let mut deduped = messages
+        .into_iter()
+        .filter(|message| seen.insert((message.topic.clone(), message.seq)))
+        .collect::<Vec<_>>();
+    deduped.sort_by(|left, right| {
+        left.topic
+            .cmp(&right.topic)
+            .then_with(|| left.seq.cmp(&right.seq))
+    });
+    deduped
+}
+
+fn add_side_event(
+    content: &mut JsonValue,
+    event_type: &str,
+    event_content: Option<JsonValue>,
+    include: bool,
+) {
+    if !include {
+        return;
+    }
+    let Some(object) = content.as_object_mut() else {
+        return;
+    };
+    let events = object
+        .entry(CONNECTOR_SIDE_EVENTS_FIELD)
+        .or_insert_with(|| JsonValue::Array(Vec::new()));
+    let Some(events) = events.as_array_mut() else {
+        return;
+    };
+    let mut event = JsonMap::new();
+    event.insert("type".to_string(), json!(event_type));
+    if let Some(content) = event_content {
+        event.insert("content".to_string(), content);
+    }
+    events.push(JsonValue::Object(event));
+}
+
+fn add_side_event_with_path(
+    content: &mut JsonValue,
+    event_type: &str,
+    event_path: &str,
+    event_content: Option<JsonValue>,
+    include: bool,
+) {
+    if !include {
+        return;
+    }
+    let Some(object) = content.as_object_mut() else {
+        return;
+    };
+    let events = object
+        .entry(CONNECTOR_SIDE_EVENTS_FIELD)
+        .or_insert_with(|| JsonValue::Array(Vec::new()));
+    let Some(events) = events.as_array_mut() else {
+        return;
+    };
+    let mut event = JsonMap::new();
+    event.insert("type".to_string(), json!(event_type));
+    event.insert("path".to_string(), json!(event_path));
+    if let Some(content) = event_content {
+        event.insert("content".to_string(), content);
+    }
+    events.push(JsonValue::Object(event));
+}
+
+fn text_preview(text: &str) -> String {
+    const MAX_CHARS: usize = 80;
+    let mut preview = text.chars().take(MAX_CHARS).collect::<String>();
+    if text.chars().count() > MAX_CHARS {
+        preview.push_str("...");
+    }
+    preview
+}
+
+fn now_millis() -> u128 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis()
+}
+
+fn now_millis_string() -> String {
+    now_millis().to_string()
+}
+
+fn credential_status_label(status: ConnectorCredentialStatus) -> &'static str {
+    match status {
+        ConnectorCredentialStatus::Missing => "missing",
+        ConnectorCredentialStatus::Ready => "ready",
+        ConnectorCredentialStatus::Expired => "expired",
+        ConnectorCredentialStatus::Failed => "failed",
+    }
+}
+
+fn to_websocket_url(endpoint: &str, api_key: &str) -> String {
+    let base = endpoint.trim_end_matches('/');
+    let ws_base = if let Some(rest) = base.strip_prefix("https://") {
+        format!("wss://{rest}")
+    } else if let Some(rest) = base.strip_prefix("http://") {
+        format!("ws://{rest}")
+    } else {
+        base.to_string()
+    };
+    format!("{ws_base}/v0/channels?apikey={api_key}")
+}
+
+fn tinode_ctrl_error(label: &str, ctrl: &JsonValue) -> ConnectorError {
+    let text = ctrl
+        .get("text")
+        .and_then(JsonValue::as_str)
+        .unwrap_or("Tinode request failed");
+    let code = ctrl.get("code").and_then(JsonValue::as_i64).unwrap_or(500);
+    let credential_creation_server_error = label == "acc" && code >= 500;
+    let appfs_code = if code == 401 || code == 403 {
+        connector_error_codes::AUTH_EXPIRED
+    } else if code == 404 {
+        connector_error_codes::PROFILE_NOT_FOUND
+    } else if code == 429 {
+        connector_error_codes::RATE_LIMITED
+    } else if credential_creation_server_error {
+        connector_error_codes::CREDENTIALS_FAILED
+    } else if code >= 500 {
+        connector_error_codes::UPSTREAM_UNAVAILABLE
+    } else {
+        connector_error_codes::CREDENTIALS_FAILED
+    };
+    connector_err(
+        appfs_code,
+        format!("{label} failed in Tinode: code={code} text={text}"),
+        (code >= 500 || code == 429) && !credential_creation_server_error,
+    )
+}
+
+fn is_tinode_duplicate_credential_error(err: &ConnectorError) -> bool {
+    err.code == connector_error_codes::CREDENTIALS_FAILED
+        && err.message.contains("code=409")
+        && err
+            .message
+            .to_ascii_lowercase()
+            .contains("duplicate credential")
+}
+
+fn is_tinode_session_reconnectable(err: &ConnectorError) -> bool {
+    err.retryable
+        && (err.code == connector_error_codes::UPSTREAM_UNAVAILABLE
+            || err.code == connector_error_codes::TIMEOUT)
+}
+
+fn connector_err(code: &str, message: impl Into<String>, retryable: bool) -> ConnectorError {
+    ConnectorError {
+        code: code.to_string(),
+        message: message.into(),
+        retryable,
+        details: None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        TinodeAccount, TinodeAccountRequest, TinodeConnector, TinodeConnectorConfig, TinodeContact,
+        TinodeCredentials, TinodeGateway, TinodeGroupMember, TinodeGroupReceipt, TinodeGroupRecord,
+        TinodeInboundMessage, TinodeSendReceipt, CONNECTOR_SIDE_EVENTS_FIELD,
+    };
+    use crate::{
+        connector_error_codes, ActionExecutionMode, AppConnector, AppStructureSyncResult,
+        ConnectorContext, ConnectorError, FetchSnapshotChunkRequest, GetAppStructureRequest,
+        SnapshotResume, SubmitActionOutcome, SubmitActionRequest,
+    };
+    use serde_json::{json, Value as JsonValue};
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::{Arc, Mutex};
+
+    static TEST_PREFIX_SEQ: AtomicUsize = AtomicUsize::new(0);
+
+    fn config() -> TinodeConnectorConfig {
+        let seq = TEST_PREFIX_SEQ.fetch_add(1, Ordering::Relaxed);
+        TinodeConnectorConfig::new(
+            "http://127.0.0.1:6060",
+            "auto-create",
+            format!("appfs{seq}"),
+        )
+        .expect("tinode config")
+    }
+
+    fn ctx() -> ConnectorContext {
+        ConnectorContext {
+            app_id: "tinode".to_string(),
+            session_id: "sess-1".to_string(),
+            request_id: "req-1".to_string(),
+            client_token: Some("client-1".to_string()),
+            trace_id: None,
+            principal_id: Some("default".to_string()),
+            profile_id: Some("tinode:default".to_string()),
+        }
+    }
+
+    #[derive(Default)]
+    struct MockGatewayState {
+        created: Vec<TinodeAccountRequest>,
+        resolved: Vec<String>,
+        sent: Vec<(String, String, Option<String>)>,
+        groups_created: Vec<(String, Vec<String>, Option<String>)>,
+        group_invites: Vec<(String, Vec<String>)>,
+        group_sent: Vec<(String, String, Option<String>)>,
+        inbound: Vec<TinodeInboundMessage>,
+        fetched_since: Vec<Option<i64>>,
+        fail_resolve: bool,
+    }
+
+    struct MockTinodeGateway {
+        state: Arc<Mutex<MockGatewayState>>,
+    }
+
+    impl MockTinodeGateway {
+        fn new(state: Arc<Mutex<MockGatewayState>>) -> Self {
+            Self { state }
+        }
+    }
+
+    impl TinodeGateway for MockTinodeGateway {
+        fn create_or_reuse_account(
+            &mut self,
+            request: TinodeAccountRequest,
+        ) -> std::result::Result<TinodeAccount, ConnectorError> {
+            self.state
+                .lock()
+                .expect("mock state")
+                .created
+                .push(request.clone());
+            Ok(TinodeAccount {
+                tinode_user_id: format!("usr-{}", request.login),
+                login: request.login,
+                display_name: request.display_name,
+                token: "secret-token".to_string(),
+            })
+        }
+
+        fn resolve_basic_user(
+            &mut self,
+            _credentials: &TinodeCredentials,
+            login: &str,
+        ) -> std::result::Result<TinodeContact, ConnectorError> {
+            let mut state = self.state.lock().expect("mock state");
+            state.resolved.push(login.to_string());
+            if state.fail_resolve {
+                return Err(ConnectorError {
+                    code: connector_error_codes::PROFILE_NOT_FOUND.to_string(),
+                    message: format!("not found: basic:{login}"),
+                    retryable: false,
+                    details: None,
+                });
+            }
+            Ok(TinodeContact {
+                key: login.to_string(),
+                tinode_user_id: format!("usr-{login}"),
+                basic_login: Some(login.to_string()),
+                display_name: Some(format!("User {login}")),
+            })
+        }
+
+        fn send_direct_message(
+            &mut self,
+            _credentials: &TinodeCredentials,
+            contact: &TinodeContact,
+            text: &str,
+            client_token: Option<&str>,
+        ) -> std::result::Result<TinodeSendReceipt, ConnectorError> {
+            self.state.lock().expect("mock state").sent.push((
+                contact.tinode_user_id.clone(),
+                text.to_string(),
+                client_token.map(ToOwned::to_owned),
+            ));
+            Ok(TinodeSendReceipt {
+                topic: contact.tinode_user_id.clone(),
+                message_id: format!("tinode:{}:1", contact.tinode_user_id),
+                seq: Some(1),
+            })
+        }
+
+        fn fetch_direct_messages(
+            &mut self,
+            _credentials: &TinodeCredentials,
+            _contact: &TinodeContact,
+            since_seq: Option<i64>,
+        ) -> std::result::Result<Vec<TinodeInboundMessage>, ConnectorError> {
+            let mut state = self.state.lock().expect("mock state");
+            state.fetched_since.push(since_seq);
+            let since_seq = since_seq.unwrap_or(0);
+            Ok(state
+                .inbound
+                .iter()
+                .filter(|message| message.seq > since_seq)
+                .cloned()
+                .collect())
+        }
+
+        fn create_group(
+            &mut self,
+            _credentials: &TinodeCredentials,
+            title: &str,
+            members: &[TinodeGroupMember],
+            client_token: Option<&str>,
+        ) -> std::result::Result<TinodeGroupReceipt, ConnectorError> {
+            self.state.lock().expect("mock state").groups_created.push((
+                title.to_string(),
+                members
+                    .iter()
+                    .map(|member| member.tinode_user_id.clone())
+                    .collect(),
+                client_token.map(ToOwned::to_owned),
+            ));
+            Ok(TinodeGroupReceipt {
+                topic: format!("grp-{}", super::sanitize_path_key(title)),
+            })
+        }
+
+        fn invite_group_members(
+            &mut self,
+            _credentials: &TinodeCredentials,
+            group: &TinodeGroupRecord,
+            members: &[TinodeGroupMember],
+        ) -> std::result::Result<(), ConnectorError> {
+            self.state.lock().expect("mock state").group_invites.push((
+                group.topic_id.clone(),
+                members
+                    .iter()
+                    .map(|member| member.tinode_user_id.clone())
+                    .collect(),
+            ));
+            Ok(())
+        }
+
+        fn send_group_message(
+            &mut self,
+            _credentials: &TinodeCredentials,
+            group: &TinodeGroupRecord,
+            text: &str,
+            client_token: Option<&str>,
+        ) -> std::result::Result<TinodeSendReceipt, ConnectorError> {
+            self.state.lock().expect("mock state").group_sent.push((
+                group.topic_id.clone(),
+                text.to_string(),
+                client_token.map(ToOwned::to_owned),
+            ));
+            Ok(TinodeSendReceipt {
+                topic: group.topic_id.clone(),
+                message_id: format!("tinode:{}:1", group.topic_id),
+                seq: Some(1),
+            })
+        }
+    }
+
+    fn connector_with_mock(state: Arc<Mutex<MockGatewayState>>) -> TinodeConnector {
+        TinodeConnector::new_with_gateway(config(), Box::new(MockTinodeGateway::new(state)))
+    }
+
+    fn connector_with_mock_config(
+        config: TinodeConnectorConfig,
+        state: Arc<Mutex<MockGatewayState>>,
+    ) -> TinodeConnector {
+        TinodeConnector::new_with_gateway(config, Box::new(MockTinodeGateway::new(state)))
+    }
+
+    fn completed_content(response: crate::SubmitActionResponse) -> JsonValue {
+        let SubmitActionOutcome::Completed { content } = response.outcome else {
+            panic!("expected completed response");
+        };
+        content
+    }
+
+    #[test]
+    fn tinode_config_requires_endpoint_policy_and_safe_prefix() {
+        assert!(TinodeConnectorConfig::new("", "auto-create", "appfs").is_err());
+        assert!(TinodeConnectorConfig::new("ws://127.0.0.1:6060", "auto-create", "appfs").is_err());
+        assert!(TinodeConnectorConfig::new("http://127.0.0.1:6060", "", "appfs").is_err());
+        assert!(TinodeConnectorConfig::new("http://127.0.0.1:6060", "manual", "appfs").is_err());
+        assert!(
+            TinodeConnectorConfig::new("http://127.0.0.1:6060", "auto-create", "bad prefix")
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn tinode_generated_basic_login_respects_server_policy() {
+        let config = TinodeConnectorConfig::new(
+            "http://127.0.0.1:6060",
+            "auto-create",
+            "appfsmanual20260507082331",
+        )
+        .expect("tinode config");
+
+        let default_login = super::login_for_profile(&config, "default", "tinode:default");
+        let code_login =
+            super::login_for_profile(&config, "code-implementer", "tinode:code-implementer");
+
+        assert!(default_login.len() <= 26, "{default_login}");
+        assert!(code_login.len() <= 26, "{code_login}");
+        assert_ne!(default_login, code_login);
+        for login in [default_login, code_login] {
+            assert!(login.len() >= 4, "{login}");
+            assert!(login
+                .chars()
+                .next()
+                .is_some_and(|ch| ch.is_ascii_alphanumeric()));
+            assert!(login
+                .chars()
+                .last()
+                .is_some_and(|ch| ch.is_ascii_alphanumeric()));
+            assert!(login
+                .chars()
+                .all(|ch| ch.is_ascii_alphanumeric() || ch == '_' || ch == '.'));
+        }
+    }
+
+    #[test]
+    fn tinode_account_server_error_is_terminal_credentials_failure() {
+        let err = super::tinode_ctrl_error(
+            "acc",
+            &json!({
+                "code": 500,
+                "text": "internal error"
+            }),
+        );
+
+        assert_eq!(err.code, connector_error_codes::CREDENTIALS_FAILED);
+        assert!(!err.retryable);
+    }
+
+    #[test]
+    fn tinode_duplicate_credential_can_be_reused_by_basic_login() {
+        let err = super::tinode_ctrl_error(
+            "acc",
+            &json!({
+                "code": 409,
+                "text": "duplicate credential"
+            }),
+        );
+
+        assert_eq!(err.code, connector_error_codes::CREDENTIALS_FAILED);
+        assert!(super::is_tinode_duplicate_credential_error(&err));
+    }
+
+    #[test]
+    fn tinode_structure_exposes_safe_skeleton_without_credentials() {
+        let mut connector = TinodeConnector::new(config());
+        let response = connector
+            .get_app_structure(
+                GetAppStructureRequest {
+                    app_id: "tinode".to_string(),
+                    known_revision: None,
+                },
+                &ctx(),
+            )
+            .expect("structure");
+        let AppStructureSyncResult::Snapshot { snapshot } = response.result else {
+            panic!("expected snapshot");
+        };
+        assert_eq!(connector.credential_create_attempts(), 0);
+        let paths = snapshot
+            .nodes
+            .iter()
+            .map(|node| node.path.as_str())
+            .collect::<Vec<_>>();
+        for expected in [
+            "_app/actions.res.json",
+            "_app/control.res.json",
+            "_app/self.res.json",
+            "_app/skill.res.json",
+            "_app/ensure_credentials.act",
+            "_app/refresh_structure.act",
+            "_app/refresh_inbox.act",
+            "contacts/index.res.jsonl",
+            "contacts/send_message.act",
+            "contacts/resolve.act",
+            "contacts/search_results.res.jsonl",
+            "groups/index.res.jsonl",
+            "groups/create_group.act",
+            "inbox/recent.res.jsonl",
+            "inbox/unread.res.jsonl",
+            "inbox/mark_read.act",
+            "topics/index.res.jsonl",
+        ] {
+            assert!(paths.contains(&expected), "missing {expected}");
+        }
+        assert!(!paths.contains(&"_stream/events.evt.jsonl"));
+        let skill_doc = snapshot
+            .nodes
+            .iter()
+            .find(|node| node.path == "_app/skill.res.json")
+            .and_then(|node| node.seed_content.as_ref())
+            .expect("tinode skill seed content");
+        assert_eq!(skill_doc["app_id"], "tinode");
+        assert_eq!(
+            skill_doc["description"],
+            "Tinode private chat app for the current AppFS principal."
+        );
+        let actions_doc = snapshot
+            .nodes
+            .iter()
+            .find(|node| node.path == "_app/actions.res.json")
+            .and_then(|node| node.seed_content.as_ref())
+            .expect("tinode actions seed content");
+        assert!(actions_doc["recommended_actions"]
+            .as_array()
+            .expect("recommended actions")
+            .iter()
+            .any(|action| action["path"] == "contacts/send_message.act"));
+    }
+
+    #[test]
+    fn tinode_self_resource_is_safe_and_supports_non_ascii_principal() {
+        let connector = TinodeConnector::new(config());
+        let mut ctx = ctx();
+        ctx.principal_id = Some("zhangsan-agent".to_string());
+        ctx.profile_id = Some("tinode:zhangsan-agent".to_string());
+        let self_doc = connector.self_resource(&ctx);
+        assert_eq!(self_doc["credential_status"], "missing");
+        assert_eq!(self_doc["principal_id"], "zhangsan-agent");
+        assert_eq!(self_doc["profile_id"], "tinode:zhangsan-agent");
+        let rendered = self_doc.to_string();
+        for forbidden in ["token", "refresh_token", "password", "secret", "cookie"] {
+            assert!(!rendered.contains(forbidden));
+        }
+    }
+
+    #[test]
+    fn tinode_snapshot_resources_are_empty_before_credentials() {
+        let mut connector = TinodeConnector::new(config());
+        let response = connector
+            .fetch_snapshot_chunk(
+                FetchSnapshotChunkRequest {
+                    resource_path: "/contacts/index.res.jsonl".to_string(),
+                    resume: SnapshotResume::Start,
+                    budget_bytes: 1024,
+                },
+                &ctx(),
+            )
+            .expect("empty snapshot");
+        assert!(response.records.is_empty());
+        assert!(!response.has_more);
+    }
+
+    #[test]
+    fn root_send_message_auto_creates_credentials_and_sends_direct_message() {
+        let state = Arc::new(Mutex::new(MockGatewayState::default()));
+        let mut connector = connector_with_mock(Arc::clone(&state));
+        let content = completed_content(
+            connector
+                .submit_action(
+                    SubmitActionRequest {
+                        path: "/contacts/send_message.act".to_string(),
+                        payload: json!({"to":"basic:zhangsan","text":"hello"}),
+                        execution_mode: ActionExecutionMode::Inline,
+                    },
+                    &ctx(),
+                )
+                .expect("send message"),
+        );
+
+        assert_eq!(connector.credential_create_attempts(), 1);
+        assert_eq!(content["ok"], true);
+        assert_eq!(content["profile_id"], "tinode:default");
+        assert_eq!(content["text_preview"], "hello");
+        let events = content
+            .get(CONNECTOR_SIDE_EVENTS_FIELD)
+            .and_then(JsonValue::as_array)
+            .expect("side events");
+        assert_eq!(events.len(), 3);
+        assert_eq!(events[0]["type"], "action.accepted");
+        assert_eq!(events[1]["type"], "profile.credentials.ready");
+        assert_eq!(events[2]["type"], "message.sent");
+        assert!(!content.to_string().contains("secret-token"));
+
+        let state = state.lock().expect("mock state");
+        assert_eq!(state.created.len(), 1);
+        assert_eq!(state.resolved, vec!["zhangsan"]);
+        assert_eq!(state.sent.len(), 1);
+        assert_eq!(state.sent[0].1, "hello");
+    }
+
+    #[test]
+    fn root_send_message_reuses_existing_credentials() {
+        let state = Arc::new(Mutex::new(MockGatewayState::default()));
+        let mut connector = connector_with_mock(Arc::clone(&state));
+        for text in ["one", "two"] {
+            connector
+                .submit_action(
+                    SubmitActionRequest {
+                        path: "/contacts/send_message.act".to_string(),
+                        payload: json!({"to":"basic:zhangsan","text":text}),
+                        execution_mode: ActionExecutionMode::Inline,
+                    },
+                    &ctx(),
+                )
+                .expect("send message");
+        }
+
+        assert_eq!(connector.credential_create_attempts(), 1);
+        let state = state.lock().expect("mock state");
+        assert_eq!(state.created.len(), 1);
+        assert_eq!(state.sent.len(), 2);
+    }
+
+    #[test]
+    fn action_payload_cannot_override_effective_profile_id() {
+        let state = Arc::new(Mutex::new(MockGatewayState::default()));
+        let mut connector = connector_with_mock(state);
+        let content = completed_content(
+            connector
+                .submit_action(
+                    SubmitActionRequest {
+                        path: "/contacts/send_message.act".to_string(),
+                        payload: json!({
+                            "to":"basic:zhangsan",
+                            "text":"hello",
+                            "profile_id":"tinode:attacker"
+                        }),
+                        execution_mode: ActionExecutionMode::Inline,
+                    },
+                    &ctx(),
+                )
+                .expect("send message"),
+        );
+
+        assert_eq!(content["profile_id"], "tinode:default");
+        assert!(connector.credentials.contains_key("tinode:default"));
+        assert!(!connector.credentials.contains_key("tinode:attacker"));
+        assert!(!content.to_string().contains("tinode:attacker"));
+    }
+
+    #[test]
+    fn bad_recipient_returns_useful_failure() {
+        let state = Arc::new(Mutex::new(MockGatewayState {
+            fail_resolve: true,
+            ..MockGatewayState::default()
+        }));
+        let mut connector = connector_with_mock(state);
+        let err = connector
+            .submit_action(
+                SubmitActionRequest {
+                    path: "/contacts/send_message.act".to_string(),
+                    payload: json!({"to":"basic:missing","text":"hello"}),
+                    execution_mode: ActionExecutionMode::Inline,
+                },
+                &ctx(),
+            )
+            .expect_err("recipient should fail");
+        assert_eq!(err.code, connector_error_codes::PROFILE_NOT_FOUND);
+        assert!(err.message.contains("basic:missing"));
+    }
+
+    #[test]
+    fn malformed_send_payload_does_not_create_credentials() {
+        let state = Arc::new(Mutex::new(MockGatewayState::default()));
+        let mut connector = connector_with_mock(Arc::clone(&state));
+        let err = connector
+            .submit_action(
+                SubmitActionRequest {
+                    path: "/contacts/send_message.act".to_string(),
+                    payload: json!({"text":"hello"}),
+                    execution_mode: ActionExecutionMode::Inline,
+                },
+                &ctx(),
+            )
+            .expect_err("missing recipient should fail before upstream auth");
+
+        assert_eq!(err.code, connector_error_codes::INVALID_ARGUMENT);
+        assert_eq!(connector.credential_create_attempts(), 0);
+        assert!(state.lock().expect("mock state").created.is_empty());
+    }
+
+    #[test]
+    fn contact_index_and_messages_are_safe_snapshot_resources_after_send() {
+        let state = Arc::new(Mutex::new(MockGatewayState::default()));
+        let mut connector = connector_with_mock(state);
+        connector
+            .submit_action(
+                SubmitActionRequest {
+                    path: "/contacts/send_message.act".to_string(),
+                    payload: json!({"to":"basic:zhangsan","text":"hello"}),
+                    execution_mode: ActionExecutionMode::Inline,
+                },
+                &ctx(),
+            )
+            .expect("send message");
+
+        let contacts = connector
+            .fetch_snapshot_chunk(
+                FetchSnapshotChunkRequest {
+                    resource_path: "/contacts/index.res.jsonl".to_string(),
+                    resume: SnapshotResume::Start,
+                    budget_bytes: 1024,
+                },
+                &ctx(),
+            )
+            .expect("contacts");
+        assert_eq!(contacts.records.len(), 1);
+        assert_eq!(contacts.records[0].line["basic_login"], "zhangsan");
+
+        let messages = connector
+            .fetch_snapshot_chunk(
+                FetchSnapshotChunkRequest {
+                    resource_path: "/contacts/zhangsan/messages.res.jsonl".to_string(),
+                    resume: SnapshotResume::Start,
+                    budget_bytes: 1024,
+                },
+                &ctx(),
+            )
+            .expect("messages");
+        assert_eq!(messages.records.len(), 1);
+        assert_eq!(messages.records[0].line["text"], "hello");
+        assert!(!messages.records[0]
+            .line
+            .to_string()
+            .contains("secret-token"));
+    }
+
+    #[test]
+    fn inbound_direct_messages_become_events_and_inbox_records() {
+        let state = Arc::new(Mutex::new(MockGatewayState::default()));
+        let mut connector = connector_with_mock(Arc::clone(&state));
+        connector
+            .submit_action(
+                SubmitActionRequest {
+                    path: "/contacts/send_message.act".to_string(),
+                    payload: json!({"to":"basic:zhangsan","text":"outbound"}),
+                    execution_mode: ActionExecutionMode::Inline,
+                },
+                &ctx(),
+            )
+            .expect("seed contact");
+        state
+            .lock()
+            .expect("mock state")
+            .inbound
+            .push(TinodeInboundMessage {
+                topic: "usr-zhangsan".to_string(),
+                seq: 2,
+                from_tinode_user_id: "usr-zhangsan".to_string(),
+                text: "reply from user".to_string(),
+            });
+
+        let events = connector
+            .drain_inbound_events(&ctx())
+            .expect("drain inbound");
+        assert_eq!(events.len(), 2);
+        assert_eq!(events[0].event_type, "message.received");
+        assert_eq!(events[0].path, "contacts/zhangsan/messages.res.jsonl");
+        assert_eq!(
+            events[0]
+                .content
+                .as_ref()
+                .and_then(|value| value.get("text_preview"))
+                .and_then(JsonValue::as_str),
+            Some("reply from user")
+        );
+        assert_eq!(events[1].event_type, "inbox.updated");
+
+        let unread = connector
+            .fetch_snapshot_chunk(
+                FetchSnapshotChunkRequest {
+                    resource_path: "/inbox/unread.res.jsonl".to_string(),
+                    resume: SnapshotResume::Start,
+                    budget_bytes: 1024,
+                },
+                &ctx(),
+            )
+            .expect("unread inbox");
+        assert_eq!(unread.records.len(), 1);
+        assert_eq!(unread.records[0].line["text"], "reply from user");
+        assert_eq!(unread.records[0].line["unread"], true);
+
+        let messages = connector
+            .fetch_snapshot_chunk(
+                FetchSnapshotChunkRequest {
+                    resource_path: "/contacts/zhangsan/messages.res.jsonl".to_string(),
+                    resume: SnapshotResume::Start,
+                    budget_bytes: 1024,
+                },
+                &ctx(),
+            )
+            .expect("messages");
+        assert_eq!(messages.records.len(), 2);
+        assert_eq!(messages.records[1].line["direction"], "inbound");
+
+        let duplicate = connector
+            .drain_inbound_events(&ctx())
+            .expect("second drain");
+        assert!(duplicate.is_empty());
+    }
+
+    #[test]
+    fn refresh_inbox_action_returns_side_events_for_inbound_messages() {
+        let state = Arc::new(Mutex::new(MockGatewayState::default()));
+        let mut connector = connector_with_mock(Arc::clone(&state));
+        connector
+            .submit_action(
+                SubmitActionRequest {
+                    path: "/contacts/send_message.act".to_string(),
+                    payload: json!({"to":"basic:zhangsan","text":"outbound"}),
+                    execution_mode: ActionExecutionMode::Inline,
+                },
+                &ctx(),
+            )
+            .expect("seed contact");
+        state
+            .lock()
+            .expect("mock state")
+            .inbound
+            .push(TinodeInboundMessage {
+                topic: "usr-zhangsan".to_string(),
+                seq: 2,
+                from_tinode_user_id: "usr-zhangsan".to_string(),
+                text: "refresh reply".to_string(),
+            });
+
+        let content = completed_content(
+            connector
+                .submit_action(
+                    SubmitActionRequest {
+                        path: "/_app/refresh_inbox.act".to_string(),
+                        payload: json!({}),
+                        execution_mode: ActionExecutionMode::Inline,
+                    },
+                    &ctx(),
+                )
+                .expect("refresh inbox"),
+        );
+        assert_eq!(content["event_count"], 2);
+        let side_events = content
+            .get(CONNECTOR_SIDE_EVENTS_FIELD)
+            .and_then(JsonValue::as_array)
+            .expect("side events");
+        assert_eq!(side_events[0]["type"], "message.received");
+        assert_eq!(
+            side_events[0]["path"],
+            "contacts/zhangsan/messages.res.jsonl"
+        );
+    }
+
+    #[test]
+    fn mark_read_clears_unread_inbox_without_upstream_receipts() {
+        let state = Arc::new(Mutex::new(MockGatewayState::default()));
+        let mut connector = connector_with_mock(Arc::clone(&state));
+        connector
+            .submit_action(
+                SubmitActionRequest {
+                    path: "/contacts/send_message.act".to_string(),
+                    payload: json!({"to":"basic:zhangsan","text":"outbound"}),
+                    execution_mode: ActionExecutionMode::Inline,
+                },
+                &ctx(),
+            )
+            .expect("seed contact");
+        state
+            .lock()
+            .expect("mock state")
+            .inbound
+            .push(TinodeInboundMessage {
+                topic: "usr-zhangsan".to_string(),
+                seq: 2,
+                from_tinode_user_id: "usr-zhangsan".to_string(),
+                text: "reply".to_string(),
+            });
+        connector
+            .drain_inbound_events(&ctx())
+            .expect("drain inbound");
+
+        let content = completed_content(
+            connector
+                .submit_action(
+                    SubmitActionRequest {
+                        path: "/inbox/mark_read.act".to_string(),
+                        payload: json!({"all": true}),
+                        execution_mode: ActionExecutionMode::Inline,
+                    },
+                    &ctx(),
+                )
+                .expect("mark read"),
+        );
+        assert_eq!(content["unread_count"], 0);
+
+        let unread = connector
+            .fetch_snapshot_chunk(
+                FetchSnapshotChunkRequest {
+                    resource_path: "/inbox/unread.res.jsonl".to_string(),
+                    resume: SnapshotResume::Start,
+                    budget_bytes: 1024,
+                },
+                &ctx(),
+            )
+            .expect("unread inbox");
+        assert!(unread.records.is_empty());
+    }
+
+    #[test]
+    fn direct_message_can_target_ready_principal_without_guessing_login() {
+        let config = config();
+        let state = Arc::new(Mutex::new(MockGatewayState::default()));
+        let mut default_connector = connector_with_mock_config(config.clone(), Arc::clone(&state));
+        let mut incident_connector = connector_with_mock_config(config, Arc::clone(&state));
+
+        let mut incident_ctx = ctx();
+        incident_ctx.principal_id = Some("incident-reporter".to_string());
+        incident_ctx.profile_id = Some("tinode:incident-reporter".to_string());
+        incident_connector
+            .submit_action(
+                SubmitActionRequest {
+                    path: "/_app/ensure_credentials.act".to_string(),
+                    payload: json!({}),
+                    execution_mode: ActionExecutionMode::Inline,
+                },
+                &incident_ctx,
+            )
+            .expect("incident credentials");
+
+        let content = completed_content(
+            default_connector
+                .submit_action(
+                    SubmitActionRequest {
+                        path: "/contacts/send_message.act".to_string(),
+                        payload: json!({
+                            "to": "principal:incident-reporter",
+                            "text": "hello incident agent"
+                        }),
+                        execution_mode: ActionExecutionMode::Inline,
+                    },
+                    &ctx(),
+                )
+                .expect("principal direct message"),
+        );
+
+        assert_eq!(content["ok"], true);
+        assert_eq!(content["conversation_type"], "direct");
+        let state = state.lock().expect("mock state");
+        assert_eq!(state.sent.len(), 1);
+        assert!(state.sent[0].0.contains("incident_reporter"));
+        assert!(
+            state.resolved.is_empty(),
+            "principal ref must not use basic search"
+        );
+    }
+
+    #[test]
+    fn principal_receiver_discovers_ready_sender_for_inbox_drain() {
+        let config = config();
+        let state = Arc::new(Mutex::new(MockGatewayState::default()));
+        let mut default_connector = connector_with_mock_config(config.clone(), Arc::clone(&state));
+        let mut code_connector = connector_with_mock_config(config, Arc::clone(&state));
+
+        default_connector
+            .submit_action(
+                SubmitActionRequest {
+                    path: "/_app/ensure_credentials.act".to_string(),
+                    payload: json!({}),
+                    execution_mode: ActionExecutionMode::Inline,
+                },
+                &ctx(),
+            )
+            .expect("default credentials");
+
+        let mut code_ctx = ctx();
+        code_ctx.principal_id = Some("code-implementer".to_string());
+        code_ctx.profile_id = Some("tinode:code-implementer".to_string());
+        code_connector
+            .submit_action(
+                SubmitActionRequest {
+                    path: "/_app/ensure_credentials.act".to_string(),
+                    payload: json!({}),
+                    execution_mode: ActionExecutionMode::Inline,
+                },
+                &code_ctx,
+            )
+            .expect("code credentials");
+
+        assert!(
+            code_connector.contacts.is_empty(),
+            "receiver should not need an explicit local contact"
+        );
+        let default_login = state
+            .lock()
+            .expect("mock state")
+            .created
+            .iter()
+            .find(|request| request.profile_id == "tinode:default")
+            .expect("default account request")
+            .login
+            .clone();
+        state
+            .lock()
+            .expect("mock state")
+            .inbound
+            .push(TinodeInboundMessage {
+                topic: format!("usr-{default_login}"),
+                seq: 1,
+                from_tinode_user_id: format!("usr-{default_login}"),
+                text: "hello from default".to_string(),
+            });
+
+        let events = code_connector
+            .drain_inbound_events(&code_ctx)
+            .expect("drain principal inbound");
+
+        assert_eq!(events.len(), 2);
+        assert_eq!(events[0].event_type, "message.received");
+        assert_eq!(events[0].path, "contacts/default/messages.res.jsonl");
+        assert_eq!(
+            events[0]
+                .content
+                .as_ref()
+                .and_then(|value| value.get("contact_key"))
+                .and_then(JsonValue::as_str),
+            Some("default")
+        );
+        assert!(code_connector.contacts.contains_key("default"));
+    }
+
+    #[test]
+    fn principal_receiver_inbox_read_through_discovers_ready_sender() {
+        let config = config();
+        let state = Arc::new(Mutex::new(MockGatewayState::default()));
+        let mut default_connector = connector_with_mock_config(config.clone(), Arc::clone(&state));
+        let mut code_connector = connector_with_mock_config(config, Arc::clone(&state));
+
+        default_connector
+            .submit_action(
+                SubmitActionRequest {
+                    path: "/_app/ensure_credentials.act".to_string(),
+                    payload: json!({}),
+                    execution_mode: ActionExecutionMode::Inline,
+                },
+                &ctx(),
+            )
+            .expect("default credentials");
+
+        let mut code_ctx = ctx();
+        code_ctx.principal_id = Some("code-implementer".to_string());
+        code_ctx.profile_id = Some("tinode:code-implementer".to_string());
+        code_connector
+            .submit_action(
+                SubmitActionRequest {
+                    path: "/_app/ensure_credentials.act".to_string(),
+                    payload: json!({}),
+                    execution_mode: ActionExecutionMode::Inline,
+                },
+                &code_ctx,
+            )
+            .expect("code credentials");
+
+        let default_login = state
+            .lock()
+            .expect("mock state")
+            .created
+            .iter()
+            .find(|request| request.profile_id == "tinode:default")
+            .expect("default account request")
+            .login
+            .clone();
+        state
+            .lock()
+            .expect("mock state")
+            .inbound
+            .push(TinodeInboundMessage {
+                topic: format!("usr-{default_login}"),
+                seq: 1,
+                from_tinode_user_id: format!("usr-{default_login}"),
+                text: "read-through hello".to_string(),
+            });
+
+        let inbox = code_connector
+            .fetch_snapshot_chunk(
+                FetchSnapshotChunkRequest {
+                    resource_path: "/inbox/recent.res.jsonl".to_string(),
+                    resume: SnapshotResume::Start,
+                    budget_bytes: 1024,
+                },
+                &code_ctx,
+            )
+            .expect("inbox read-through");
+
+        assert_eq!(inbox.records.len(), 1);
+        assert_eq!(inbox.records[0].line["contact_key"], "default");
+        assert_eq!(inbox.records[0].line["text"], "read-through hello");
+    }
+
+    #[test]
+    fn principal_receiver_inbox_read_through_uses_shared_credentials_for_fresh_connector() {
+        let config = config();
+        let state = Arc::new(Mutex::new(MockGatewayState::default()));
+        let mut default_runtime_connector =
+            connector_with_mock_config(config.clone(), Arc::clone(&state));
+        let mut code_runtime_connector =
+            connector_with_mock_config(config.clone(), Arc::clone(&state));
+        let mut fresh_read_through_connector =
+            connector_with_mock_config(config, Arc::clone(&state));
+
+        default_runtime_connector
+            .submit_action(
+                SubmitActionRequest {
+                    path: "/_app/ensure_credentials.act".to_string(),
+                    payload: json!({}),
+                    execution_mode: ActionExecutionMode::Inline,
+                },
+                &ctx(),
+            )
+            .expect("default credentials");
+
+        let mut code_ctx = ctx();
+        code_ctx.principal_id = Some("code-implementer".to_string());
+        code_ctx.profile_id = Some("tinode:code-implementer".to_string());
+        code_runtime_connector
+            .submit_action(
+                SubmitActionRequest {
+                    path: "/_app/ensure_credentials.act".to_string(),
+                    payload: json!({}),
+                    execution_mode: ActionExecutionMode::Inline,
+                },
+                &code_ctx,
+            )
+            .expect("code credentials");
+
+        let default_login = state
+            .lock()
+            .expect("mock state")
+            .created
+            .iter()
+            .find(|request| request.profile_id == "tinode:default")
+            .expect("default account request")
+            .login
+            .clone();
+        state
+            .lock()
+            .expect("mock state")
+            .inbound
+            .push(TinodeInboundMessage {
+                topic: format!("usr-{default_login}"),
+                seq: 1,
+                from_tinode_user_id: format!("usr-{default_login}"),
+                text: "fresh connector hello".to_string(),
+            });
+
+        assert!(
+            fresh_read_through_connector.credentials.is_empty(),
+            "mount read-through starts as a fresh connector instance"
+        );
+        let inbox = fresh_read_through_connector
+            .fetch_snapshot_chunk(
+                FetchSnapshotChunkRequest {
+                    resource_path: "/inbox/recent.res.jsonl".to_string(),
+                    resume: SnapshotResume::Start,
+                    budget_bytes: 1024,
+                },
+                &code_ctx,
+            )
+            .expect("fresh connector inbox read-through");
+
+        assert_eq!(inbox.records.len(), 1);
+        assert_eq!(inbox.records[0].line["contact_key"], "default");
+        assert_eq!(inbox.records[0].line["text"], "fresh connector hello");
+        assert!(
+            fresh_read_through_connector
+                .credentials
+                .contains_key("tinode:code-implementer"),
+            "fresh read-through connector should hydrate its credential from shared state"
+        );
+    }
+
+    #[test]
+    fn inbound_messages_parse_from_tinode_meta_data_payloads() {
+        let messages = super::inbound_messages_from_meta(
+            &json!({
+                "topic": "usrDefault",
+                "data": [
+                    {
+                        "seq": 7,
+                        "from": "usrCode",
+                        "content": { "txt": "hello from meta" }
+                    }
+                ]
+            }),
+            "usrFallback",
+        );
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].topic, "usrDefault");
+        assert_eq!(messages[0].seq, 7);
+        assert_eq!(messages[0].from_tinode_user_id, "usrCode");
+        assert_eq!(messages[0].text, "hello from meta");
+    }
+
+    #[test]
+    fn tinode_text_plain_content_is_sent_as_string_and_read_back() {
+        let content = super::tinode_text_plain_content("hello plain text");
+        assert_eq!(content, json!("hello plain text"));
+
+        let inbound = super::inbound_message_from_data(&json!({
+            "topic": "usrDefault",
+            "seq": 8,
+            "from": "usrCode",
+            "content": "hello plain text"
+        }))
+        .expect("plain text inbound");
+        assert_eq!(inbound.text, "hello plain text");
+    }
+
+    #[test]
+    fn tinode_inbound_messages_are_deduped_after_sub_and_get() {
+        let messages = super::dedupe_tinode_inbound_messages(vec![
+            TinodeInboundMessage {
+                topic: "usrA".to_string(),
+                seq: 2,
+                from_tinode_user_id: "usrA".to_string(),
+                text: "two".to_string(),
+            },
+            TinodeInboundMessage {
+                topic: "usrA".to_string(),
+                seq: 1,
+                from_tinode_user_id: "usrA".to_string(),
+                text: "one".to_string(),
+            },
+            TinodeInboundMessage {
+                topic: "usrA".to_string(),
+                seq: 2,
+                from_tinode_user_id: "usrA".to_string(),
+                text: "two duplicate".to_string(),
+            },
+        ]);
+
+        assert_eq!(messages.len(), 2);
+        assert_eq!(messages[0].seq, 1);
+        assert_eq!(messages[1].seq, 2);
+        assert_eq!(messages[1].text, "two");
+    }
+
+    #[test]
+    fn tinode_get_data_payload_uses_nested_data_options() {
+        let payload = super::tinode_get_data_payload("usrCode", Some(7), 50);
+
+        assert_eq!(payload["topic"], "usrCode");
+        assert_eq!(payload["what"], "data");
+        assert_eq!(payload["data"]["since"], 8);
+        assert_eq!(payload["data"]["limit"], 50);
+        assert!(payload.get("since").is_none());
+        assert!(payload.get("limit").is_none());
+
+        let sub = super::tinode_sub_data_payload("usrCode", Some(7), 50);
+        assert_eq!(sub["topic"], "usrCode");
+        assert_eq!(sub["get"]["what"], "data");
+        assert_eq!(sub["get"]["data"]["since"], 8);
+        assert_eq!(sub["get"]["data"]["limit"], 50);
+    }
+
+    #[test]
+    fn group_create_invite_and_send_support_basic_and_principal_members() {
+        let config = config();
+        let state = Arc::new(Mutex::new(MockGatewayState::default()));
+        let mut default_connector = connector_with_mock_config(config.clone(), Arc::clone(&state));
+        let mut incident_connector = connector_with_mock_config(config, Arc::clone(&state));
+
+        let mut incident_ctx = ctx();
+        incident_ctx.principal_id = Some("incident-reporter".to_string());
+        incident_ctx.profile_id = Some("tinode:incident-reporter".to_string());
+        incident_connector
+            .submit_action(
+                SubmitActionRequest {
+                    path: "/_app/ensure_credentials.act".to_string(),
+                    payload: json!({}),
+                    execution_mode: ActionExecutionMode::Inline,
+                },
+                &incident_ctx,
+            )
+            .expect("incident credentials");
+
+        let create = completed_content(
+            default_connector
+                .submit_action(
+                    SubmitActionRequest {
+                        path: "/groups/create_group.act".to_string(),
+                        payload: json!({
+                            "title": "Incident Room",
+                            "members": ["basic:zhangsan", "principal:incident-reporter"],
+                            "initial_message": "group boot"
+                        }),
+                        execution_mode: ActionExecutionMode::Inline,
+                    },
+                    &ctx(),
+                )
+                .expect("create group"),
+        );
+        assert_eq!(create["ok"], true);
+        assert_eq!(create["group_key"], "incidentroom");
+        assert_eq!(create["member_count"], 2);
+
+        let send = completed_content(
+            default_connector
+                .submit_action(
+                    SubmitActionRequest {
+                        path: "/groups/incidentroom/send_message.act".to_string(),
+                        payload: json!({"text":"follow up"}),
+                        execution_mode: ActionExecutionMode::Inline,
+                    },
+                    &ctx(),
+                )
+                .expect("send group"),
+        );
+        assert_eq!(send["conversation_type"], "group");
+
+        let groups = default_connector
+            .fetch_snapshot_chunk(
+                FetchSnapshotChunkRequest {
+                    resource_path: "/groups/index.res.jsonl".to_string(),
+                    resume: SnapshotResume::Start,
+                    budget_bytes: 1024,
+                },
+                &ctx(),
+            )
+            .expect("groups index");
+        assert_eq!(groups.records.len(), 1);
+        assert_eq!(groups.records[0].line["member_count"], 2);
+        assert_eq!(groups.records[0].line["group_key"], "incidentroom");
+
+        let messages = default_connector
+            .fetch_snapshot_chunk(
+                FetchSnapshotChunkRequest {
+                    resource_path: "/groups/incidentroom/messages.res.jsonl".to_string(),
+                    resume: SnapshotResume::Start,
+                    budget_bytes: 1024,
+                },
+                &ctx(),
+            )
+            .expect("group messages");
+        assert_eq!(messages.records.len(), 2);
+        assert_eq!(messages.records[1].line["text"], "follow up");
+
+        let state = state.lock().expect("mock state");
+        assert_eq!(state.groups_created.len(), 1);
+        assert_eq!(state.groups_created[0].1.len(), 2);
+        assert_eq!(state.group_sent.len(), 2);
+        assert_eq!(state.resolved, vec!["zhangsan"]);
+    }
+
+    #[test]
+    fn principal_group_member_requires_ready_credentials() {
+        let state = Arc::new(Mutex::new(MockGatewayState::default()));
+        let mut connector = connector_with_mock(state);
+        let err = connector
+            .submit_action(
+                SubmitActionRequest {
+                    path: "/groups/create_group.act".to_string(),
+                    payload: json!({
+                        "title": "Incident Room",
+                        "members": ["principal:missing-agent"]
+                    }),
+                    execution_mode: ActionExecutionMode::Inline,
+                },
+                &ctx(),
+            )
+            .expect_err("missing principal should fail");
+
+        assert_eq!(err.code, connector_error_codes::PROFILE_NOT_READY);
+        assert!(err.message.contains("principal:missing-agent"));
+    }
+}


### PR DESCRIPTION
## Summary
- backfill AppFS principal/app policy schema, principal control plane, private app auto-instantiation, and principal/profile connector context from appfs-platform
- add the generic credential store plus Tinode in-process connector for credential bootstrap, direct messages, inbox events/read-through snapshots, and group actions
- include the AIIM+Tinode compose fixture and preserve the mount-side read-through fixes validated in appfs-platform

## Validation
- `cargo fmt --manifest-path cli\Cargo.toml --all -- --check`
- `cargo fmt --manifest-path sdk\rust\Cargo.toml --all -- --check`
- `cargo test --manifest-path sdk\rust\Cargo.toml tinode_connector --lib --target-dir C:\tmp\appfs-backfill-sdk-target`
- `cargo test --manifest-path cli\Cargo.toml --package agentfs mount_runtime --target-dir C:\tmp\appfs-backfill-cli-target`
- `cargo test --manifest-path cli\Cargo.toml --package agentfs principal --target-dir C:\tmp\appfs-backfill-cli-target`
- `cargo test --manifest-path cli\Cargo.toml --package agentfs runtime_supervisor --target-dir C:\tmp\appfs-backfill-cli-target`

## Notes
- Stacked on #158 / `codex/platform-appfs-sync-20260505` to avoid duplicating the pending AIIM descriptor backfill.